### PR TITLE
Optimize update instance status

### DIFF
--- a/pkg/api/activity_test.go
+++ b/pkg/api/activity_test.go
@@ -55,6 +55,9 @@ func TestGetActivity(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 5, len(activityEntries))
 
+	hasRecentActivity := a.hasRecentActivity(activityInstanceUpdateFailed, ActivityQueryParams{Severity: activitySuccess, AppID: tApp.ID, Version: tVersion, GroupID: tGroup.ID})
+	assert.True(t, hasRecentActivity)
+
 	_, err = a.GetActivity("invalidTeamID", ActivityQueryParams{})
 	assert.Error(t, err, "Team id used must be a valid uuid.")
 

--- a/pkg/api/groups_test.go
+++ b/pkg/api/groups_test.go
@@ -200,7 +200,10 @@ func TestGetVersionCountTimeline(t *testing.T) {
 	instanceID := uuid.New().String()
 
 	_, _ = a.RegisterInstance(instanceID, "10.0.0.1", version, tApp.ID, tGroup.ID)
-	_ = a.grantUpdate(instanceID, tApp.ID, version)
+
+	instance, err := a.GetInstance(instanceID, tApp.ID)
+	assert.NoError(t, err)
+	_ = a.grantUpdate(instance, version)
 	_ = a.updateInstanceStatus(instanceID, tApp.ID, InstanceStatusComplete)
 
 	// get VersionCountTimeline from 1 hr before now
@@ -243,10 +246,18 @@ func TestGetStatusCountTimeline(t *testing.T) {
 	instanceID2 := uuid.New().String()
 
 	_, _ = a.RegisterInstance(instanceID1, "10.0.0.1", version, tApp.ID, tGroup.ID)
-	_ = a.grantUpdate(instanceID1, tApp.ID, version)
+
+	instance1, err := a.GetInstance(instanceID1, tApp.ID)
+	assert.NoError(t, err)
+
+	_ = a.grantUpdate(instance1, version)
 	_ = a.updateInstanceStatus(instanceID1, tApp.ID, InstanceStatusComplete)
 	_, _ = a.RegisterInstance(instanceID2, "10.0.0.2", version, tApp.ID, tGroup.ID)
-	_ = a.grantUpdate(instanceID2, tApp.ID, version)
+
+	instance2, err := a.GetInstance(instanceID2, tApp.ID)
+	assert.NoError(t, err)
+
+	_ = a.grantUpdate(instance2, version)
 	_ = a.updateInstanceStatus(instanceID2, tApp.ID, InstanceStatusDownloading)
 
 	// get StatusCountTimeline from 1 hr before now

--- a/pkg/api/instances.go
+++ b/pkg/api/instances.go
@@ -344,6 +344,12 @@ func (api *API) updateInstanceStatus(instanceID, appID string, newStatus int) er
 	if err != nil {
 		return err
 	}
+	return api.updateInstanceObjStatus(instance, newStatus)
+}
+
+func (api *API) updateInstanceObjStatus(instance *Instance, newStatus int) error {
+	appID := instance.Application.ApplicationID
+
 	if instance.Application.Status.Valid && instance.Application.Status.Int64 == int64(newStatus) {
 		return nil
 	}

--- a/pkg/api/instances.go
+++ b/pkg/api/instances.go
@@ -393,14 +393,16 @@ func (api *API) updateInstanceStatus(instanceID, appID string, newStatus int) er
 	return api.updateInstanceObjStatus(instance, newStatus)
 }
 
-func (api *API) updateInstanceObjStatus(instance *Instance, newStatus int) error {
+func (api *API) updateInstanceData(instance *Instance, data map[string]interface{}) error {
 	appID := instance.Application.ApplicationID
+
+	insertData := data
+	newStatus := insertData["status"].(int)
 
 	if instance.Application.Status.Valid && instance.Application.Status.Int64 == int64(newStatus) {
 		return nil
 	}
-	var insertData = make(map[string]interface{})
-	insertData["status"] = newStatus
+
 	if newStatus == InstanceStatusComplete {
 		insertData["version"] = goqu.L("CASE WHEN last_update_version IS NOT NULL THEN last_update_version ELSE version END")
 	}
@@ -427,6 +429,13 @@ func (api *API) updateInstanceObjStatus(instance *Instance, newStatus int) error
 
 	_, err = api.db.Exec(insertQuery)
 	return err
+}
+
+func (api *API) updateInstanceObjStatus(instance *Instance, newStatus int) error {
+	insertData := make(map[string]interface{})
+	insertData["status"] = newStatus
+
+	return api.updateInstanceData(instance, insertData)
 }
 
 // instanceAppQuery returns a SelectDataset prepared to return the app status

--- a/pkg/api/updates.go
+++ b/pkg/api/updates.go
@@ -86,7 +86,7 @@ func (api *API) GetUpdatePackage(instanceID, instanceIP, instanceVersion, appID,
 	for _, blacklistedChannelID := range group.Channel.Package.ChannelsBlacklist {
 		if blacklistedChannelID == group.Channel.ID {
 			if updateAlreadyGranted {
-				if err := api.updateInstanceStatus(instance.ID, appID, InstanceStatusComplete); err != nil {
+				if err := api.updateInstanceObjStatus(instance, InstanceStatusComplete); err != nil {
 					logger.Error("GetUpdatePackage - could not update instance status", err)
 				}
 			}
@@ -98,7 +98,7 @@ func (api *API) GetUpdatePackage(instanceID, instanceIP, instanceVersion, appID,
 	packageSemver, _ := semver.Make(group.Channel.Package.Version)
 	if !instanceSemver.LT(packageSemver) {
 		if updateAlreadyGranted {
-			if err := api.updateInstanceStatus(instance.ID, appID, InstanceStatusComplete); err != nil {
+			if err := api.updateInstanceObjStatus(instance, InstanceStatusComplete); err != nil {
 				logger.Error("GetUpdatePackage - could not update instance status", err)
 			}
 		}
@@ -136,7 +136,7 @@ func (api *API) GetUpdatePackage(instanceID, instanceIP, instanceVersion, appID,
 		}
 	}
 
-	if err := api.updateInstanceStatus(instance.ID, appID, InstanceStatusUpdateGranted); err != nil {
+	if err := api.updateInstanceObjStatus(instance, InstanceStatusUpdateGranted); err != nil {
 		logger.Error("GetUpdatePackage - could not update instance status", err)
 	}
 

--- a/pkg/api/updates.go
+++ b/pkg/api/updates.go
@@ -118,12 +118,14 @@ func (api *API) GetUpdatePackage(instanceID, instanceIP, instanceVersion, appID,
 		return nil, err
 	}
 
-	if err := api.grantUpdate(instance, group.Channel.Package.Version); err != nil {
+	version := group.Channel.Package.Version
+
+	if err := api.grantUpdate(instance, version); err != nil {
 		logger.Error("GetUpdatePackage - grantUpdate error (propagates as ErrGrantingUpdate):", err)
 	}
 
-	if updatesStats.UpdatesToCurrentVersionGranted == 0 {
-		if err := api.newGroupActivityEntry(activityRolloutStarted, activityInfo, group.Channel.Package.Version, appID, group.ID); err != nil {
+	if !api.hasRecentActivity(activityRolloutStarted, ActivityQueryParams{Severity: activityInfo, AppID: appID, Version: version, GroupID: group.ID}) {
+		if err := api.newGroupActivityEntry(activityRolloutStarted, activityInfo, version, appID, group.ID); err != nil {
 			logger.Error("GetUpdatePackage - could not add new group activity entry", err)
 		}
 	}

--- a/pkg/api/updates.go
+++ b/pkg/api/updates.go
@@ -7,6 +7,10 @@ import (
 	"github.com/blang/semver"
 )
 
+const (
+	maxParallelUpdates = 900000
+)
+
 var (
 	// ErrRegisterInstanceFailed indicates that the instance registration did
 	// not succeed.
@@ -108,13 +112,7 @@ func (api *API) GetUpdatePackage(instanceID, instanceIP, instanceVersion, appID,
 		return group.Channel.Package, nil
 	}
 
-	updatesStats, err := api.getGroupUpdatesStats(group)
-	if err != nil {
-		logger.Error("GetUpdatePackage - getGroupUpdatesStats error (propagates as ErrGetUpdatesStatsFailed):", err)
-		return nil, ErrGetUpdatesStatsFailed
-	}
-
-	if err := api.enforceRolloutPolicy(instance, group, updatesStats); err != nil {
+	if err := api.enforceRolloutPolicy(instance, group); err != nil {
 		return nil, err
 	}
 
@@ -142,7 +140,7 @@ func (api *API) GetUpdatePackage(instanceID, instanceIP, instanceVersion, appID,
 // enforceRolloutPolicy validates if an update should be provided to the
 // requesting instance based on the group rollout policy and the current status
 // of the updates taking place in the group.
-func (api *API) enforceRolloutPolicy(instance *Instance, group *Group, updatesStats *UpdatesStats) error {
+func (api *API) enforceRolloutPolicy(instance *Instance, group *Group) error {
 	appID := instance.Application.ApplicationID
 
 	if !group.PolicyUpdatesEnabled {
@@ -154,6 +152,18 @@ func (api *API) enforceRolloutPolicy(instance *Instance, group *Group, updatesSt
 	}
 
 	effectiveMaxUpdates := group.PolicyMaxUpdatesPerPeriod
+
+	// If no policy enforcement is needed, then we skip getting the update stats below.
+	if effectiveMaxUpdates >= maxParallelUpdates && !group.PolicySafeMode {
+		return nil
+	}
+
+	updatesStats, err := api.getGroupUpdatesStats(group)
+	if err != nil {
+		logger.Error("GetUpdatePackage - getGroupUpdatesStats error (propagates as ErrGetUpdatesStatsFailed):", err)
+		return ErrGetUpdatesStatsFailed
+	}
+
 	if group.PolicySafeMode && updatesStats.UpdatesToCurrentVersionAttempted == 0 {
 		effectiveMaxUpdates = 1
 	}

--- a/pkg/api/updates_test.go
+++ b/pkg/api/updates_test.go
@@ -303,6 +303,11 @@ func TestGetUpdatePackage_UpdateInProgressOnInstance(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, p1, p2)
 
+	instance, err := a.GetInstance(instanceID, tApp.ID)
+	assert.NoError(t, err)
+	assert.True(t, instance.Application.UpdateInProgress)
+	assert.Equal(t, "12.1.0", instance.Application.LastUpdateVersion.String)
+
 	err = a.updateInstanceStatus(instanceID, tApp.ID, InstanceStatusDownloading)
 	assert.NoError(t, err)
 	_, err = a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)

--- a/pkg/api/updates_test.go
+++ b/pkg/api/updates_test.go
@@ -329,6 +329,13 @@ func TestGetUpdatePackage_CheckVersionForGrantedUpdate(t *testing.T) {
 	_, err := a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
+	instance, err := a.GetInstance(instanceID, tApp.ID)
+	assert.NoError(t, err)
+	assert.True(t, instance.Application.UpdateInProgress)
+	assert.Equal(t, int64(InstanceStatusUpdateGranted), instance.Application.Status.Int64)
+	assert.Equal(t, "12.1.0", instance.Application.LastUpdateVersion.String)
+	assert.Equal(t, "12.0.0", instance.Application.Version)
+
 	_, err = a.GetUpdatePackage(instanceID, "10.0.0.1", "12.1.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrNoUpdatePackageAvailable, err)
 


### PR DESCRIPTION
This PR has the following optimizations affecting the `GetUpdatePackage` method:
* When updating the instance status, update `instance` + `instance_application` in the same query (instead of 2 queries);
* Don't update the `instance_application` twice when granting an update (it was setting the version + timestamp, etc. and then updating the status) which means 1 write instead of 2;
* Don't update the `instance_application` when an instance checks in if the last check in is less than 5 minutes ago (this reduces drastically the number of constant writes when using the `updateservicectl` fake instances which constantly ping the server)
* Don't fetch the group's stats (it's a count query that may get complex if we have lots of instances registered in the last 24h) unless we need them for enforcing the policy (i.e. if we allow more than 900000 parallel updates, then we don't need the stats because we're not using them for enforcing anything)

Here is a chart showing the number of writes with the latest stable release (throwing 2k instances pings every 0-10 seconds):
![Screenshot from 2020-10-30 17-59-34](https://user-images.githubusercontent.com/1029635/97741879-5e77c680-1adb-11eb-8feb-75c03bbd4eb4.png)

Here is the chart showing the same but with the new logic in this PR:
![Screenshot from 2020-10-30 18-00-00](https://user-images.githubusercontent.com/1029635/97741928-718a9680-1adb-11eb-8c5c-bab6c9f0c30b.png)

The CPU still reached 100% in both cases with this configuration in the very week machine I used:
(Old logic + the decline after I stopped the test case)
![Screenshot from 2020-10-30 18-01-04](https://user-images.githubusercontent.com/1029635/97742017-9d0d8100-1adb-11eb-8716-6a1f0b94f59e.png)

(New logic)
![Screenshot from 2020-10-30 18-01-14](https://user-images.githubusercontent.com/1029635/97742052-a991d980-1adb-11eb-830a-523ea463f60b.png)


So even if we're still reaching 100% CPU and there is room for more optimization, this PR dramatically reduces the number of writes and that's a good thing.