### PR TITLE
pkg: add support for the experimental edge channel

### DIFF
--- a/pkg/omaha/omaha.go
+++ b/pkg/omaha/omaha.go
@@ -21,6 +21,7 @@ var (
 		"alpha":  "5b810680-e36a-4879-b98a-4f989e80b899",
 		"beta":   "3fe10490-dd73-4b49-b72a-28ac19acfcdc",
 		"stable": "9a2deb70-37be-4026-853f-bfdd6b347bbe",
+		"edge":   "72834a2b-ad86-4d6d-b498-e08a19ebe54e",
 	}
 
 	// ErrMalformedRequest error indicates that the omaha request it has

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -123,7 +123,7 @@ func (s *Syncer) initialize() error {
 	}
 
 	for _, c := range coreosApp.Channels {
-		if c.Name == "stable" || c.Name == "beta" || c.Name == "alpha" {
+		if c.Name == "stable" || c.Name == "beta" || c.Name == "alpha" || c.Name == "edge" {
 			s.machinesIDs[c.Name] = "{" + uuid.NewV4().String() + "}"
 			s.bootIDs[c.Name] = "{" + uuid.NewV4().String() + "}"
 			s.channelsIDs[c.Name] = c.ID
@@ -140,7 +140,7 @@ func (s *Syncer) initialize() error {
 }
 
 // checkForUpdates polls the public CoreOS servers looking for updates in the
-// official channels (stable, beta, alpha) sending Omaha requests. When an
+// official channels (stable, beta, alpha, edge) sending Omaha requests. When an
 // update is received we'll process it, creating packages and updating channels
 // in CoreRoller as needed.
 func (s *Syncer) checkForUpdates() error {


### PR DESCRIPTION
To make the experimental edge channel work like ordinary channels, Nebraska also needs to be able to interpret the `edge` string. The given group ID for the edge channel is simply taken from the Nebraska UI.