### PR TITLE
backend: Update Syncer URL to fetch Flatcar updates

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	coreosUpdatesURL = "https://public.update.core-os.net/v1/update/"
+	coreosUpdatesURL = "https://public.update.flatcar-linux.net/v1/update/"
 	coreosAppID      = "{e96281a6-d1af-4bde-9a0a-97b76e56dc57}"
 	checkFrequency   = 1 * time.Hour
 )


### PR DESCRIPTION
The Syncer URL was fetching updates for CoreOS, but it should instead
get those for Flatcar.

For the Syncer to be used, Nebraska needs to be run with the `-enable-syncer` flag. It will also only assign the package updates to the groups that have a canonical name (`stable`, `beta`, `alpha`, `edge`).