### PR TITLE
pkg/api: force the mode on go-bindata

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -24,7 +24,7 @@ import (
 //
 //    make bindata
 
-//go:generate go-bindata -ignore=\.swp -pkg=api -modtime=1 db db/migrations
+//go:generate go-bindata -mode 0644 -ignore=\.swp -pkg=api -modtime=1 db db/migrations
 
 const (
 	defaultDbURL          = "postgres://postgres@127.0.0.1:5432/nebraska?sslmode=disable&connect_timeout=10"


### PR DESCRIPTION
regardless of the hosts' umask, there is an occassional difference in
the mode of the generated bindata content (0644 vs 0664).
Just instruct the generated output to be 0644.

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>