### PR TITLE
frontend: remove obsolete CSS links from index.html

### DIFF
--- a/frontend/built/index.html
+++ b/frontend/built/index.html
@@ -5,8 +5,6 @@
     <title>Nebraska</title>
     <meta name="viewport" content="width=1170">
     <link rel="icon" href="favicon.png" type="image/png">
-    <link rel="stylesheet" href="css/font-awesome.css">
-    <link rel="stylesheet" href="css/loaders.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link href="https://fonts.googleapis.com/css?family=Overpass&display=swap" rel="stylesheet">


### PR DESCRIPTION
The CSS files were removed with acf65f9a5bd15bb1d9811fac9295eb0fac20b1b2
when switching to the new Material UI and are not needed & available
anymore.