### PR TITLE
Restyle channels list

### DIFF
--- a/frontend/src/js/components/Channels/Item.react.js
+++ b/frontend/src/js/components/Channels/Item.react.js
@@ -10,7 +10,7 @@ import MoreMenu from '../Common/MoreMenu';
 import ChannelAvatar from './ChannelAvatar';
 
 function Item(props) {
-  let {channel, packages, handleUpdateChannel, ...others} = props;
+  let {channel, packages, handleUpdateChannel, showArch=true, ...others} = props;
   const name = channel.name;
   const version = channel.package ? cleanSemverVersion(channel.package.version) : 'No package';
 
@@ -25,6 +25,24 @@ function Item(props) {
     props.handleUpdateChannel(channel.id);
   }
 
+  function getSecondaryText() {
+    let text = '';
+
+    if (version) {
+      text = cleanSemverVersion(version);
+    }
+
+    if (showArch) {
+      if (text !== '') {
+        text += ' ';
+      }
+
+      text += `(${ARCHES[channel.arch]})`;
+    }
+
+    return text;
+  }
+
   return (
     <ListItem component="div" {...others}>
       <ListItemAvatar>
@@ -33,7 +51,7 @@ function Item(props) {
       <ListItemText
         primary={name}
 
-        secondary={`${version ? cleanSemverVersion(version) + ' ': ''}(${ARCHES[channel.arch]})`}
+        secondary={getSecondaryText()}
       />
       {props.handleUpdateChannel &&
         <ListItemSecondaryAction>

--- a/frontend/src/js/components/Channels/List.react.js
+++ b/frontend/src/js/components/Channels/List.react.js
@@ -1,16 +1,16 @@
-import PropTypes from 'prop-types';
-import { applicationsStore } from "../../stores/Stores"
-import React from "react"
-import _ from "underscore"
-import ModalButton from "../Common/ModalButton.react"
-import EditDialog from "./EditDialog"
-import Item from "./Item.react"
-import Loader from '../Common/Loader';
 import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
 import MuiList from '@material-ui/core/List';
+import Typography from '@material-ui/core/Typography';
+import PropTypes from 'prop-types';
+import React from "react";
+import _ from "underscore";
+import { applicationsStore } from "../../stores/Stores";
 import Empty from '../Common/EmptyContent';
+import Loader from '../Common/Loader';
+import ModalButton from "../Common/ModalButton.react";
 import SectionPaper from '../Common/SectionPaper';
+import EditDialog from "./EditDialog";
+import Item from "./Item.react";
 
 class List extends React.Component {
 


### PR DESCRIPTION
This PR addresses the problem of having the channel list too clutter due to having new architectures and the same channels' names.

For being able to scale a bit better maybe we should have the architectures as tabs in the future, but this is a good and quick improvement for now.

**Old:**
![Screenshot from 2020-03-03 18-18-42](https://user-images.githubusercontent.com/1029635/75801454-73992b80-5d7b-11ea-9722-17da2092ea02.png)

**New:**
![Screenshot from 2020-03-03 17-53-52](https://user-images.githubusercontent.com/1029635/75801221-0e453a80-5d7b-11ea-8460-2394266ca8dc.png)
