### PR TITLE
frontend: Fix z-index for the version progress bar

### DIFF
--- a/frontend/src/js/components/Common/VersionBreakdownBar.js
+++ b/frontend/src/js/components/Common/VersionBreakdownBar.js
@@ -19,7 +19,7 @@ const useStyles = makeStyles({
 
 const useChartStyle = makeStyles(theme => ({
   chart: {
-    zIndex: theme.zIndex.tooltip,
+    zIndex: theme.zIndex.drawer,
   },
   container: {
     marginLeft: 'auto',


### PR DESCRIPTION
The version progress bar had the same z-index value as the tooltips
since it's tooltip should be displayed on top of the other elements (and
that was not the case with the default value).
However, this value was higher than e.g. the dialogs', which meant that
when editing a package, the progress bar would still be rendered above
the dialog.

This patch uses the "drawer" z-index value for the progress bar. This is
the same as the dialogs' and means that the progress bar is rendered on
top of the normal elements, but not on top of the dialogs.