### PR TITLE
frontend: Fix color for "information activity"

### DIFF
--- a/frontend/src/js/components/Activity/Item.react.js
+++ b/frontend/src/js/components/Activity/Item.react.js
@@ -35,7 +35,7 @@ const stateIcons = {
   },
   info: {
     icon: infoIcon,
-    color: '#ff5500'
+    color: '#00d3ff'
   },
   error: {
     icon: errorIcon,


### PR DESCRIPTION
The icon associated with the "information activity" was being assigned
the same color as the "warning activity" (orange).
It should be blue instead, so this patch changes that.

This is the fix for #45 .