### PR TITLE
Added / to packages URL so the packages are downloaded properly when …

### DIFF
--- a/cmd/nebraska/controller.go
+++ b/cmd/nebraska/controller.go
@@ -59,7 +59,7 @@ func newController(conf *controllerConfig) (*controller, error) {
 			API:          conf.api,
 			HostPackages: conf.hostFlatcarPackages,
 			PackagesPath: conf.flatcarPackagesPath,
-			PackagesURL:  conf.nebraskaURL + "/flatcar",
+			PackagesURL:  conf.nebraskaURL + "/flatcar/",
 		}
 		syncer, err := syncer.New(syncerConf)
 		if err != nil {


### PR DESCRIPTION
…Nebraska is configured to host and sync packages

controller.go Syncer config is missing a slash at the end "/flatcar" of the packages URL creating the following URL when packages are loaded

https://nebraskaserver/flatcarflatcar-amd64-2345.3.0.gz

This results in the file not being found.

I0304 08:05:11.067962  3574 action_processor.cc:82] ActionProcessor::ActionComplete: finished OmahaRequestAction, starting DownloadAction
I0304 08:05:11.068303  3574 install_plan.cc:53] InstallPlan: , new_update, url: https://nebraska server/flatcarflatcar-amd64->
I0304 08:05:11.068821  3574 update_attempter.cc:408] Download status: active
I0304 08:05:11.069169  3574 multi_range_http_fetcher.cc:30] starting first transfer
I0304 08:05:11.069728  3574 multi_range_http_fetcher.cc:58] starting transfer of range 0+?
I0304 08:05:11.070104  3574 libcurl_http_fetcher.cc:48] Starting/Resuming transfer
I0304 08:05:11.070497  3574 libcurl_http_fetcher.cc:152] Setting up curl options for HTTP
I0304 08:05:11.070989  3574 libcurl_http_fetcher.cc:427] Setting up timeout source: 1 seconds.
E0304 08:05:12.006531  3574 libcurl_http_fetcher.cc:243] Unable to get http response code: Empty reply from server
I0304 08:05:12.007259  3574 libcurl_http_fetcher.cc:274] Transfer resulted in an error (0), 0 bytes downloaded
I0304 08:05:12.007503  3574 multi_range_http_fetcher.cc:151] Received transfer complete.
I0304 08:05:12.007741  3574 multi_range_http_fetcher.cc:108] TransferEnded w/ code 0
I0304 08:05:12.007957  3574 multi_range_http_fetcher.cc:142] Done w/ all transfers
I0304 08:05:12.013857  3574 update_attempter.cc:408] Download status: inactive

When the slash is added to the package URL via the frontend, the packages are downloaded by the system and the update. 
Added the slash at the the end "/flatcar" of the packages URL

https://nebraska server/flatcar/flatcar-amd64-2345.3.0.gz