### PR TITLE
frontend: Hide the "See Instances" link when there's no instances

### DIFF
--- a/frontend/src/js/components/Groups/ItemExtended.react.js
+++ b/frontend/src/js/components/Groups/ItemExtended.react.js
@@ -124,15 +124,18 @@ function ItemExtended(props) {
           <Paper className={classes.instancesChartPaper}>
             <ListHeader
               title="Update Progress"
-              actions={[
-                <Link
-                  className={classes.link}
-                  to={{pathname: `/apps/${props.appID}/groups/${props.groupID}/instances`}}
-                  component={RouterLink}
-                >
-                  See instances
-                </Link>
-              ]}
+              actions={group.instances_stats.total > 0 ? [
+                  <Link
+                    className={classes.link}
+                    to={{pathname: `/apps/${props.appID}/groups/${props.groupID}/instances`}}
+                    component={RouterLink}
+                  >
+                    See instances
+                  </Link>
+                ]
+              :
+                []
+              }
             />
             <Box padding="1em">
               <InstanceStatusArea instanceStats={group.instances_stats} />


### PR DESCRIPTION
In the group details view, if there are no instances to show, the
"See Instances" link should also not be shown.