### PR TITLE
Make queries slimmer

### DIFF
--- a/cmd/nebraska/controller.go
+++ b/cmd/nebraska/controller.go
@@ -405,6 +405,23 @@ func (ctl *controller) getGroupInstancesStats(c *gin.Context) {
 	}
 }
 
+func (ctl *controller) getGroupVersionBreakdown(c *gin.Context) {
+	groupID := c.Params.ByName("group_id")
+
+	versionBreakdown, err := ctl.api.GetGroupVersionBreakdown(groupID)
+	switch err {
+	case nil:
+		if err := json.NewEncoder(c.Writer).Encode(versionBreakdown); err != nil {
+			logger.Error("getVersionBreakdown - encoding group", "error", err.Error(), "version_breakdown", versionBreakdown)
+		}
+	case sql.ErrNoRows:
+		httpError(c, http.StatusNotFound)
+	default:
+		logger.Error("getVersionBreakdown - getting version breakdown", "error", err.Error(), "groupID", groupID)
+		httpError(c, http.StatusBadRequest)
+	}
+}
+
 // ----------------------------------------------------------------------------
 // API: channels CRUD
 //

--- a/cmd/nebraska/controller.go
+++ b/cmd/nebraska/controller.go
@@ -388,6 +388,23 @@ func (ctl *controller) getGroupStatusCountTimeline(c *gin.Context) {
 	}
 }
 
+func (ctl *controller) getGroupInstancesStats(c *gin.Context) {
+	groupID := c.Params.ByName("group_id")
+
+	instancesStats, err := ctl.api.GetGroupInstancesStats(groupID)
+	switch err {
+	case nil:
+		if err := json.NewEncoder(c.Writer).Encode(instancesStats); err != nil {
+			logger.Error("getGroupInstancesStats - encoding group", "error", err.Error(), "instancesStats", instancesStats)
+		}
+	case sql.ErrNoRows:
+		httpError(c, http.StatusNotFound)
+	default:
+		logger.Error("getGroupInstancesStats - getting instances stats", "error", err.Error(), "groupID", groupID)
+		httpError(c, http.StatusBadRequest)
+	}
+}
+
 // ----------------------------------------------------------------------------
 // API: channels CRUD
 //

--- a/cmd/nebraska/nebraska.go
+++ b/cmd/nebraska/nebraska.go
@@ -245,6 +245,7 @@ func setupRoutes(ctl *controller, httpLog bool) *gin.Engine {
 	apiRouter.GET("/apps/:app_id/groups", ctl.getGroups)
 	apiRouter.GET("/apps/:app_id/groups/:group_id/version_timeline", ctl.getGroupVersionCountTimeline)
 	apiRouter.GET("/apps/:app_id/groups/:group_id/status_timeline", ctl.getGroupStatusCountTimeline)
+	apiRouter.GET("/apps/:app_id/groups/:group_id/instances_stats", ctl.getGroupInstancesStats)
 
 	// Channels
 	apiRouter.POST("/apps/:app_id/channels", ctl.addChannel)

--- a/cmd/nebraska/nebraska.go
+++ b/cmd/nebraska/nebraska.go
@@ -246,6 +246,7 @@ func setupRoutes(ctl *controller, httpLog bool) *gin.Engine {
 	apiRouter.GET("/apps/:app_id/groups/:group_id/version_timeline", ctl.getGroupVersionCountTimeline)
 	apiRouter.GET("/apps/:app_id/groups/:group_id/status_timeline", ctl.getGroupStatusCountTimeline)
 	apiRouter.GET("/apps/:app_id/groups/:group_id/instances_stats", ctl.getGroupInstancesStats)
+	apiRouter.GET("/apps/:app_id/groups/:group_id/version_breakdown", ctl.getGroupVersionBreakdown)
 
 	// Channels
 	apiRouter.POST("/apps/:app_id/channels", ctl.addChannel)

--- a/frontend/src/js/api/API.js
+++ b/frontend/src/js/api/API.js
@@ -70,6 +70,10 @@ class API {
     return API.getJSON(BASE_URL + '/apps/' + applicationID + '/groups/' + groupID + '/status_timeline');
   }
 
+  static getGroupInstancesStats(applicationID, groupID) {
+    return API.getJSON(BASE_URL + '/apps/' + applicationID + '/groups/' + groupID + '/instances_stats');
+  }
+
   // Channels
 
   static deleteChannel(applicationID, channelID) {

--- a/frontend/src/js/api/API.js
+++ b/frontend/src/js/api/API.js
@@ -74,6 +74,10 @@ class API {
     return API.getJSON(BASE_URL + '/apps/' + applicationID + '/groups/' + groupID + '/instances_stats');
   }
 
+  static getGroupVersionBreakdown(applicationID, groupID) {
+    return API.getJSON(BASE_URL + '/apps/' + applicationID + '/groups/' + groupID + '/version_breakdown');
+  }
+
   // Channels
 
   static deleteChannel(applicationID, channelID) {

--- a/frontend/src/js/components/Applications/ApplicationItemGroupItem.react.js
+++ b/frontend/src/js/components/Applications/ApplicationItemGroupItem.react.js
@@ -3,6 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
+import API from '../../api/API';
 
 const useStyles = makeStyles(theme => ({
   groupLink: {
@@ -12,7 +13,19 @@ const useStyles = makeStyles(theme => ({
 
 function ApplicationItemGroupItem(props) {
   const classes = useStyles();
-  const instances_total = props.group.instances_stats.total ? '(' + props.group.instances_stats.total + ')' : '';
+  const {group} = props;
+  const [totalInstances, setTotalInstances] = React.useState(-1);
+
+  React.useEffect(() => {
+    // We use this function without any filter to get the total number of instances
+    // in the group.
+    API.getInstances(group.application_id, group.id)
+      .then(result => {
+        setTotalInstances(result.total);
+      })
+      .catch(err => console.error('Error loading total instances in Instances/List', err));
+  },
+  [group]);
 
   return (
     <Link
@@ -20,7 +33,7 @@ function ApplicationItemGroupItem(props) {
       to={{pathname: `/apps/${props.group.application_id}/groups/${props.group.id}`}}
       component={RouterLink}
     >
-      {props.group.name} {instances_total}
+      {props.group.name} {(totalInstances > 0) && `(${totalInstances})`}
     </Link>
   );
 }

--- a/frontend/src/js/components/Groups/Charts.js
+++ b/frontend/src/js/components/Groups/Charts.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { Area, AreaChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
 import semver from 'semver';
 import _ from 'underscore';
-import { cleanSemverVersion, getInstanceStatus, getMinuteDifference, makeColorsForVersions, makeLocaleTime } from '../../constants/helpers';
+import { cleanSemverVersion, getInstanceStatus, getMinuteDifference, makeColorsForVersions, makeLocaleTime, useGroupVersionBreakdown } from '../../constants/helpers';
 import { applicationsStore } from '../../stores/Stores';
 import Loader from '../Common/Loader';
 import SimpleTable from '../Common/SimpleTable';
@@ -126,6 +126,7 @@ function TimelineChart(props) {
 }
 
 export function VersionCountTimeline(props) {
+  const groupVersionBreakdown = useGroupVersionBreakdown(props.group);
   const [selectedEntry, setSelectedEntry] = React.useState(-1);
   const [timelineChartData, setTimelineChartData] = React.useState({
     data: [],
@@ -189,7 +190,7 @@ export function VersionCountTimeline(props) {
     // If there is no timeline or no specific time is selected,
     // use the version breakdown (the whole period breakdown).
     if (timelineChartData.data.length === 0 || selectedEntry === -1) {
-      version_breakdown = [...props.group.version_breakdown];
+      version_breakdown = [...groupVersionBreakdown];
     }
 
     let total = 0;

--- a/frontend/src/js/components/Groups/Item.react.js
+++ b/frontend/src/js/components/Groups/Item.react.js
@@ -6,6 +6,7 @@ import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import _ from 'underscore';
 import API from '../../api/API';
+import { useGroupVersionBreakdown } from '../../constants/helpers';
 import { applicationsStore } from '../../stores/Stores';
 import ChannelItem from '../Channels/Item.react';
 import { CardFeatureLabel, CardHeader, CardLabel } from '../Common/Card';
@@ -24,8 +25,7 @@ function Item(props) {
   const classes = useStyles();
   const [totalInstances, setTotalInstances] = React.useState(-1);
 
-  const version_breakdown = (props.group &&
-    props.group.version_breakdown) ? props.group.version_breakdown : [];
+  const version_breakdown = useGroupVersionBreakdown(props.group);
   const description = props.group.description || 'No description provided';
   const channel = props.group.channel || {};
 

--- a/frontend/src/js/components/Groups/Item.react.js
+++ b/frontend/src/js/components/Groups/Item.react.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import _ from 'underscore';
+import API from '../../api/API';
 import { applicationsStore } from '../../stores/Stores';
 import ChannelItem from '../Channels/Item.react';
 import { CardFeatureLabel, CardHeader, CardLabel } from '../Common/Card';
@@ -21,13 +22,10 @@ const useStyles = makeStyles(theme => ({
 
 function Item(props) {
   const classes = useStyles();
+  const [totalInstances, setTotalInstances] = React.useState(-1);
 
   const version_breakdown = (props.group &&
     props.group.version_breakdown) ? props.group.version_breakdown : [];
-  const noInstancesLabel = 'None';
-  const instances_total = props.group.instances_stats ?
-    (props.group.instances_stats.total || noInstancesLabel)
-    : noInstancesLabel;
   const description = props.group.description || 'No description provided';
   const channel = props.group.channel || {};
 
@@ -46,6 +44,15 @@ function Item(props) {
   function updateGroup() {
     props.handleUpdateGroup(props.group.application_id, props.group.id);
   }
+
+  React.useEffect(() => {
+    API.getInstances(props.group.application_id, props.group.id)
+      .then(result => {
+        setTotalInstances(result.total);
+      })
+      .catch(err => console.error('Error getting total instances in Group/Item', err));
+  },
+  []);
 
   return (
     <ListItem disableGutters>
@@ -87,7 +94,10 @@ function Item(props) {
                   to={groupPath}
                   component={RouterLink}
                 >
-                  {instances_total}
+                  {totalInstances === -1 ? '…'
+                    :
+                    totalInstances > 0 ? totalInstances : 'None'
+                  }
                 </Link>
               </CardLabel>
             </Grid>

--- a/frontend/src/js/components/Groups/ItemExtended.react.js
+++ b/frontend/src/js/components/Groups/ItemExtended.react.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import _ from 'underscore';
+import API from '../../api/API';
 import { applicationsStore } from '../../stores/Stores';
 import ChannelItem from '../Channels/Item.react';
 import { CardFeatureLabel, CardHeader, CardLabel } from '../Common/Card';
@@ -27,6 +28,7 @@ const useStyles = makeStyles({
 function ItemExtended(props) {
   const [application, setApplication] = React.useState(null);
   const [group, setGroup] = React.useState(null);
+  const [instancesStats, setInstancesStats] = React.useState({});
   const classes = useStyles();
   function onChange() {
     const app = applicationsStore.getCachedApplication(props.appID);
@@ -59,6 +61,20 @@ function ItemExtended(props) {
     };
   },
   [application, group]);
+
+  React.useEffect(() => {
+    if (group) {
+      API.getGroupInstancesStats(group.application_id, group.id)
+        .then(stats => {
+          setInstancesStats(stats);
+        })
+        .catch(err => {
+          console.error('Error getting instances stats in Groups/ItemExtended', err);
+          setInstancesStats({});
+        });
+    }
+  },
+  [group]);
 
   return (
     <Grid
@@ -138,7 +154,7 @@ function ItemExtended(props) {
           <Paper className={classes.instancesChartPaper}>
             <ListHeader
               title="Update Progress"
-              actions={group.instances_stats.total > 0 ? [
+              actions={instancesStats.total > 0 ? [
                 <Link
                   className={classes.link}
                   to={{pathname: `/apps/${props.appID}/groups/${props.groupID}/instances`}}
@@ -152,12 +168,12 @@ function ItemExtended(props) {
               }
             />
             <Box padding="1em">
-              <InstanceStatusArea instanceStats={group.instances_stats} />
+              <InstanceStatusArea instanceStats={instancesStats} />
             </Box>
           </Paper>
         }
       </Grid>
-      { (group && group.instances_stats.total > 0) &&
+      { instancesStats.total > 0 &&
         <Grid item xs={12}>
           <Paper>
             <Grid

--- a/frontend/src/js/components/Groups/ItemExtended.react.js
+++ b/frontend/src/js/components/Groups/ItemExtended.react.js
@@ -69,7 +69,7 @@ function ItemExtended(props) {
           setInstancesStats(stats);
         })
         .catch(err => {
-          console.error('Error getting instances stats in Groups/ItemExtended', err);
+          console.error('Error getting instances stats in Groups/ItemExtended. Group:', group, '\nError:', err);
           setInstancesStats({});
         });
     }

--- a/frontend/src/js/constants/helpers.js
+++ b/frontend/src/js/constants/helpers.js
@@ -3,6 +3,8 @@ import deepOrange from '@material-ui/core/colors/deepOrange';
 import lime from '@material-ui/core/colors/lime';
 import orange from '@material-ui/core/colors/orange';
 import red from '@material-ui/core/colors/red';
+import React from 'react';
+import API from '../api/API';
 
 // Indexes/keys for the architectures need to match the ones in
 // pkg/api/arches.go.
@@ -161,4 +163,25 @@ export function getInstanceStatus(statusID, version) {
   const statusDetails = statusID ? status[statusID] : status[1];
 
   return statusDetails;
+}
+
+export function useGroupVersionBreakdown(group) {
+  const [versionBreakdown, setVersionBreakdown] = React.useState([]);
+
+  React.useEffect(() => {
+    if (!group) {
+      return;
+    }
+
+    const version_breakdown = API.getGroupVersionBreakdown(group.application_id, group.id)
+      .then(version_breakdown => {
+        setVersionBreakdown(version_breakdown || []);
+      })
+      .catch(err => {
+        console.error('Error getting version breakdown for group', group.id, '\nError:', err);
+      });
+  },
+  [group]);
+
+  return versionBreakdown;
 }

--- a/pkg/api/groups_test.go
+++ b/pkg/api/groups_test.go
@@ -172,8 +172,10 @@ func TestGetGroupsFiltered(t *testing.T) {
 		stats, err := a.GetGroupInstancesStats(g.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, stats.Total)
-		if assert.Len(t, g.VersionBreakdown, 1) {
-			vb := g.VersionBreakdown[0]
+		versionBreakdown, vbErr := a.GetGroupVersionBreakdown(g.ID)
+		assert.NoError(t, vbErr)
+		if assert.Len(t, versionBreakdown, 1) {
+			vb := versionBreakdown[0]
 			assert.Equal(t, "1.0.0", vb.Version)
 			assert.Equal(t, 1, vb.Instances)
 		}

--- a/pkg/api/groups_test.go
+++ b/pkg/api/groups_test.go
@@ -169,7 +169,9 @@ func TestGetGroupsFiltered(t *testing.T) {
 	assert.NoError(t, err)
 	if assert.Len(t, groups, 1) {
 		g := groups[0]
-		assert.Equal(t, 1, g.InstancesStats.Total)
+		stats, err := a.GetGroupInstancesStats(g.ID)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, stats.Total)
 		if assert.Len(t, g.VersionBreakdown, 1) {
 			vb := g.VersionBreakdown[0]
 			assert.Equal(t, "1.0.0", vb.Version)

--- a/pkg/api/updates_test.go
+++ b/pkg/api/updates_test.go
@@ -202,16 +202,18 @@ func TestGetUpdatePackage_RolloutStats(t *testing.T) {
 
 	group, _ := a.GetGroup(tGroup.ID)
 	assert.True(t, group.RolloutInProgress)
-	assert.Equal(t, 3, group.InstancesStats.Total)
-	assert.Equal(t, 1, group.InstancesStats.UpdateGranted)
-	assert.Equal(t, 2, group.InstancesStats.OnHold)
+	stats, _ := a.GetGroupInstancesStats(group.ID)
+	assert.Equal(t, 3, stats.Total)
+	assert.Equal(t, 1, stats.UpdateGranted)
+	assert.Equal(t, 2, stats.OnHold)
 
 	_ = a.RegisterEvent(instance1.ID, tApp.ID, tGroup.ID, EventUpdateDownloadStarted, ResultSuccess, "", "")
 
 	group, _ = a.GetGroup(tGroup.ID)
 	assert.True(t, group.RolloutInProgress)
-	assert.Equal(t, 1, group.InstancesStats.Downloading)
-	assert.Equal(t, 2, group.InstancesStats.OnHold)
+	stats, _ = a.GetGroupInstancesStats(group.ID)
+	assert.Equal(t, 1, stats.Downloading)
+	assert.Equal(t, 2, stats.OnHold)
 
 	_ = a.RegisterEvent(instance1.ID, tApp.ID, tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
 	_, _ = a.GetUpdatePackage(instance2.ID, "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
@@ -219,23 +221,26 @@ func TestGetUpdatePackage_RolloutStats(t *testing.T) {
 
 	group, _ = a.GetGroup(tGroup.ID)
 	assert.True(t, group.RolloutInProgress)
-	assert.Equal(t, 1, group.InstancesStats.Complete)
-	assert.Equal(t, 2, group.InstancesStats.UpdateGranted)
+	stats, _ = a.GetGroupInstancesStats(group.ID)
+	assert.Equal(t, 1, stats.Complete)
+	assert.Equal(t, 2, stats.UpdateGranted)
 
 	_ = a.RegisterEvent(instance2.ID, tApp.ID, tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
 	_ = a.RegisterEvent(instance3.ID, tApp.ID, tGroup.ID, EventUpdateComplete, ResultFailed, "", "")
 
 	group, _ = a.GetGroup(tGroup.ID)
 	assert.True(t, group.RolloutInProgress)
-	assert.Equal(t, 2, group.InstancesStats.Complete)
-	assert.Equal(t, 1, group.InstancesStats.Error)
+	stats, _ = a.GetGroupInstancesStats(group.ID)
+	assert.Equal(t, 2, stats.Complete)
+	assert.Equal(t, 1, stats.Error)
 
 	_, _ = a.GetUpdatePackage(instance3.ID, "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	_ = a.RegisterEvent(instance3.ID, tApp.ID, tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
 
 	group, _ = a.GetGroup(tGroup.ID)
 	assert.False(t, group.RolloutInProgress)
-	assert.Equal(t, 3, group.InstancesStats.Complete)
+	stats, _ = a.GetGroupInstancesStats(group.ID)
+	assert.Equal(t, 3, stats.Complete)
 }
 
 func TestGetUpdatePackage_UpdateInProgressOnInstance(t *testing.T) {


### PR DESCRIPTION
This PR decouples fetching the version breakdown + the instances stats from when getting a group's information.
Those queries were done in order to make it simpler for the UI to show the info, but they're a bit heavy so we should avoid them when they're not needed.

The PR also adds connections limits to the DB (overridable by the use of env vars).