### PR TITLE
Add scripts for easy running of local instances of the database and nebraska

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ container_id:
 .PHONY: check-backend-with-container
 check-backend-with-container: container_id
 	set -e; \
-	trap "docker kill $$(cat container_id); docker rm $$(cat container_id); rm -f container_id" EXIT; \
+	trap "$(DOCKER_CMD) kill $$(cat container_id); $(DOCKER_CMD) rm $$(cat container_id); rm -f container_id" EXIT; \
 	go test -p 1 ./...
 
 .PHONY: frontend

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check:
 	go test -p 1 ./...
 check-code-coverage:
 	go test -p 1 -coverprofile=coverage.out ./...
-print-code-coverage: 
+print-code-coverage:
 	go tool cover -html=coverage.out
 container_id:
 	set -e; \
@@ -38,13 +38,13 @@ container_id:
 		>container_id.tmp; \
 	until docker exec \
 		$$(cat container_id.tmp) \
-		pg_isready -h localhost; do sleep 3; done
+		pg_isready -h localhost; do sleep 3; done; \
 	docker exec \
 		$$(cat container_id.tmp) \
-		psql -h localhost -U postgres -c 'create database nebraska_tests;'
+		psql -h localhost -U postgres -c 'create database nebraska_tests;'; \
 	docker exec \
 		$$(cat container_id.tmp) \
-		psql -h localhost -U postgres -d nebraska_tests -c 'set timezone = "utc";'
+		psql -h localhost -U postgres -d nebraska_tests -c 'set timezone = "utc";'; \
 	mv container_id.tmp container_id
 
 .PHONY: check-backend-with-container

--- a/Makefile
+++ b/Makefile
@@ -28,23 +28,10 @@ check-code-coverage:
 print-code-coverage:
 	go tool cover -html=coverage.out
 container_id:
-	set -e; \
-	trap "rm -f container_id.tmp container_id" ERR; \
-	docker run \
-		--detach \
-		--publish 127.0.0.1:5432:5432 \
-		-e POSTGRES_PASSWORD=nebraska \
-		postgres \
-		>container_id.tmp; \
-	until docker exec \
-		$$(cat container_id.tmp) \
-		pg_isready -h localhost; do sleep 3; done; \
-	docker exec \
-		$$(cat container_id.tmp) \
-		psql -h localhost -U postgres -c 'create database nebraska_tests;'; \
-	docker exec \
-		$$(cat container_id.tmp) \
-		psql -h localhost -U postgres -d nebraska_tests -c 'set timezone = "utc";'; \
+	./tools/setup_local_db.sh \
+		--id-file container_id.tmp \
+		--db-name nebraska_tests \
+		--password nebraska
 	mv container_id.tmp container_id
 
 .PHONY: check-backend-with-container

--- a/tools/run-all.sh
+++ b/tools/run-all.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# This script sets up a database and runs the local nebraska
+# instance. The database is torn down after nebraska quits.
+#
+# To use a different port for the database (7890 in the example):
+#
+# ./run-all.sh -P 7890
+#
+#
+# Long names of the parameters are available too:
+#
+# -P is --port
+
+set -euo pipefail
+
+function fail() {
+    echo "${@}" >&2
+    exit 1
+}
+
+opts=$(getopt \
+           --name "$(basename "${0}")" \
+           --options 'P:' \
+           --longoptions 'port:' \
+           -- "${@}"
+    )
+
+eval set -- "${opts}"
+
+port=''
+
+while true; do
+    case "${1}" in
+        '-P'|'--port')
+            port="${2}"
+            shift 2
+            ;;
+        '--')
+            shift
+            break
+            ;;
+        *)
+            fail 'Internal error!'
+            ;;
+    esac
+done
+
+tools_dir="$(dirname "${0}")"
+cid_file=$(mktemp)
+
+# This is used as a bare variable (without putting into double quotes)
+# to enable the use of DOCKER_CMD="sudo docker".
+DOCKER_CMD="${DOCKER_CMD:-docker}"
+
+cleanup_stage=0
+function cleanup() {
+    if [[ ${cleanup_stage} -ge 1 ]]; then
+        ${DOCKER_CMD} kill "$(cat "${cid_file}")"
+        ${DOCKER_CMD} rm "$(cat "${cid_file}")"
+    fi
+    rm -f "${cid_file}"
+}
+trap cleanup EXIT
+
+sld_opts=(
+    --id-file="${cid_file}"
+    --db-name=nebraska
+)
+
+if [[ -n "${port}" ]]; then
+    sld_opts+=(
+        --port="${port}"
+    )
+fi
+
+"${tools_dir}/setup_local_db.sh" "${sld_opts[@]}"
+
+cleanup_stage=1
+
+if [[ -n "${port}" ]]; then
+    export NEBRASKA_DB_URL="postgres://postgres@127.0.0.1:${port}/nebraska?sslmode=disable&connect_timeout=10"
+fi
+
+"${tools_dir}/run-local-nebraska.sh"

--- a/tools/run-local-nebraska.sh
+++ b/tools/run-local-nebraska.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script runs a local instance of nebraska. It expects that both
+# frontend and backend are already built, and the database in expected
+# is already running. To override the database location nebraska is
+# using, specify the NEBRASKA_DB_URL environment variable.
+#
+# Whatever parameters passed to the script are forwarded to nebraska.
+
+set -euo pipefail
+
+tools_dir="$(dirname "${0}")"
+binary="${tools_dir}/../bin/nebraska"
+static_dir="${tools_dir}/../frontend/build"
+
+LOGXI=* \
+"${binary}" \
+    -auth-mode noop \
+    -http-log \
+    -http-static-dir "${static_dir}" \
+    "${@}"

--- a/tools/setup_local_db.sh
+++ b/tools/setup_local_db.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# This script sets a up local postgres docker container with a
+# database. The first parameter to the script should be a file name
+# where an ID of the postgres docker container will be saved. The
+# second parameter should be a name of the database in the container.
+#
+#
+# To run a local db for checking the frontend, run:
+#
+# ./tools/setup_local_db.sh -f cid -n nebraska
+#
+#
+# To run a local db for API tests, run:
+#
+# ./tools/setup_local_db.sh -f cid -n nebraska_tests -p nebraska
+#
+#
+# It's possible to specify a port under which the database is
+# available (7890 in the example):
+#
+# ./tools/setup_local_db.sh -f cid -n nebraska_tests -p nebraska -P 7890
+#
+#
+# Long names of the parameters are available too:
+#
+# -p is --password
+# -f is --id-file
+# -n is --db-name
+# -P is --port
+#
+# After being finished with the database, do:
+#
+# docker kill "$(cat cid)"
+# docker rm "$(cat cid)"
+# rm -f cid
+
+
+set -euo pipefail
+
+function fail() {
+    echo "${@}" >&2
+    exit 1
+}
+
+opts=$(getopt \
+           --name "$(basename "${0}")" \
+           --options 'f:n:p:P:' \
+           --longoptions 'id-file:,db-name:,password:,port:' \
+           -- "${@}"
+    )
+
+eval set -- "${opts}"
+
+id_file=''
+db_name=''
+password=''
+port=''
+
+# This is used as a bare variable (without putting into double quotes)
+# to enable the use of DOCKER_CMD="sudo docker".
+DOCKER_CMD="${DOCKER_CMD:-docker}"
+
+while true; do
+    case "${1}" in
+        '-f'|'--id-file')
+            id_file="${2}"
+            shift 2
+            ;;
+        '-n'|'--db-name')
+            db_name="${2}"
+            shift 2
+            ;;
+        '-p'|'--password')
+            password="${2}"
+            shift 2
+            ;;
+        '-P'|'--port')
+            port="${2}"
+            shift 2
+            ;;
+        '--')
+            shift
+            break
+            ;;
+        *)
+            fail 'Internal error!'
+            ;;
+    esac
+done
+
+if [[ "${#}" -ne 0 ]]; then
+    fail "Leftover unrecognized arguments: ${@}"
+fi
+
+if [[ -z "${id_file}" ]]; then
+    fail 'No container ID file name passed, use -f or --id-file'
+fi
+if [[ -z "${db_name}" ]]; then
+    fail 'No database name passed, use -n or --db-name'
+fi
+if [[ -z "${port}" ]]; then
+    port=5432
+fi
+
+cleanup_stage=0
+function cleanup() {
+    if [[ ${cleanup_stage} -ge 2 ]]; then
+        ${DOCKER_CMD} kill "$(cat "${id_file}")"
+        ${DOCKER_CMD} rm "$(cat "${id_file}")"
+    fi
+    if [[ ${cleanup_stage} -ge 1 ]]; then
+        rm -f "${id_file}"
+    fi
+}
+trap cleanup ERR
+
+run_opts=(
+    --detach
+    --publish "127.0.0.1:${port}:5432"
+)
+
+if [[ -n "${password}" ]]; then
+    run_opts+=(
+        -e POSTGRES_PASSWORD="${password}"
+    )
+else
+    run_opts+=(
+        -e POSTGRES_HOST_AUTH_METHOD=trust
+    )
+fi
+
+run_opts+=(
+    postgres
+)
+
+cleanup_stage=1
+${DOCKER_CMD} run "${run_opts[@]}" >"${id_file}"
+
+cleanup_stage=2
+cid="$(cat "${id_file}")"
+until ${DOCKER_CMD} exec "${cid}" pg_isready -h localhost
+do
+    sleep 3
+done
+${DOCKER_CMD} exec "${cid}" \
+       psql -h localhost -U postgres -c "create database ${db_name};"
+${DOCKER_CMD} exec "${cid}" \
+       psql -h localhost -U postgres -d "${db_name}" -c 'set timezone = "utc";'


### PR DESCRIPTION
There was no straightforward way of running the local database and nebraska since dockerfile.postgres was removed. So I've added 3 scripts - one for setting up the database (which the build system is now using), one for running a local no-auth nebraska instance, and one that does both of the above and a proper cleanup. Now checking if some thing works (during a PR review, for example) should basically be `git checkout …; make; ./tools/run-all.sh` and going to `localhost:8000` in a browser.

I used that to review #250.