### PR TITLE
frontend: Don't pass the cacheConfig to the Appbar's useStyles function

### DIFF
--- a/frontend/src/js/components/Header.react.js
+++ b/frontend/src/js/components/Header.react.js
@@ -54,7 +54,7 @@ function prepareDarkTheme(theme){
 
 function Appbar(props) {
   const {cachedConfig, menuAnchorEl, projectLogo, config, handleClose, handleMenu} = props;
-  const classes = useStyles(cachedConfig);
+  const classes = useStyles();
 
   return (
     <AppBar position='static' className={classes.header}>


### PR DESCRIPTION
We were passing the mentioned config to the useStyles function of the
Appbar component and this was causing an issue when the config was null.
Passing the config was left over as a mistake, so this patch simply
removes it.