### PR TITLE
api: only disable updates when `api.disableUpdatesOnFailedRollout` is set 

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -35,6 +35,10 @@ type API struct {
 	dbR      *runner.DB
 	dbDriver string
 	dbURL    string
+
+	// disableUpdatesOnFailedRollout defines wether to disable updates
+	// after a first rollout attempt failed (ResultFailed)
+	disableUpdatesOnFailedRollout bool
 }
 
 // New creates a new API instance, creating the underlying db connection and

--- a/pkg/api/events.go
+++ b/pkg/api/events.go
@@ -178,9 +178,11 @@ func (api *API) triggerEventConsequences(instanceID, appID, groupID, lastUpdateV
 			return err
 		}
 		if updatesStats.UpdatesToCurrentVersionAttempted == 1 {
-			_ = api.disableUpdates(groupID)
-			_ = api.setGroupRolloutInProgress(groupID, false)
-			_ = api.newGroupActivityEntry(activityRolloutFailed, activityError, lastUpdateVersion, appID, groupID)
+			if api.disableUpdatesOnFailedRollout {
+				_ = api.disableUpdates(groupID)
+				_ = api.setGroupRolloutInProgress(groupID, false)
+				_ = api.newGroupActivityEntry(activityRolloutFailed, activityError, lastUpdateVersion, appID, groupID)
+			}
 		}
 	}
 


### PR DESCRIPTION
Doesn't add an option to enable it actually, we don't need that
currently.