### PR TITLE
cmd/nebraska: Support secret API endpoint suffix for private instances

### DIFF
--- a/cmd/nebraska/nebraska.go
+++ b/cmd/nebraska/nebraska.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -50,6 +51,7 @@ var (
 	appLogoPath         = flag.String("client-logo", "", "Client app logo, should be a path to svg file")
 	appTitle            = flag.String("client-title", "", "Client app title")
 	appHeaderStyle      = flag.String("client-header-style", "light", "Client app header style, should be either dark or light")
+	apiEndpointSuffix   = flag.String("api-endpoint-suffix", "", "Additional suffix for the API endpoint to serve Omaha clients on; use a secret to only serve your clients, e.g., mysecret results in /v1/update/mysecret")
 )
 
 func main() {
@@ -287,7 +289,7 @@ func setupRoutes(ctl *controller, httpLog bool) *gin.Engine {
 	// Omaha server router setup
 	omahaRouter := wrappedEngine.Group("/", "omaha")
 	omahaRouter.POST("/omaha", ctl.processOmahaRequest)
-	omahaRouter.POST("/v1/update", ctl.processOmahaRequest)
+	omahaRouter.POST(path.Join("/v1/update", *apiEndpointSuffix), ctl.processOmahaRequest)
 
 	// Config router setup
 	configRouter := wrappedEngine.Group("/config", "config")


### PR DESCRIPTION
Private instances that are deployed on the Internet should sometimes
    only serve a set of trusted clients. Since the server interacts with
    human users via the administration web interface, an IP address filter
    on the host system is not convenient.
    Allow to move the Omaha API endpoint to a secret path so that only
    clients that know the path are able to register. The secret is appended
    to the well-known /v1/update path and separated by a slash. For now
    there is only one global secret specified as program parameter.
    A future feature could be to manage multiple secrets in the web UI
    conveniently to handle leaks, transitions, and multiple trustees.

# How to use

```
make backend-binary
docker run --rm -d --name nebraska-postgres-dev --tmpfs /var/lib/postgresql/data:rw,noexec,nosuid,size=5G --network host -e POSTGRES_PASSWORD=nebraska postgres && (sleep 10 && psql postgres://postgres:nebraska@localhost:5432/postgres -c 'create database nebraska;' && psql postgres://postgres:nebraska@localhost:5432/nebraska -c 'set timezone = "utc";' )
bin/nebraska -auth-mode noop -http-static-dir "$PWD"/frontend/build -http-log --api-endpoint /mysecret
```

# Testing done

Create `/tmp/payload`:
```
<?xml version="1.0" encoding="UTF-8"?>
<request protocol="3.0" version="update_engine-0.4.10" updaterversion="update_engine-0.4.10" installsource="scheduler" ismachine="1">
    <os version="Chateau" platform="CoreOS" sp="2512.2.0_x86_64"></os>
    <app appid="e96281a6-d1af-4bde-9a0a-97b76e56dc57" version="0.0.0" track="stable" bootid="{965fb4c5-ad3e-4eb7-a4c2-ca0c0e31ec84}" oem="ami" oemversion="0.1.1-r1" alephversion="0.0.0" machineid="ab9e671d61774703ac7be60715220bfe" lang="en-US" board="amd64-usr" hardware_class="" delta_okay="false" >
        <ping active="1"></ping>
        <updatecheck></updatecheck>
        <event eventtype="3" eventresult="1"></event>
    </app>
</request>
```

Query an update:
```
curl -d @/tmp/payload -H 'Content-Type: text/xml' http://localhost:8000/mysecret
```