### PR TITLE
backend: Disable/disallow updates after timeout only in Safe Mode

### DIFF
--- a/pkg/api/updates.go
+++ b/pkg/api/updates.go
@@ -159,7 +159,7 @@ func (api *API) enforceRolloutPolicy(instance *Instance, group *Group, updatesSt
 		return ErrMaxConcurrentUpdatesLimitReached
 	}
 
-	if updatesStats.UpdatesTimedOut >= effectiveMaxUpdates {
+	if group.PolicySafeMode && updatesStats.UpdatesTimedOut >= effectiveMaxUpdates {
 		if group.PolicyUpdatesEnabled {
 			_ = api.disableUpdates(group.ID)
 		}


### PR DESCRIPTION
When there are timed-out instances which didn't complete their update
and their number reaches the number of maximal allowed updating
instances, updates will be disabled in Safe Mode. However, this was
also the case when Safe Mode is not used, causing updates to be
disabled permanently when enough clients don't ping back due to
failures or when malicious clients are making many requests exceeding
the number of maximal allowed updating instances (Such a DoS is
unfortunate and we can't do something about it but it shouldn't result
in updates being disabled permanently).
Just limiting the disabling of updates to the Safe Mode is not enough
because ErrMaxTimedOutUpdatesLimitReached would still be reached for
all future update requests. Therefore, disabling updates and returning
ErrMaxTimedOutUpdatesLimitReached need to be both guarded by the Safe
Mode (until we would define a second interval which is used to ignore
timed-out instances but I see no benefit in doing so).