### PR TITLE
backend: Ensure instances are not stuck in an updating state

### DIFF
--- a/pkg/api/instances.go
+++ b/pkg/api/instances.go
@@ -407,7 +407,7 @@ func (api *API) updateInstanceData(instance *Instance, data map[string]interface
 		insertData["version"] = goqu.L("CASE WHEN last_update_version IS NOT NULL THEN last_update_version ELSE version END")
 	}
 
-	if newStatus == InstanceStatusComplete || newStatus == InstanceStatusError {
+	if newStatus == InstanceStatusComplete || newStatus == InstanceStatusError || newStatus == InstanceStatusUndefined || newStatus == InstanceStatusOnHold {
 		insertData["update_in_progress"] = false
 	}
 


### PR DESCRIPTION
The Complete event is sometimes ignored similarly to unexpected events
when no update is in progress. This is supposed to prevent Complete
events for already updated instances or those where the previous
version mismatched the version seen by the server. However, the
previous version seen by the server is nothing to be trusted because
the database state may be wrong or from a malicious client. Since
update-engine has inbuilt rollback detection it will create an error
event on its own if it detects that it does not run the new version
instead of a Complete event. The case left to cover is that
update-engine sends Complete events all the time in normal operation
and we want to reset the updating state so that the instance can be
granted updates again. Therefore, do a state transition even though
we drop the event. The Undefined state is chosen because the instance
did not tell that it just now updated from another version but sent an
invalid previous version. Also make sure that the UpdateInProgress
actually relates to the instance state by resetting it for the
Undefined state (and OnHold which was forgotten, too).

Fixes https://github.com/kinvolk/nebraska/issues/303

# How to use/testing done

I used a Flatcar instance that forced an update, canceled an update, did a rollback, and a successful update.
The other test was manually by turning using an update request, then another request to move the instance into the Downloading state and then verifying that using the first request is able to get updates again without being stuck in the Downloading state (unless the particular saved previous version was used).