### PR TITLE
Enable goproxy and run no linters inside container build

### DIFF
--- a/Dockerfile.nebraska
+++ b/Dockerfile.nebraska
@@ -10,7 +10,7 @@ COPY . /go/src/github.com/kinvolk/nebraska/
 
 RUN cd /go/src/github.com/kinvolk/nebraska && \
 	rm -rf frontend/node_modules tools/go-bindata tools/golangci-lint bin/nebraska && \
-	make frontend backend
+	make frontend backend-binary
 
 FROM alpine:3.10
 

--- a/Dockerfile.nebraska
+++ b/Dockerfile.nebraska
@@ -9,7 +9,7 @@ RUN apk update && \
 COPY . /go/src/github.com/kinvolk/nebraska/
 
 RUN cd /go/src/github.com/kinvolk/nebraska && \
-	rm -rf frontend/node_modules && \
+	rm -rf frontend/node_modules tools/go-bindata tools/golangci-lint bin/nebraska && \
 	make frontend backend
 
 FROM alpine:3.10

--- a/Dockerfile.nebraska
+++ b/Dockerfile.nebraska
@@ -1,6 +1,7 @@
 FROM alpine:3.10 as nebraska-build
 
-ENV GOPATH=/go
+ENV GOPATH=/go \
+    GOPROXY=https://proxy.golang.org
 
 RUN apk update && \
 	apk add git go nodejs npm ca-certificates make musl-dev bash

--- a/Makefile
+++ b/Makefile
@@ -72,14 +72,14 @@ test-clean-work-tree-backend:
 
 .PHONY: tools
 tools:
-	CGO_ENABLED=0 go build -o bin/initdb ./cmd/initdb
-	CGO_ENABLED=0 go build -o bin/userctl ./cmd/userctl
+	go build -o bin/initdb ./cmd/initdb
+	go build -o bin/userctl ./cmd/userctl
 
 tools/go-bindata: go.mod go.sum
-	CGO_ENABLED=0 go build -o tools/go-bindata github.com/kevinburke/go-bindata/go-bindata
+	go build -o tools/go-bindata github.com/kevinburke/go-bindata/go-bindata
 
 tools/golangci-lint: go.mod go.sum
-	CGO_ENABLED=0 go build -o ./tools/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
+	go build -o ./tools/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
 
 .PHONY: container-nebraska
 container-nebraska:

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ frontend-watch:
 .PHONY: backend
 backend: run-generators backend-code-checks build-backend-binary
 
+.PHONY: backend-binary
+backend-binary: run-generators build-backend-binary
+
 .PHONY: test-clean-work-tree-backend
 test-clean-work-tree-backend:
 	@if ! git diff --quiet -- go.mod go.sum pkg cmd updaters tools/tools.go; then \

--- a/Makefile
+++ b/Makefile
@@ -72,14 +72,14 @@ test-clean-work-tree-backend:
 
 .PHONY: tools
 tools:
-	go build -o bin/initdb ./cmd/initdb
-	go build -o bin/userctl ./cmd/userctl
+	CGO_ENABLED=0 go build -o bin/initdb ./cmd/initdb
+	CGO_ENABLED=0 go build -o bin/userctl ./cmd/userctl
 
 tools/go-bindata: go.mod go.sum
-	go build -o tools/go-bindata github.com/kevinburke/go-bindata/go-bindata
+	CGO_ENABLED=0 go build -o tools/go-bindata github.com/kevinburke/go-bindata/go-bindata
 
 tools/golangci-lint: go.mod go.sum
-	go build -o ./tools/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
+	CGO_ENABLED=0 go build -o ./tools/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
 
 .PHONY: container-nebraska
 container-nebraska:

--- a/Makefile
+++ b/Makefile
@@ -48,17 +48,7 @@ frontend-watch:
 	cd frontend && npx webpack --watch-poll 1000 --watch --config ./webpack.config.js --mode development
 
 .PHONY: backend
-backend: tools/go-bindata tools/golangci-lint
-	PATH="$(abspath tools):$${PATH}" go generate ./...
-	# this is to get nice error messages when something doesn't
-	# build (both the project and the tests), golangci-lint's
-	# output in this regard in unreadable.
-	go build ./...
-	./tools/check_pkg_test.sh
-	NEBRASKA_SKIP_TESTS=1 go test ./... >/dev/null
-	./tools/golangci-lint run --fix
-	go mod tidy
-	go build -o bin/nebraska ./cmd/nebraska
+backend: run-generators backend-code-checks build-backend-binary
 
 .PHONY: test-clean-work-tree-backend
 test-clean-work-tree-backend:
@@ -102,3 +92,22 @@ container: container-nebraska container-postgres
 
 .PHONY: backend-ci
 backend-ci: backend test-clean-work-tree-backend check-backend-with-container
+
+.PHONY: run-generators
+run-generators: tools/go-bindata
+	PATH="$(abspath tools):$${PATH}" go generate ./...
+
+.PHONY: build-backend-binary
+build-backend-binary:
+	go build -o bin/nebraska ./cmd/nebraska
+
+.PHONY: backend-code-checks
+backend-code-checks: tools/golangci-lint
+	# this is to get nice error messages when something doesn't
+	# build (both the project and the tests), golangci-lint's
+	# output in this regard in unreadable.
+	go build ./...
+	./tools/check_pkg_test.sh
+	NEBRASKA_SKIP_TESTS=1 go test ./... >/dev/null
+	./tools/golangci-lint run --fix
+	go mod tidy


### PR DESCRIPTION
Closes #129.

This PR follows up the #129 PR by making the changes as suggested there.

I had some more changes with regard to tools, but those I'll put in a separate PR when it's ready.