### PR TITLE
Fix reading NEBRASKA_GITHUB_OAUTH_CLIENT_ID env var.

### DIFF
--- a/cmd/nebraska/nebraska.go
+++ b/cmd/nebraska/nebraska.go
@@ -151,7 +151,7 @@ func obtainSessionCryptKey(potentialKey string) []byte {
 }
 
 func obtainOAuthClientID(potentialID string) (string, error) {
-	if id := getPotentialOrEnv(potentialID, ghClientIDEnvName); potentialID != "" {
+	if id := getPotentialOrEnv(potentialID, ghClientIDEnvName); id != "" {
 		return id, nil
 	}
 	return "", errors.New("no oauth client ID")


### PR DESCRIPTION
## Problem

You should be able to configure the Github client ID for Github authorization by setting the environment variable: `NEBRASKA_GITHUB_OAUTH_CLIENT_ID`. However, `nebraska` isn't picking up the value of this env var. Instead, when you set it, `nebraska` fails to start with this error message:

```
{"_t":"2020-03-03T06:47:12+0000", "_p":"1", "_l":"ERR", "_n":"nebraska", "_m":"no oauth client ID"}
```

## Solution 

The bug is in `func obtainOAuthClientID`. There's a check for empty string that is looking at the wrong variable. That's fixed in this PR.

(I glanced through the other `obtain*` functions to see if they had similar issues. They all look good. It's only `obtainOAuthClientID` that has this issue.)