### PR TITLE
backend: Add error logging for API package

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -7,6 +7,7 @@ import (
 	//register "pgx" sql driver
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/jmoiron/sqlx"
+	log "github.com/mgutz/logxi/v1"
 	migrate "github.com/rubenv/sql-migrate"
 
 	// Postgresql driver
@@ -36,6 +37,8 @@ func nowUTC() time.Time {
 }
 
 var (
+	logger = log.New("api")
+
 	// ErrNoRowsAffected indicates that no rows were affected in an update or
 	// delete database operation.
 	ErrNoRowsAffected = errors.New("nebraska: no rows affected")

--- a/pkg/api/applications.go
+++ b/pkg/api/applications.go
@@ -60,6 +60,7 @@ func (api *API) AddAppCloning(app *Application, sourceAppID string) (*Applicatio
 	if sourceAppID != "" {
 		sourceApp, err := api.GetApp(sourceAppID)
 		if err != nil {
+			logger.Error("AddAppCloning - could not get source app", err)
 			return app, nil
 		}
 
@@ -71,6 +72,7 @@ func (api *API) AddAppCloning(app *Application, sourceAppID string) (*Applicatio
 			channel.PackageID = null.String{}
 			channelCopy, err := api.AddChannel(channel)
 			if err != nil {
+				logger.Error("AddAppCloning - could not add channel", err)
 				return app, nil // FIXME - think about what we should return to the caller
 			}
 			channelsIDsMappings[originalChannelID] = null.StringFrom(channelCopy.ID)
@@ -83,6 +85,7 @@ func (api *API) AddAppCloning(app *Application, sourceAppID string) (*Applicatio
 			}
 			group.PolicyUpdatesEnabled = true
 			if _, err := api.AddGroup(group); err != nil {
+				logger.Error("AddAppCloning - could not add group", err)
 				return app, nil // FIXME - think about what we should return to the caller
 			}
 		}

--- a/pkg/api/channels.go
+++ b/pkg/api/channels.go
@@ -99,7 +99,9 @@ func (api *API) UpdateChannel(channel *Channel) error {
 	}
 
 	if channelBeforeUpdate.PackageID.String != channel.PackageID.String && pkg != nil {
-		_ = api.newChannelActivityEntry(activityChannelPackageUpdated, activityInfo, pkg.Version, pkg.ApplicationID, channel.ID)
+		if err := api.newChannelActivityEntry(activityChannelPackageUpdated, activityInfo, pkg.Version, pkg.ApplicationID, channel.ID); err != nil {
+			logger.Error("UpdateChannel - could not add channel activity", err)
+		}
 	}
 
 	return nil

--- a/pkg/api/instances.go
+++ b/pkg/api/instances.go
@@ -115,8 +115,9 @@ func (api *API) RegisterInstance(instanceID, instanceIP, instanceVersion, appID,
 		return nil, err
 	}
 	defer func() {
-		//TODO log the failed rollback if err != sql.ErrTxDone
-		_ = tx.Rollback()
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			logger.Error("RegisterInstance - could not roll back", err)
+		}
 	}()
 	query, _, err := goqu.Insert("instance").
 		Cols("id", "ip").

--- a/pkg/api/packages.go
+++ b/pkg/api/packages.go
@@ -73,8 +73,9 @@ func (api *API) AddPackage(pkg *Package) (*Package, error) {
 		return nil, err
 	}
 	defer func() {
-		//TODO log a failed rollback if err != ErrTxDone
-		_ = tx.Rollback()
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			logger.Error("AddPackage - could not roll back", err)
+		}
 	}()
 
 	query, _, err := goqu.Insert("package").
@@ -154,8 +155,9 @@ func (api *API) UpdatePackage(pkg *Package) error {
 		return err
 	}
 	defer func() {
-		//TODO log a failed rollback if err != ErrTxDone
-		_ = tx.Rollback()
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			logger.Error("UpdatePackage - could not roll back", err)
+		}
 	}()
 	query, _, err := goqu.Update("package").
 		Set(goqu.Record{


### PR DESCRIPTION
Errors like those reported from the database library went unnoticed
    because there was no error logging in the API package.
    Log all errors with enough context to relate them to request errors
    when the original errors are turned into other errors for the client.