### PR TITLE
Fix access management URL

### DIFF
--- a/cmd/nebraska/controller_test.go
+++ b/cmd/nebraska/controller_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kinvolk/nebraska/cmd/nebraska/auth"
 )
 
 func TestGetRequestIP(t *testing.T) {
@@ -26,4 +28,50 @@ func TestGetRequestIP(t *testing.T) {
 		r.Header.Set("X-Forwarded-For", tc.xForwardedFor)
 		assert.Equal(t, tc.expectedOutput, getRequestIP(r))
 	}
+}
+
+func TestClientConfig(t *testing.T) {
+	// Test the client configuration with the "noop" auth backend
+	noopAuthConfig := &auth.NoopAuthConfig{}
+	conf := &controllerConfig{
+		noopAuthConfig: noopAuthConfig,
+	}
+
+	ctl, err := newController(conf)
+
+	assert.NoError(t, err, "Couldn't create controller")
+
+	assert.Equal(t, "",
+		ctl.clientConfig.AccessManagementURL,
+		"AccessManagementURL should be empty!")
+
+	// Test the client configuration with the Github auth backend
+	ghAuthConfig := &auth.GithubAuthConfig{}
+	conf = &controllerConfig{
+		githubAuthConfig: ghAuthConfig,
+	}
+
+	ctl, err = newController(conf)
+
+	assert.NoError(t, err, "Couldn't create controller")
+
+	assert.Equal(t, "https://github.com/settings/apps/authorizations",
+		ctl.clientConfig.AccessManagementURL)
+
+	// Test the client configuration with the Github Enterprise auth backend
+	const phonyURL = "https://phony-ghe.url"
+
+	ghAuthConfig = &auth.GithubAuthConfig{
+		EnterpriseURL: phonyURL,
+	}
+	conf = &controllerConfig{
+		githubAuthConfig: ghAuthConfig,
+	}
+
+	ctl, err = newController(conf)
+
+	assert.NoError(t, err, "Couldn't create controller")
+
+	assert.Equal(t, phonyURL+"/settings/apps/authorizations",
+		ctl.clientConfig.AccessManagementURL)
 }

--- a/cmd/nebraska/nebraska.go
+++ b/cmd/nebraska/nebraska.go
@@ -272,6 +272,11 @@ func setupRoutes(ctl *controller, httpLog bool) *gin.Engine {
 	omahaRouter.POST("/omaha", ctl.processOmahaRequest)
 	omahaRouter.POST("/v1/update", ctl.processOmahaRequest)
 
+	// Config router setup
+	configRouter := wrappedEngine.Group("/config", "config")
+	configRouter.Use(ctl.authenticate)
+	configRouter.GET("/", ctl.getConfig)
+
 	// Host Flatcar packages payloads
 	if *hostFlatcarPackages {
 		flatcarPkgsRouter := wrappedEngine.Group("/flatcar", "flatcar")

--- a/frontend/src/js/api/API.js
+++ b/frontend/src/js/api/API.js
@@ -170,6 +170,12 @@ class API {
     return API.doRequest("PUT", url, JSON.stringify(userData))
   }
 
+  // Config
+
+  static getConfig() {
+    return API.doRequest("GET", "/config")
+  }
+
   // Helpers
 
   static removeKeysFromObject(data, valuesToRemove) {

--- a/frontend/src/js/components/Header.react.js
+++ b/frontend/src/js/components/Header.react.js
@@ -13,6 +13,7 @@ import { Icon } from '@iconify/react';
 import React from 'react';
 import nebraskaLogo from '../icons/nebraska-logo.json';
 import _ from 'underscore';
+import API from '../api/API';
 
 const useStyles = makeStyles(theme => ({
   title: {
@@ -30,6 +31,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function Header() {
   const classes = useStyles();
+  const [config, setConfig] = React.useState(null);
   const projectLogo = _.isEmpty(nebraskaLogo) ? null : nebraskaLogo;
 
   let [menuAnchorEl, setMenuAnchorEl] = React.useState(null);
@@ -42,6 +44,20 @@ export default function Header() {
     setMenuAnchorEl(null);
   }
 
+  // @todo: This should be abstracted but we should do it when we integrate Redux.
+  React.useEffect(() => {
+    if (!config) {
+      API.getConfig()
+        .done(config => {
+          setConfig(config);
+        })
+        .fail(error => {
+          console.error(error);
+        });
+    }
+  },
+  [config]);
+
   return (
     <AppBar position='static' className={classes.header}>
       <Toolbar>
@@ -51,15 +67,17 @@ export default function Header() {
         <Typography variant='h6' className={classes.title}>
           {process.env.PROJECT_NAME}
         </Typography>
-        <IconButton
-          aria-label='User menu'
-          aria-controls='menu-appbar'
-          aria-haspopup='true'
-          onClick={handleMenu}
-          color='inherit'
-        >
-          <AccountCircle />
-        </IconButton>
+        {config && config.access_management_url &&
+          <IconButton
+            aria-label='User menu'
+            aria-controls='menu-appbar'
+            aria-haspopup='true'
+            onClick={handleMenu}
+            color='inherit'
+          >
+            <AccountCircle />
+          </IconButton>
+        }
         <Menu
           id='customized-menu'
           anchorEl={menuAnchorEl}
@@ -76,7 +94,7 @@ export default function Header() {
         >
           <MenuItem
             component="a"
-            href="https://github.com/settings/apps/authorizations"
+            href={config && config.access_management_url}
           >
             <ListItemIcon>
               <CreateOutlined />


### PR DESCRIPTION
This PR allows us to set the access management URL according to the auth backend being used, i.e. fixes #130 and makes it more future-proof when we add more authentication backends.