### PR TITLE
Makefile: build nebraska without host path info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ run-generators: tools/go-bindata
 
 .PHONY: build-backend-binary
 build-backend-binary:
-	go build -ldflags ${LDFLAGS} -o bin/nebraska ./cmd/nebraska
+	go build -trimpath -ldflags ${LDFLAGS} -o bin/nebraska ./cmd/nebraska
 
 .PHONY: backend-code-checks
 backend-code-checks: tools/golangci-lint


### PR DESCRIPTION


`go build -trimpath` removes the full path info used in the build
process of the binary. (less info for folks to sniff out)

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

![Screenshot from 2020-11-04 10-40-18](https://user-images.githubusercontent.com/67049/98132239-27623600-1e8a-11eb-8e30-47fe71e3f960.png)
for reference