### PR TITLE
auth/github: support GitHub Enterprise

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -138,6 +138,14 @@ generated on github (`https://github.com/settings/tokens`).
 
 Personal access token requires just one scope: `read:org`.
 
+# GitHub Enterprise
+
+If you want to authenticate against GitHub Enterprise, set `-gh-enterprise-url`
+to the URL of your GitHub Enterprise instance, for example
+`https://github.myorganization.net`.
+
+After that, follow the same procedures as with GitHub.
+
 # Troubleshooting:
 
 - I'm getting a blank page!


### PR DESCRIPTION
If the flag `-gh-enterprise-url` is specified, use that as endpoint for
GitHub authentication following the GitHub Enterprise conventions.