### PR TITLE
Show correct number of instances in instances list view

### DIFF
--- a/frontend/src/js/api/API.js
+++ b/frontend/src/js/api/API.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import _ from "underscore";
 import moment from "moment";
 import PubSub from "pubsub-js"
+import queryString from 'querystring';
 
 const MAIN_PROGRESS_BAR = "main_progress_bar"
 const BASE_URL = "/api"
@@ -134,9 +135,13 @@ class API {
 
   // Instances
 
-  static getInstances(applicationID, groupID) {
-    let url = BASE_URL + "/apps/" + applicationID + "/groups/" + groupID + "/instances"
-    
+  static getInstances(applicationID, groupID, queryOptions={}) {
+    let url = BASE_URL + "/apps/" + applicationID + "/groups/" + groupID + "/instances";
+
+    if (!_.isEmpty(queryOptions)) {
+      url += "?" + queryString.stringify(queryOptions);
+    }
+
     return API.getJSON(url)
   }
 

--- a/frontend/src/js/components/Instances/List.js
+++ b/frontend/src/js/components/Instances/List.js
@@ -169,7 +169,10 @@ function ListView(props) {
     const now = moment();
     if (now.diff(lastCheck, 'seconds', true) > CHECKS_TIMEOUT) {
       setLastCheck(now);
-      instancesStore.getInstances(application.id, group.id, null);
+      instancesStore.getInstances(application.id, group.id, null,
+        {
+          perpage: group.instances_stats.total
+        });
     }
 
     return function cleanup() {

--- a/frontend/src/js/components/Instances/List.js
+++ b/frontend/src/js/components/Instances/List.js
@@ -82,7 +82,7 @@ function InstanceFilter(props) {
           >
             <MenuItem key="" value="">Show All</MenuItem>
             {
-              versions.map(({version}) => {
+              (versions || []).map(({version}) => {
                 return <MenuItem key={version} value={version}>{version}</MenuItem>;
               })
             }
@@ -97,7 +97,7 @@ function ListView(props) {
   let {application, group} = props;
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(10);
-  const [instances, setInstances] = React.useState([]);
+  const [instances, setInstances] = React.useState(null);
   const [filteredInstances, setFilteredInstances] = React.useState([]);
   const [lastCheck, setLastCheck] = React.useState(moment([0, 0])); // Long long time ago.
   const [filters, setFilters] = React.useState({status: '', version: ''});
@@ -141,13 +141,13 @@ function ListView(props) {
 
   function onChangeInstances() {
     let cachedInstances = instancesStore.getCachedInstances(application.id, group.id) || [];
-    if (instances.length == 0 || filteredInstances.length == 0) {
+    if (!instances || instances.length == 0 || filteredInstances.length == 0) {
       setInstances(cachedInstances);
       setFilteredInstances(cachedInstances);
       return;
     }
 
-    if (cachedInstances.length > 0 && instances.length > 0) {
+    if (cachedInstances.length > 0 && instances && instances.length > 0) {
       // Update instances state only when needed.
       if (cachedInstances.length != instances.length ||
           cachedInstances[0].id != instances[0].id ||
@@ -182,7 +182,7 @@ function ListView(props) {
   [lastCheck, instances]);
 
   function getInstanceCount() {
-    if (instances.length == 0)
+    if (!instances || instances.length == 0)
       return group.instances_stats.total;
     if (filteredInstances.length == instances.length)
       return filteredInstances.length;
@@ -219,7 +219,7 @@ function ListView(props) {
                 versions={group.version_breakdown}
                 onFiltersChanged={onFiltersChanged}
                 filter={filters}
-                disabled={instances.length == 0}
+                disabled={!instances || instances.length === 0}
               />
             </Grid>
           </Grid>
@@ -237,7 +237,7 @@ function ListView(props) {
             </Grid>
           }
           <Grid item md={12}>
-            { instances.length > 0 ?
+            { instances ?
               (filteredInstances.length > 0 ?
                 <React.Fragment>
                   <Table

--- a/frontend/src/js/stores/InstancesStore.js
+++ b/frontend/src/js/stores/InstancesStore.js
@@ -20,10 +20,10 @@ class InstancesStore extends Store {
     return cachedInstances
   }
 
-  getInstances(applicationID, groupID, selectedInstance) {
+  getInstances(applicationID, groupID, selectedInstance, queryOptions={}) {
     let application = this.instances.hasOwnProperty(applicationID) ? this.instances[applicationID] : this.instances[applicationID] = {}
 
-    API.getInstances(applicationID, groupID).
+    API.getInstances(applicationID, groupID, queryOptions).
       done(instances => {
         let sortedInstances = _.sortBy(instances, (instance) => {
           if (selectedInstance) {


### PR DESCRIPTION
Due to #122 the instances list view was displaying just up to 500 instances.
This patch fixes that until we have the backend pagination working correctly.