### PR TITLE
Syncer configuration

### DIFF
--- a/cmd/nebraska/controller.go
+++ b/cmd/nebraska/controller.go
@@ -52,6 +52,8 @@ type controllerConfig struct {
 	nebraskaURL         string
 	noopAuthConfig      *auth.NoopAuthConfig
 	githubAuthConfig    *auth.GithubAuthConfig
+	flatcarUpdatesURL   string
+	checkFrequency      time.Duration
 }
 
 func newController(conf *controllerConfig) (*controller, error) {
@@ -67,10 +69,12 @@ func newController(conf *controllerConfig) (*controller, error) {
 
 	if conf.enableSyncer {
 		syncerConf := &syncer.Config{
-			API:          conf.api,
-			HostPackages: conf.hostFlatcarPackages,
-			PackagesPath: conf.flatcarPackagesPath,
-			PackagesURL:  conf.nebraskaURL + "/flatcar/",
+			API:               conf.api,
+			HostPackages:      conf.hostFlatcarPackages,
+			PackagesPath:      conf.flatcarPackagesPath,
+			PackagesURL:       conf.nebraskaURL + "/flatcar/",
+			FlatcarUpdatesURL: conf.flatcarUpdatesURL,
+			CheckFrequency:    conf.checkFrequency,
 		}
 		syncer, err := syncer.New(syncerConf)
 		if err != nil {

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -184,7 +184,7 @@ func (s *Syncer) checkForUpdates() error {
 		}
 
 		select {
-		case <-time.After(1 * time.Minute):
+		case <-time.After(5 * time.Second):
 		case <-s.stopCh:
 			break
 		}


### PR DESCRIPTION
- pkg/syncer/syncer: Add parameters for sync interval and source URL
    The interval was hardcoded to one hour which is inconvenient when new
    settings should be quickly propagated during a test phase. The sync
    URL was also hardcoded and required source code changes when a different
    source URL should has to be used.
    Expose both values as parameters with the current values as default.
- pkg/syncer/syncer: Reduce waiting time between two channels
    The syncer was sleeping for a minute before the next channel was
    synced. This makes it look like a bug and even if known it is not
    really useful but rather disturbing to wait 8 minutes until all
    channels are synced.
    Wait for 5 seconds which is a bit waiting time to not hammer the
    server but still allows to sync all channels in under a minute.