### PR TITLE
[WIP] Update docker-compose setup

### DIFF
--- a/Dockerfile.rollerd
+++ b/Dockerfile.rollerd
@@ -22,6 +22,6 @@ RUN apk update && \
 COPY --from=coreroller-build /go/src/github.com/coreroller/coreroller/bin/rollerd /coreroller/
 COPY --from=coreroller-build /go/src/github.com/coreroller/coreroller/frontend/built/ /coreroller/static/
 
-ENV COREROLLER_DB_URL "postgres://postgres@postgres:5432/coreroller?sslmode=disable&connect_timeout=10"
+ENV COREROLLER_DB_URL "postgres://postgres@127.0.0.1:5432/coreroller?sslmode=disable&connect_timeout=10"
 EXPOSE 8000
 CMD ["/coreroller/rollerd", "-http-static-dir=/coreroller/static"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,21 +4,19 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.rollerd
-    ports:
-      - 8000:8000
     command: |
       sh -c '
         sleep 3
-        /coreroller/rollerd -http-static-dir=/coreroller/static'
+        LOGXI=* /coreroller/rollerd -http-static-dir=/coreroller/static'
+    network_mode: host
     depends_on:
-      - "postgres"
+      - postgres
   postgres:
     build:
       context: .
       dockerfile: Dockerfile.postgres
     volumes:
       - postgres-data:/coreroller/data
-    ports:
-      - 5432:5432
+    network_mode: host
 volumes:
   postgres-data:


### PR DESCRIPTION
The current docker-compose configuration doesn't go together w/ how we
configure Postgres (all users except from localhost need to present a
client certificate).

To make the docker-compose setup usable for local testing, run things in
the host network namespace (then rollerd can simply access Postgres w/o
further setup).

To also get sample data, run

```
psql -h localhost -U postgres coreroller < pkg/api/db/sample_data.sql
```

after `docker-compose up`.