### PR TITLE
backend: Migrate to a maintained uuid package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gobuffalo/packr v1.30.1 // indirect
 	github.com/golangci/golangci-lint v1.21.0
 	github.com/google/go-github/v28 v28.1.1
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/securecookie v1.1.1
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/kevinburke/go-bindata v3.16.0+incompatible
@@ -32,7 +33,7 @@ require (
 	github.com/mgutz/to v1.0.0 // indirect
 	github.com/pmylund/go-cache v2.1.0+incompatible // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20191025130928-9355dd04f4b3
-	github.com/satori/go.uuid v1.2.0
+	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/pkg/api/activity_test.go
+++ b/pkg/api/activity_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgutz/dat.v1"
 )
@@ -20,8 +20,8 @@ func TestGetActivity(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 	tGroup2, _ := a.AddGroup(&Group{Name: "group2", ApplicationID: tApp.ID, PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	tInstance, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	tInstance2, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.2", "1.0.0", tApp.ID, tGroup2.ID)
+	tInstance, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance2, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.2", "1.0.0", tApp.ID, tGroup2.ID)
 
 	_ = a.newGroupActivityEntry(activityRolloutStarted, activitySuccess, tVersion, tApp.ID, tGroup.ID)
 	_ = a.newGroupActivityEntry(activityRolloutStarted, activitySuccess, tVersion, tApp.ID, tGroup2.ID)
@@ -50,6 +50,6 @@ func TestGetActivity(t *testing.T) {
 	_, err = a.GetActivity("invalidTeamID", ActivityQueryParams{})
 	assert.Error(t, err, "Team id used must be a valid uuid.")
 
-	_, err = a.GetActivity(uuid.NewV4().String(), ActivityQueryParams{})
+	_, err = a.GetActivity(uuid.New().String(), ActivityQueryParams{})
 	assert.Error(t, err, "Team id used must exist.")
 }

--- a/pkg/api/applications_test.go
+++ b/pkg/api/applications_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgutz/dat.v1"
 )
@@ -30,7 +30,7 @@ func TestAddApp(t *testing.T) {
 	_, err = a.AddApp(&Application{Name: "app2"})
 	assert.Error(t, err, "Team id is required.")
 
-	_, err = a.AddApp(&Application{Name: "app2", TeamID: uuid.NewV4().String()})
+	_, err = a.AddApp(&Application{Name: "app2", TeamID: uuid.New().String()})
 	assert.Error(t, err, "Team id used must exist.")
 
 	_, err = a.AddApp(&Application{Name: "app2", TeamID: "invalidTeamID"})
@@ -117,7 +117,7 @@ func TestGetApp(t *testing.T) {
 	assert.Equal(t, tApp.Name, app.Name)
 	assert.Equal(t, tChannel.Name, app.Channels[0].Name)
 
-	_, err = a.GetApp(uuid.NewV4().String())
+	_, err = a.GetApp(uuid.New().String())
 	assert.Error(t, err, "Trying to get non existent app.")
 }
 
@@ -137,6 +137,6 @@ func TestGetApps(t *testing.T) {
 	assert.Equal(t, tApp2.Name, apps[0].Name)
 	assert.Equal(t, tChannel.Name, apps[1].Channels[0].Name)
 
-	_, err = a.GetApps(uuid.NewV4().String(), 0, 0)
+	_, err = a.GetApps(uuid.New().String(), 0, 0)
 	assert.Error(t, err, "Trying to get apps of inexisting team.")
 }

--- a/pkg/api/channels_test.go
+++ b/pkg/api/channels_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgutz/dat.v1"
 )
@@ -40,13 +40,13 @@ func TestAddChannel(t *testing.T) {
 	_, err = a.AddChannel(&Channel{Name: "channel3", ApplicationID: "invalidAppID"})
 	assert.Error(t, err, "App id must be a valid uuid.")
 
-	_, err = a.AddChannel(&Channel{Name: "channel3", ApplicationID: uuid.NewV4().String()})
+	_, err = a.AddChannel(&Channel{Name: "channel3", ApplicationID: uuid.New().String()})
 	assert.Error(t, err, "App used must exist.")
 
 	_, err = a.AddChannel(&Channel{Name: "channel3", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom("invalidPackageID")})
 	assert.Error(t, err, "Package id must be a valid uuid.")
 
-	_, err = a.AddChannel(&Channel{Name: "channel3", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(uuid.NewV4().String())})
+	_, err = a.AddChannel(&Channel{Name: "channel3", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(uuid.New().String())})
 	assert.Error(t, err, "Package used must exist.")
 
 	_, err = a.AddChannel(&Channel{Name: "channel3", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg2.ID)})
@@ -119,7 +119,7 @@ func TestGetChannel(t *testing.T) {
 	_, err = a.GetChannel("invalidChannelID")
 	assert.Error(t, err, "Channel id must be a valid uuid.")
 
-	_, err = a.GetChannel(uuid.NewV4().String())
+	_, err = a.GetChannel(uuid.New().String())
 	assert.Error(t, err, "Channel id must exist.")
 }
 
@@ -145,6 +145,6 @@ func TestGetChannels(t *testing.T) {
 	_, err = a.GetChannels("invalidAppID", 0, 0)
 	assert.Error(t, err, "Add id must be a valid uuid.")
 
-	_, err = a.GetChannels(uuid.NewV4().String(), 0, 0)
+	_, err = a.GetChannels(uuid.New().String(), 0, 0)
 	assert.Error(t, err, "App id used must exist.")
 }

--- a/pkg/api/events_test.go
+++ b/pkg/api/events_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgutz/dat.v1"
 )
@@ -18,15 +18,15 @@ func TestRegisterEvent_InvalidParams(t *testing.T) {
 	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	tInstance, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
-	err := a.RegisterEvent(uuid.NewV4().String(), tApp.ID, tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
+	err := a.RegisterEvent(uuid.New().String(), tApp.ID, tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
 	assert.Equal(t, ErrInvalidInstance, err)
 
-	err = a.RegisterEvent(tInstance.ID, uuid.NewV4().String(), tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
+	err = a.RegisterEvent(tInstance.ID, uuid.New().String(), tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
 	assert.Equal(t, ErrInvalidApplicationOrGroup, err)
 
-	err = a.RegisterEvent(tInstance.ID, tApp.ID, uuid.NewV4().String(), EventUpdateComplete, ResultSuccessReboot, "", "")
+	err = a.RegisterEvent(tInstance.ID, tApp.ID, uuid.New().String(), EventUpdateComplete, ResultSuccessReboot, "", "")
 	assert.Equal(t, sql.ErrNoRows, err)
 
 	err = a.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, EventUpdateDownloadStarted, ResultSuccess, "", "")
@@ -50,8 +50,8 @@ func TestRegisterEvent_TriggerEventConsequences(t *testing.T) {
 	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	tInstance, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	tInstance2, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.2", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance2, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.2", "1.0.0", tApp.ID, tGroup.ID)
 
 	_, err := a.GetUpdatePackage(tInstance.ID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
@@ -96,7 +96,7 @@ func TestRegisterEvent_TriggerEventConsequences_FirstUpdateAttemptFailed(t *test
 	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	tInstance, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
 	_, err := a.GetUpdatePackage(tInstance.ID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)

--- a/pkg/api/groups_test.go
+++ b/pkg/api/groups_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgutz/dat.v1"
 )
@@ -124,7 +124,7 @@ func TestGetGroup(t *testing.T) {
 	assert.Equal(t, tChannel.Name, group.Channel.Name)
 	assert.Equal(t, tPkg.Version, group.Channel.Package.Version)
 
-	_, err = a.GetGroup(uuid.NewV4().String())
+	_, err = a.GetGroup(uuid.New().String())
 	assert.Error(t, err, "Trying to get non existent group.")
 }
 

--- a/pkg/api/instances.go
+++ b/pkg/api/instances.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"gopkg.in/mgutz/dat.v1"
 )
 
@@ -184,11 +184,11 @@ func (api *API) GetInstances(p InstancesQueryParams) ([]*Instance, error) {
 // groupID provided if both are valid and the group belongs to the given
 // application, or an error if something goes wrong.
 func (api *API) validateApplicationAndGroup(appID, groupID string) (string, string, error) {
-	appUUID, err := uuid.FromString(appID)
+	appUUID, err := uuid.Parse(appID)
 	if err != nil {
 		return "", "", err
 	}
-	groupUUID, err := uuid.FromString(groupID)
+	groupUUID, err := uuid.Parse(groupID)
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/api/instances_test.go
+++ b/pkg/api/instances_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgutz/dat.v1"
 )
@@ -21,7 +21,7 @@ func TestRegisterInstance(t *testing.T) {
 	tGroup2, _ := a.AddGroup(&Group{Name: "group2", ApplicationID: tApp2.ID, PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 	tGroup3, _ := a.AddGroup(&Group{Name: "group3", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
-	instanceID := uuid.NewV4().String()
+	instanceID := uuid.New().String()
 
 	_, err := a.RegisterInstance("", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 	assert.Error(t, err, "Using empty string as instance id.")
@@ -73,9 +73,9 @@ func TestGetInstance(t *testing.T) {
 	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	tInstance, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
-	_, err := a.GetInstance(uuid.NewV4().String(), tApp.ID)
+	_, err := a.GetInstance(uuid.New().String(), tApp.ID)
 	assert.Error(t, err, "Using non existent instance id.")
 
 	_, err = a.GetInstance("invalidInstanceID", tApp.ID)
@@ -102,9 +102,9 @@ func TestGetInstances(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 	tGroup2, _ := a.AddGroup(&Group{Name: "group2", ApplicationID: tApp.ID, PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	tInstance, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	_, _ = a.RegisterInstance(uuid.NewV4().String(), "10.0.0.2", "1.0.1", tApp.ID, tGroup.ID)
-	_, _ = a.RegisterInstance(uuid.NewV4().String(), "10.0.0.3", "1.0.2", tApp.ID, tGroup2.ID)
+	tInstance, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(uuid.New().String(), "10.0.0.2", "1.0.1", tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(uuid.New().String(), "10.0.0.3", "1.0.2", tApp.ID, tGroup2.ID)
 
 	instances, err := a.GetInstances(InstancesQueryParams{ApplicationID: tApp.ID, GroupID: tGroup.ID, Version: "1.0.0", Page: 1, PerPage: 10})
 	assert.NoError(t, err)

--- a/pkg/api/packages_test.go
+++ b/pkg/api/packages_test.go
@@ -5,7 +5,7 @@ import (
 
 	"gopkg.in/mgutz/dat.v1"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,7 +45,7 @@ func TestAddPackage(t *testing.T) {
 	_, err = a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0"})
 	assert.Error(t, err, "App id is required and must be a valid uuid.")
 
-	_, err = a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID, ChannelsBlacklist: []string{uuid.NewV4().String()}})
+	_, err = a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID, ChannelsBlacklist: []string{uuid.New().String()}})
 	assert.Error(t, err, "Blacklisted channels must be existing channels ids.")
 
 	_, err = a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID, ChannelsBlacklist: []string{"invalidChannelID"}})
@@ -185,7 +185,7 @@ func TestGetPackage(t *testing.T) {
 	_, err = a.GetPackage("invalidPackageID")
 	assert.Error(t, err, "Package id must be a valid uuid.")
 
-	_, err = a.GetPackage(uuid.NewV4().String())
+	_, err = a.GetPackage(uuid.New().String())
 	assert.Error(t, err, "Package id must exist.")
 }
 
@@ -208,7 +208,7 @@ func TestGetPackageByVersion(t *testing.T) {
 	_, err = a.GetPackageByVersion("invalidAppID", "12.1.0")
 	assert.Error(t, err, "Application id must be a valid uuid.")
 
-	_, err = a.GetPackageByVersion(uuid.NewV4().String(), "12.1.0")
+	_, err = a.GetPackageByVersion(uuid.New().String(), "12.1.0")
 	assert.Error(t, err, "Application id must exist.")
 
 	_, err = a.GetPackageByVersion(tApp.ID, "hola")
@@ -237,6 +237,6 @@ func TestGetPackages(t *testing.T) {
 	_, err = a.GetPackages("invalidAppID", 0, 0)
 	assert.Error(t, err, "Add id must be a valid uuid.")
 
-	_, err = a.GetPackages(uuid.NewV4().String(), 0, 0)
+	_, err = a.GetPackages(uuid.New().String(), 0, 0)
 	assert.Error(t, err, "App id used must exist.")
 }

--- a/pkg/api/updates_test.go
+++ b/pkg/api/updates_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgutz/dat.v1"
 )
@@ -22,28 +22,28 @@ func TestGetUpdatePackage(t *testing.T) {
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 	tGroup2, _ := a.AddGroup(&Group{Name: "group2", ApplicationID: tApp2.ID, ChannelID: dat.NullStringFrom(tChannel2.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
-	_, err := a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "1.0.0", "invalidApplicationID", tGroup.ID)
+	_, err := a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", "invalidApplicationID", tGroup.ID)
 	assert.Error(t, ErrInvalidApplicationOrGroup, err, "Invalid application id.")
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, "invalidGroupID")
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, "invalidGroupID")
 	assert.Error(t, err, "Invalid group id.")
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "1.0.0", uuid.NewV4().String(), tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", uuid.New().String(), tGroup.ID)
 	assert.Error(t, err, "Non existent application id.")
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, uuid.NewV4().String())
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, uuid.New().String())
 	assert.Error(t, err, "Non existent group id.")
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup2.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup2.ID)
 	assert.Error(t, err, "Group doesn't belong to the application provided.")
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp2.ID, tGroup2.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", tApp2.ID, tGroup2.ID)
 	assert.Equal(t, ErrNoPackageFound, err, "Group's channel has no package bound.")
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "12.1.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.1.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrNoUpdatePackageAvailable, err, "Instance version is up to date.")
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "1010.5.0+2016-05-27-1832", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1010.5.0+2016-05-27-1832", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrNoUpdatePackageAvailable, err, "Instance version is up to date.")
 }
 
@@ -55,7 +55,7 @@ func TestGetUpdatePackage_GroupNoChannel(t *testing.T) {
 	tApp, _ := a.AddApp(&Application{Name: "test_app", TeamID: tTeam.ID})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, PolicyUpdatesEnabled: false, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
-	_, _ = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Error(t, ErrNoPackageFound)
 }
 
@@ -69,7 +69,7 @@ func TestGetUpdatePackage_UpdatesDisabled(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: false, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
-	_, err := a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrUpdatesDisabled, err)
 }
 
@@ -85,10 +85,10 @@ func TestGetUpdatePackage_MaxUpdatesPerPeriodLimitReached_SafeMode(t *testing.T)
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: safeMode, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
-	_, err := a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxUpdatesPerPeriodLimitReached, err, "Safe mode is enabled, first update should be completed before letting more through.")
 }
 
@@ -102,17 +102,17 @@ func TestGetUpdatePackage_MaxUpdatesPerPeriodLimitReached_LimitUpdated(t *testin
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 1, PolicyUpdateTimeout: "60 minutes"})
 
-	instanceID := uuid.NewV4().String()
+	instanceID := uuid.New().String()
 	_, err := a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxUpdatesPerPeriodLimitReached, err, "Max 1 update per period, limit reached")
 
 	tGroup.PolicyMaxUpdatesPerPeriod = 2
 	_ = a.UpdateGroup(tGroup)
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 }
 
@@ -129,25 +129,25 @@ func TestGetUpdatePackage_MaxUpdatesLimitsReached(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: periodInterval, PolicyMaxUpdatesPerPeriod: maxUpdatesPerPeriod, PolicyUpdateTimeout: "60 minutes"})
 
-	newInstance1ID := uuid.NewV4().String()
+	newInstance1ID := uuid.New().String()
 
 	_, err := a.GetUpdatePackage(newInstance1ID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxUpdatesPerPeriodLimitReached, err)
 
 	time.Sleep(100 * time.Millisecond)
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxConcurrentUpdatesLimitReached, err, "Period interval is over, but there are still two updates not completed or failed.")
 
 	_ = a.updateInstanceStatus(newInstance1ID, tApp.ID, InstanceStatusComplete)
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 }
 
@@ -165,20 +165,20 @@ func TestGetUpdatePackage_MaxTimedOutUpdatesLimitReached(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: periodInterval, PolicyMaxUpdatesPerPeriod: maxUpdatesPerPeriod, PolicyUpdateTimeout: updateTimeout})
 
-	_, err := a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond)
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxConcurrentUpdatesLimitReached, err)
 
 	time.Sleep(100 * time.Millisecond)
 
-	_, err = a.GetUpdatePackage(uuid.NewV4().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxTimedOutUpdatesLimitReached, err)
 }
 
@@ -192,9 +192,9 @@ func TestGetUpdatePackage_RolloutStats(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "test_group", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 4, PolicyUpdateTimeout: "60 minutes"})
 
-	instance1, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	instance2, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	instance3, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	instance1, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	instance2, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	instance3, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
 	_, _ = a.GetUpdatePackage(instance1.ID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	_, _ = a.GetUpdatePackage(instance2.ID, "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
@@ -248,7 +248,7 @@ func TestGetUpdatePackage_UpdateInProgressOnInstance(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
-	instanceID := uuid.NewV4().String()
+	instanceID := uuid.New().String()
 
 	p1, err := a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
@@ -273,7 +273,7 @@ func TestGetUpdatePackage_InstanceStatusHistory(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: dat.NullStringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "test_group", ApplicationID: tApp.ID, ChannelID: dat.NullStringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 3, PolicyUpdateTimeout: "60 minutes"})
 
-	instance1, _ := a.RegisterInstance(uuid.NewV4().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	instance1, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
 	_, _ = a.GetUpdatePackage(instance1.ID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	_ = a.RegisterEvent(instance1.ID, tApp.ID, tGroup.ID, EventUpdateDownloadStarted, ResultSuccess, "", "")

--- a/pkg/omaha/omaha.go
+++ b/pkg/omaha/omaha.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 
 	omahaSpec "github.com/coreos/go-omaha/omaha"
+	"github.com/google/uuid"
 	log "github.com/mgutz/logxi/v1"
-	uuid "github.com/satori/go.uuid"
 
 	"github.com/kinvolk/nebraska/pkg/api"
 )
@@ -76,7 +76,7 @@ func (h *Handler) buildOmahaResponse(omahaReq *omahaSpec.Request, ip string) (*o
 		// Use Track field as the group to ask CR for updates. For the Flatcar
 		// app, map group name to its id if available.
 		group := reqApp.Track
-		if reqAppUUID, err := uuid.FromString(reqApp.ID); err == nil {
+		if reqAppUUID, err := uuid.Parse(reqApp.ID); err == nil {
 			if reqAppUUID.String() == flatcarAppID {
 				if flatcarGroupID, ok := flatcarGroups[group]; ok {
 					group = flatcarGroupID

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"github.com/coreos/go-omaha/omaha"
+	"github.com/google/uuid"
 	log "github.com/mgutz/logxi/v1"
-	uuid "github.com/satori/go.uuid"
 	"gopkg.in/mgutz/dat.v1"
 
 	"github.com/kinvolk/nebraska/pkg/api"
@@ -129,8 +129,8 @@ func (s *Syncer) initialize() error {
 
 	for _, c := range flatcarApp.Channels {
 		if c.Name == "stable" || c.Name == "beta" || c.Name == "alpha" || c.Name == "edge" {
-			s.machinesIDs[c.Name] = "{" + uuid.NewV4().String() + "}"
-			s.bootIDs[c.Name] = "{" + uuid.NewV4().String() + "}"
+			s.machinesIDs[c.Name] = "{" + uuid.New().String() + "}"
+			s.bootIDs[c.Name] = "{" + uuid.New().String() + "}"
 			s.channelsIDs[c.Name] = c.ID
 
 			if c.Package != nil {
@@ -162,7 +162,7 @@ func (s *Syncer) checkForUpdates() error {
 				return err
 			}
 			s.versions[channel] = update.Manifest.Version
-			s.bootIDs[channel] = "{" + uuid.NewV4().String() + "}"
+			s.bootIDs[channel] = "{" + uuid.New().String() + "}"
 		} else {
 			logger.Debug("checkForUpdates, no update available", "channel", channel, "currentVersion", currentVersion, "updateStatus", update.Status)
 		}


### PR DESCRIPTION
github.com/satori/go.uuid haven't seen code changes for over a year
now. This normally wouldn't be a problem if not for the fact that the
library apparently has some issues with generation of the random
UUIDs. Also the top issue in the repository has a title "PSA: This
repo is dead".

Alternatives were github.com/gofrs/uuid or github.com/google/uuid. The
former seems to be a continuation of the satori's repo. Picked the
latter, since I wasn't sure about the longevity of the former.

We still require the repository indirectly, though. When we replace
the ORM we have now with something else, then the old UUID package
will likely go away.