### PR TITLE
build: Add frontend-watch makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ check:
 frontend:
 	cd frontend && npm install && npm run build
 
+.PHONY: frontend-watch
+frontend-watch:
+	cd frontend && npx webpack --watch-poll 1000 --watch --config ./webpack.config.js --mode development
+
 .PHONY: backend
 backend:
 	go build -o bin/rollerd ./cmd/rollerd


### PR DESCRIPTION
When developing the frontend, it is very useful to "keep watching" the
changes, so it builds only the changed parts. Thus, this patch adds a
new target to the Makefile to avoid having to write a big command all
the time.