### PR TITLE
backend: Repeat the info about available update if the client asks about it again for the same app

### DIFF
--- a/pkg/api/updates_test.go
+++ b/pkg/api/updates_test.go
@@ -250,9 +250,15 @@ func TestGetUpdatePackage_UpdateInProgressOnInstance(t *testing.T) {
 
 	instanceID := uuid.NewV4().String()
 
-	_, err := a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	p1, err := a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
+	p2, err := a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, p1, p2)
+
+	err = a.updateInstanceStatus(instanceID, tApp.ID, InstanceStatusDownloading)
+	assert.NoError(t, err)
 	_, err = a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrUpdateInProgressOnInstance, err)
 }


### PR DESCRIPTION
Here is my "knee-jerk reaction" fix for #76. All the existing tests seem to pass, but probably some other test is needed, but for that I would like to know what behaviour is actually desired. There is obviously a problem that there is no explanation what this temporary hack was supposed to work around, which leaves me wondering what kind of workflow this change is going to break…

Fixes #76.