### PR TITLE
frontend: Simplify EmptyContent

### DIFF
--- a/frontend/src/js/__tests__/Common/EmptyContent.spec.js
+++ b/frontend/src/js/__tests__/Common/EmptyContent.spec.js
@@ -3,15 +3,8 @@ import React from 'react';
 import Empty from '../../components/Common/EmptyContent';
 
 describe('Empty', () => {
-  const minProps = {
-    children: [
-      'abc',
-      'def'
-    ]
-  };
   it('renders correct content', () => {
-    const {asFragment, getAllByTestId} = render(<Empty children={minProps.children}/>);
-    expect(getAllByTestId('empty')).toHaveLength(2);
+    const {asFragment} = render(<Empty>Some Dummy Content</Empty>);
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/frontend/src/js/__tests__/Common/__snapshots__/EmptyContent.spec.js.snap
+++ b/frontend/src/js/__tests__/Common/__snapshots__/EmptyContent.spec.js.snap
@@ -9,13 +9,7 @@ exports[`Empty renders correct content 1`] = `
       class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-alignCenter"
       data-testid="empty"
     >
-      abc
-    </p>
-    <p
-      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-alignCenter"
-      data-testid="empty"
-    >
-      def
+      Some Dummy Content
     </p>
   </div>
 </DocumentFragment>

--- a/frontend/src/js/components/Common/EmptyContent.js
+++ b/frontend/src/js/components/Common/EmptyContent.js
@@ -5,13 +5,7 @@ import React from 'react';
 export default function Empty(props) {
   return (
     <Box padding={2}>
-      {React.Children.map(props.children, child => {
-        if (typeof child === 'string') {
-          return <Typography color="textSecondary" align="center" data-testid="empty">{child}</Typography>;
-        }
-        return child;
-      })
-      }
+      <Typography color="textSecondary" align="center" data-testid="empty">{props.children}</Typography>
     </Box>
   );
 }


### PR DESCRIPTION
Instead of checking the EmptyContent's children types and wrap them in
a Typography element or add them directly, we should just wrap all the
children in a Typography element, since the contents of EmptyContent
are supposed to be textual anyway.