### PR TITLE
frontend: Make the access management URL configurable

### DIFF
--- a/frontend/.env.defaults
+++ b/frontend/.env.defaults
@@ -1,3 +1,4 @@
 PROJECT_NAME=Nebraska
 PRIMARY_COLOR=#09bac8
 APPBAR_BG=
+ACCESS_MANAGEMENT_URL=https://github.com/settings/apps/authorizations

--- a/frontend/src/js/components/Header.react.js
+++ b/frontend/src/js/components/Header.react.js
@@ -76,7 +76,7 @@ export default function Header() {
         >
           <MenuItem
             component="a"
-            href="https://github.com/settings/apps/authorizations"
+            href={process.env.ACCESS_MANAGEMENT_URL}
           >
             <ListItemIcon>
               <CreateOutlined />


### PR DESCRIPTION
The access management was hardcoded since we were supposed to always
manage the access in that Github page. However, when using Github
Enterprise, that URL will be different.

This patch thus allows to specify the URL in the .env configuration.