### PR TITLE
backend: Fix type for UpdatesStats

### DIFF
--- a/pkg/api/groups.go
+++ b/pkg/api/groups.go
@@ -324,7 +324,7 @@ func (api *API) getGroupUpdatesStats(group *Group) (*UpdatesStats, error) {
 	var updatesStats UpdatesStats
 
 	packageVersion := ""
-	if group.Channel.Package != nil {
+	if group.Channel != nil && group.Channel.Package != nil {
 		packageVersion = group.Channel.Package.Version
 	}
 	query, _, err := goqu.From("instance_application").Select(

--- a/pkg/api/groups_test.go
+++ b/pkg/api/groups_test.go
@@ -35,6 +35,9 @@ func TestAddGroup(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, true, group.PolicyUpdatesEnabled)
 
+	_, err = a.getGroupUpdatesStats(group)
+	assert.NoError(t, err)
+
 	groupX, err := a.GetGroup(group.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, group.Name, groupX.Name)
@@ -70,6 +73,9 @@ func TestUpdateGroup(t *testing.T) {
 	group.PolicyUpdatesEnabled = true
 	group.ChannelID = null.StringFrom(tChannel2.ID)
 	err := a.UpdateGroup(group)
+	assert.NoError(t, err)
+
+	_, err = a.getGroupUpdatesStats(group)
 	assert.NoError(t, err)
 
 	groupX, _ := a.GetGroup(group.ID)


### PR DESCRIPTION
SQL errors like the following led to no updates being served at least a
couple of times when I tested it:
  GetUpdatePackage - getGroupUpdatesStats error (propagates as
  ErrGetUpdatesStatsFailed): sql: Scan error on column index 1, name
  "updates_to_current_version_granted": converting NULL to int is
  unsupported
Covers the case when no row exists by defaulting to 0 as value.