### PR TITLE
backend: Fix nil pointer dereference in syncer

### DIFF
--- a/pkg/omaha/omaha.go
+++ b/pkg/omaha/omaha.go
@@ -135,6 +135,7 @@ func (h *Handler) buildOmahaResponse(omahaReq *omahaSpec.Request, ip string) (*o
 			pkg, err := h.crAPI.GetUpdatePackage(reqApp.MachineID, ip, reqApp.Version, reqApp.ID, group)
 			if err != nil && err != api.ErrNoUpdatePackageAvailable {
 				respApp.Status = h.getStatusMessage(err)
+				respApp.AddUpdateCheck(omahaSpec.UpdateInternalError)
 			} else {
 				h.prepareUpdateCheck(respApp, pkg)
 			}

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -166,7 +166,7 @@ func (s *Syncer) checkForUpdates() error {
 		if err != nil {
 			return err
 		}
-		if update.Status == "ok" {
+		if update != nil && update.Status == "ok" {
 			logger.Debug("checkForUpdates, got an update", "channel", descriptor.name, "arch", descriptor.arch.String(), "currentVersion", currentVersion, "availableVersion", update.Manifest.Version)
 			if err := s.processUpdate(descriptor, update); err != nil {
 				return err


### PR DESCRIPTION
It maybe possible that the app response will not contain the update
check element, so after decoding the update check field in the struct
may be nil. If that happens, treat it as no update available.