### PR TITLE
pkg/syncer/syncer: Extend list of synced channels with LTS

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -140,7 +140,7 @@ func (s *Syncer) initialize() error {
 	}
 
 	for _, c := range flatcarApp.Channels {
-		if c.Name == "stable" || c.Name == "beta" || c.Name == "alpha" || c.Name == "edge" {
+		if c.Name == "stable" || c.Name == "beta" || c.Name == "alpha" || c.Name == "edge" || strings.HasPrefix(c.Name, "lts-") {
 			descriptor := channelDescriptor{
 				name: c.Name,
 				arch: c.Arch,


### PR DESCRIPTION
The LTS channels for the different streams should be synced but not the
placeholder LTS channel used to manage the desired version in Nebraska.
Extend teh list of hard-coded synced channels with those that start
with "lts-" denoting an LTS stream channel. Ideally this would be a
boolean field on the channel itself, to set whether to sync or not.