### PR TITLE
Disable cgo and enable goproxy in compilation

### DIFF
--- a/Dockerfile.nebraska
+++ b/Dockerfile.nebraska
@@ -1,6 +1,7 @@
 FROM alpine:3.10 as nebraska-build
 
-ENV GOPATH=/go
+ENV GOPATH=/go \
+    GOPROXY=https://proxy.golang.org
 
 RUN apk update && \
 	apk add git go nodejs npm ca-certificates make musl-dev bash

--- a/Makefile
+++ b/Makefile
@@ -72,14 +72,14 @@ test-clean-work-tree-backend:
 
 .PHONY: tools
 tools:
-	go build -o bin/initdb ./cmd/initdb
-	go build -o bin/userctl ./cmd/userctl
+	CGO_ENABLED=0 go build -o bin/initdb ./cmd/initdb
+	CGO_ENABLED=0 go build -o bin/userctl ./cmd/userctl
 
 tools/go-bindata: go.mod go.sum
-	go build -o tools/go-bindata github.com/kevinburke/go-bindata/go-bindata
+	CGO_ENABLED=0 go build -o tools/go-bindata github.com/kevinburke/go-bindata/go-bindata
 
 tools/golangci-lint: go.mod go.sum
-	go build -o ./tools/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
+	CGO_ENABLED=0 go build -o ./tools/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
 
 .PHONY: container-nebraska
 container-nebraska:


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

While compiling Nebraska using docker-compose or even ``make container-nebraska`` a user might face errors because:

* golangci-lint is compiled outside of the container, and then used inside an Alpine container which doesn't have glibc. The same apply to other tools

* Network environments with performance problems might face issues while compiling, so using GOPROXY might bring performance improvement in compilation

To reproduce the behavior pre PR, please clone the master repo, and then run ``make container-nebraska`` or try using the docker-compose file :)

