### PR TITLE
backend: Temporarily filter out instances with bracketed IDs

### DIFF
--- a/pkg/api/instances.go
+++ b/pkg/api/instances.go
@@ -266,6 +266,7 @@ func (api *API) instancesQuery(p InstancesQueryParams) *dat.SelectDocBuilder {
 		From("instance_application").
 		Where("application_id = $1 AND group_id = $2", p.ApplicationID, p.GroupID).
 		Where(fmt.Sprintf("last_check_for_updates > now() at time zone 'utc' - interval '%s'", validityInterval)).
+		Where(`instance_id NOT SIMILAR TO '\{[a-fA-F0-9-]{36}\}'`).
 		Paginate(p.Page, p.PerPage)
 
 	if p.Status != 0 {


### PR DESCRIPTION
Currently syncer sends requests with machine ID set to something like
'{8d180b2a-0734-4406-af02-9a4f86bd1ee0}', while update_engine uses
contents of /etc/machine_id, which are in form like
'8d180b2a07344406af029a4f86bd1ee0'.