### PR TITLE
frontend: Show the full date in the instance details view

### DIFF
--- a/frontend/src/js/constants/helpers.js
+++ b/frontend/src/js/constants/helpers.js
@@ -58,7 +58,7 @@ export function getMinuteDifference(date1, date2) {
 }
 
 export function makeLocaleTime(timestamp, opts = {}) {
-  const {useDate = true, showTime = true, dateFormat = {weekday: 'short', day: 'numeric'}} = opts;
+  const {useDate = true, showTime = true, dateFormat = {}} = opts;
   const date = new Date(timestamp);
   const formattedDate = date.toLocaleDateString('default', dateFormat);
   const timeFormat = date.toLocaleString('default', { hour: '2-digit', minute: '2-digit' });


### PR DESCRIPTION
The instances' details view was showing the date of the last update
check without the month information, regardless of whether we were in
the same month currently as the date in question. This patch fixes that
by showing the full numeric date. We can add a more human-friendly date
format later if needed.

fixes #299 