### PR TITLE
backend: Make track name to group mapping dynamic

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -126,6 +126,7 @@ func New(options ...func(*API) error) (*API, error) {
 	if _, err := migrate.Exec(api.db.DB, "postgres", migrations, migrate.Up); err != nil {
 		return nil, err
 	}
+	api.updateFlatcarGroups()
 
 	return api, nil
 }
@@ -142,6 +143,7 @@ func OptionInitDB(api *API) error {
 	if _, err := api.db.Exec(string(sqlFile)); err != nil {
 		return err
 	}
+	api.updateFlatcarGroups()
 
 	return nil
 }
@@ -176,6 +178,7 @@ func NewForTest(options ...func(*API) error) (*API, error) {
 	if err != nil {
 		return nil, err
 	}
+	a.updateFlatcarGroups()
 
 	return a, nil
 }

--- a/pkg/api/groups_test.go
+++ b/pkg/api/groups_test.go
@@ -153,6 +153,8 @@ func TestGetGroups(t *testing.T) {
 	assert.Equal(t, tChannel.Name, groups[1].Channel.Name)
 	assert.Equal(t, tPkg.ID, groups[1].Channel.PackageID.String)
 	assert.Equal(t, tPkg.Version, groups[1].Channel.Package.Version)
+	// Should be sorted descendingly.
+	assert.Equal(t, true, groups[0].CreatedTs.After(groups[1].CreatedTs))
 }
 
 func TestGetGroupsFiltered(t *testing.T) {

--- a/pkg/omaha/omaha.go
+++ b/pkg/omaha/omaha.go
@@ -14,33 +14,10 @@ import (
 	"github.com/kinvolk/nebraska/pkg/api"
 )
 
-type channelDescriptor struct {
-	name string
-	arch api.Arch
-}
-
-func chd(name string, arch api.Arch) channelDescriptor {
-	return channelDescriptor{
-		name: name,
-		arch: arch,
-	}
-}
-
 var (
 	logger = log.New("omaha")
 
-	flatcarAppID  = "e96281a6-d1af-4bde-9a0a-97b76e56dc57"
-	flatcarGroups = map[channelDescriptor]string{
-		chd("alpha", api.ArchAMD64):  "5b810680-e36a-4879-b98a-4f989e80b899",
-		chd("beta", api.ArchAMD64):   "3fe10490-dd73-4b49-b72a-28ac19acfcdc",
-		chd("stable", api.ArchAMD64): "9a2deb70-37be-4026-853f-bfdd6b347bbe",
-		chd("edge", api.ArchAMD64):   "72834a2b-ad86-4d6d-b498-e08a19ebe54e",
-
-		chd("alpha", api.ArchAArch64):  "e641708d-fb48-4260-8bdf-ba2074a1147a",
-		chd("beta", api.ArchAArch64):   "d112ec01-ba34-4a9e-9d4b-9814a685f266",
-		chd("stable", api.ArchAArch64): "11a585f6-9418-4df0-8863-78b2fd3240f8",
-		chd("edge", api.ArchAArch64):   "b4b2fa22-c1ea-498c-a8ac-c1dc0b1d7c17",
-	}
+	flatcarAppID = "e96281a6-d1af-4bde-9a0a-97b76e56dc57"
 
 	// ErrMalformedRequest error indicates that the omaha request it has
 	// received is malformed.
@@ -111,8 +88,8 @@ func (h *Handler) buildOmahaResponse(omahaReq *omahaSpec.Request, ip string) (*o
 		group := reqApp.Track
 		if reqAppUUID, err := uuid.Parse(reqApp.ID); err == nil {
 			if reqAppUUID.String() == flatcarAppID {
-				descriptor := chd(group, getArch(omahaReq.OS, reqApp))
-				if flatcarGroupID, ok := flatcarGroups[descriptor]; ok {
+				descriptor := api.ChannelDescriptor{Name: group, Arch: getArch(omahaReq.OS, reqApp)}
+				if flatcarGroupID, ok := h.crAPI.LookupGroupFromTrack(descriptor); ok {
 					group = flatcarGroupID
 				}
 			}


### PR DESCRIPTION
The mapping of Omaha track to a group ID was hardcoded for the stable,
    beta, alpha, and edge channel using only the initial the group IDs.
    When the groups were recreated resolving the track was broken and new
    groups always had to use the group ID as track which was confusing.
    Calculate the mapping dynamically based on the channel architecture and
    the track name as the channel name which is also what a user would
    expect. Instead of having a complex query using one of the track
    name or the ID, or a two queries with the first query resolving a
    possible track name and a second query using it or the ID, the
    implementation uses a hash map cache which is swapped out when a group
    entry needs an update. A proper	solution would be to add a new slug
field for the track name and a migration to set	it up for the initial
Flatcar	groups. For new	groups it would	have to	be entered in the UI 
and enforced to	be unique.
