### PR TITLE
Refactor package list

### DIFF
--- a/frontend/src/js/components/Packages/List.react.js
+++ b/frontend/src/js/components/Packages/List.react.js
@@ -11,11 +11,14 @@ import Loader from '../Common/Loader';
 import ModalButton from "../Common/ModalButton.react";
 import EditDialog from './EditDialog';
 import Item from "./Item.react";
+import TablePagination from '@material-ui/core/TablePagination';
 
 function List(props) {
   const [application, setApplication] =
     React.useState(applicationsStore.getCachedApplication(props.appID) || null);
   const [packageToUpdate, setPackageToUpdate] = React.useState(null);
+  const rowsPerPage = 10;
+  const [page, setPage] = React.useState(0);
 
   function onChange() {
     setApplication(applicationsStore.getCachedApplication(props.appID));
@@ -44,6 +47,10 @@ function List(props) {
     }
   }
 
+  function handleChangePage(event, newPage) {
+    setPage(newPage);
+  }
+
   return (
     <Paper>
       <ListHeader
@@ -70,14 +77,15 @@ function List(props) {
             <React.Fragment>
               <MuiList>
                 {
-                  application.packages.map(packageItem =>
-                    <Item
-                      key={"packageItemID_" + packageItem.id}
-                      packageItem={packageItem}
-                      channels={application.channels}
-                      handleUpdatePackage={openEditDialog}
-                    />
-                  )
+                  application.packages.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                    .map(packageItem =>
+                      <Item
+                        key={"packageItemID_" + packageItem.id}
+                        packageItem={packageItem}
+                        channels={application.channels}
+                        handleUpdatePackage={openEditDialog}
+                      />
+                    )
                 }
               </MuiList>
               {packageToUpdate &&
@@ -86,6 +94,20 @@ function List(props) {
                   show={packageToUpdate}
                   onHide={onCloseEditDialog} />
               }
+              <TablePagination
+                rowsPerPageOptions={[]}
+                component="div"
+                count={application.packages.length}
+                rowsPerPage={rowsPerPage}
+                page={page}
+                backIconButtonProps={{
+                  'aria-label': 'previous page',
+                }}
+                nextIconButtonProps={{
+                  'aria-label': 'next page',
+                }}
+                onChangePage={handleChangePage}
+              />
             </React.Fragment>
         :
           <Loader />


### PR DESCRIPTION
The package list displayed in the application page shows all the packages available in the application's channels. This means that the list of packages is enormous, increasing the vertical size of the page  beyond what's reasonable, and a long time to load.

This PR fixes that by limiting the number of packages displayed at a time (with pagination).

![Screenshot from 2019-10-18 17-59-47](https://user-images.githubusercontent.com/1029635/67109732-70890e80-f1d1-11e9-9c83-e8b1c5447c9f.png)
