### PR TITLE
backend: Ignore instances with bracketed IDs in more places

### DIFF
--- a/pkg/api/activity.go
+++ b/pkg/api/activity.go
@@ -120,6 +120,8 @@ func (api *API) activityQuery(teamID string, p ActivityQueryParams) *dat.SelectD
 
 	if p.InstanceID != "" {
 		query.Where("a.instance_id = $1", p.InstanceID)
+	} else {
+		query.Where(ignoreFakeInstanceCondition("a.instance_id"))
 	}
 
 	if p.Version != "" {

--- a/pkg/api/applications.go
+++ b/pkg/api/applications.go
@@ -165,6 +165,7 @@ func (api *API) appInstancesCountQuery() string {
 	SELECT count(*)
 	FROM instance_application
 	WHERE application_id = application.id AND
-	      last_check_for_updates > now() at time zone 'utc' - interval '%s'
-	`, validityInterval)
+	      last_check_for_updates > now() at time zone 'utc' - interval '%s' AND
+	      %s
+	`, validityInterval, ignoreFakeInstanceCondition("instance_id"))
 }

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -2,24 +2,25 @@ package api
 
 import (
 	"database/sql"
+	"fmt"
 )
 
-const (
-	appInstancesPerChannelMetricSQL string = `
+var (
+	appInstancesPerChannelMetricSQL string = fmt.Sprintf(`
 SELECT a.name AS app_name, ia.version AS version, c.name AS channel_name, count(ia.version) AS instances_count
 FROM instance_application ia, application a, channel c, groups g
-WHERE a.team_id = $1 AND a.id = ia.application_id AND ia.group_id = g.id AND g.channel_id = c.id
+WHERE a.team_id = $1 AND a.id = ia.application_id AND ia.group_id = g.id AND g.channel_id = c.id AND %s
 GROUP BY app_name, version, channel_name
 ORDER BY app_name, version, channel_name
-`
+`, ignoreFakeInstanceCondition("ia.instance_id"))
 
-	failedUpdatesSQL string = `
+	failedUpdatesSQL string = fmt.Sprintf(`
 SELECT a.name AS app_name, count(*) as fail_count
 FROM application a, event e, event_type et
-WHERE a.team_id = $1 AND a.id = e.application_id AND e.event_type_id = et.id AND et.result = 0 AND et.type = 3
+WHERE a.team_id = $1 AND a.id = e.application_id AND e.event_type_id = et.id AND et.result = 0 AND et.type = 3 AND %s
 GROUP BY app_name
 ORDER BY app_name
-`
+`, ignoreFakeInstanceCondition("e.instance_id"))
 )
 
 type AppInstancesPerChannelMetric struct {


### PR DESCRIPTION
This is to avoid skews in statistics or metrics resulting from taking
fake instances into account.