### PR TITLE
Add instance alias

### DIFF
--- a/cmd/nebraska/controller.go
+++ b/cmd/nebraska/controller.go
@@ -745,6 +745,33 @@ func (ctl *controller) getInstance(c *gin.Context) {
 	}
 }
 
+func (ctl *controller) updateInstance(c *gin.Context) {
+	instanceID := c.Params.ByName("instance_id")
+	params := struct{ Alias string }{}
+
+	if err := json.NewDecoder(c.Request.Body).Decode(&params); err != nil {
+		logger.Error("updateInstance - decoding payload", "error", err.Error())
+		httpError(c, http.StatusBadRequest)
+		return
+	}
+
+	instance, err := ctl.api.UpdateInstance(instanceID, params.Alias)
+	if err != nil {
+		logger.Error("updateInstance - updating instance", "error", err.Error(), "instance", instanceID, "params", params)
+		httpError(c, http.StatusBadRequest)
+		return
+	}
+
+	if err == nil {
+		if err := json.NewEncoder(c.Writer).Encode(instance); err != nil {
+			logger.Error("updateInstance - encoding instance", "error", err.Error(), "instance", instanceID, "params", params)
+		}
+	} else {
+		logger.Error("updateInstance - getting instance", "error", err.Error(), "instance", instanceID, "params", params)
+		httpError(c, http.StatusBadRequest)
+	}
+}
+
 // ----------------------------------------------------------------------------
 // API: activity
 //

--- a/cmd/nebraska/controller.go
+++ b/cmd/nebraska/controller.go
@@ -710,6 +710,7 @@ func (ctl *controller) getInstances(c *gin.Context) {
 		httpError(c, http.StatusBadRequest)
 	}
 }
+
 func (ctl *controller) getInstancesCount(c *gin.Context) {
 	appID := c.Params.ByName("app_id")
 	groupID := c.Params.ByName("group_id")
@@ -729,6 +730,7 @@ func (ctl *controller) getInstancesCount(c *gin.Context) {
 		httpError(c, http.StatusBadRequest)
 	}
 }
+
 func (ctl *controller) getInstance(c *gin.Context) {
 	appID := c.Params.ByName("app_id")
 	instanceID := c.Params.ByName("instance_id")

--- a/cmd/nebraska/nebraska.go
+++ b/cmd/nebraska/nebraska.go
@@ -282,6 +282,7 @@ func setupRoutes(ctl *controller, httpLog bool) *gin.Engine {
 	apiRouter.GET("/apps/:app_id/groups/:group_id/instances", ctl.getInstances)
 	apiRouter.GET("/apps/:app_id/groups/:group_id/instancescount", ctl.getInstancesCount)
 	apiRouter.GET("/apps/:app_id/groups/:group_id/instances/:instance_id", ctl.getInstance)
+	apiRouter.PUT("/instances/:instance_id", ctl.updateInstance)
 
 	// Activity
 	apiRouter.GET("/activity", ctl.getActivity)

--- a/frontend/src/js/api/API.js
+++ b/frontend/src/js/api/API.js
@@ -157,6 +157,12 @@ class API {
     return API.getJSON(url);
   }
 
+  static updateInstance(instanceID, alias) {
+    const url = BASE_URL + '/instances/' + instanceID;
+    const params = JSON.stringify({alias});
+    return API.doRequest('PUT', url, params);
+  }
+
   // Activity
 
   static getActivity() {

--- a/frontend/src/js/api/API.js
+++ b/frontend/src/js/api/API.js
@@ -138,16 +138,19 @@ class API {
 
     return API.getJSON(url);
   }
+
   static getInstancesCount(applicationID, groupID, duration) {
     const url = `${BASE_URL}/apps/${applicationID}/groups/${groupID}/instancescount?duration=${duration}`;
 
     return API.getJSON(url);
   }
+
   static getInstance(applicationID, groupID, instanceID) {
     const url = BASE_URL + '/apps/' + applicationID + '/groups/' + groupID + '/instances/' + instanceID;
 
     return API.getJSON(url);
   }
+
   static getInstanceStatusHistory(applicationID, groupID, instanceID) {
     const url = BASE_URL + '/apps/' + applicationID + '/groups/' + groupID + '/instances/' + instanceID + '/status_history';
 

--- a/frontend/src/js/components/Instances/Details.js
+++ b/frontend/src/js/components/Instances/Details.js
@@ -189,6 +189,9 @@ function DetailsView(props) {
   const theme = useTheme();
   const {application, group, instance} = props;
   const [eventHistory, setEventHistory] = React.useState([]);
+
+  const hasAlias = !!instance.alias;
+
   React.useEffect(() => {
     API.getInstanceStatusHistory(application.id, group.id, instance.id).then((statusHistory) => {
       setEventHistory(statusHistory);
@@ -210,7 +213,7 @@ function DetailsView(props) {
           >
             <Grid item xs={12}>
               <Box fontWeight={700} fontSize={30} color={theme.palette.greyShadeColor}>
-                {instance.id}
+                {instance.alias || instance.id}
               </Box>
             </Grid>
             <Grid item md>
@@ -220,6 +223,14 @@ function DetailsView(props) {
                 <Grid container>
                   <Grid item xs={12} container>
                     <Grid item container>
+                      { hasAlias &&
+                        <Grid item xs={12}>
+                          <CardFeatureLabel>ID</CardFeatureLabel>&nbsp;
+                          <Box mt={1} mb={1}>
+                            <CardLabel>{instance.id}</CardLabel>
+                          </Box>
+                        </Grid>
+                      }
                       <Grid item xs={6}>
                         <CardFeatureLabel>IP</CardFeatureLabel>
                         <Box mt={1}>

--- a/frontend/src/js/components/Instances/Item.react.js
+++ b/frontend/src/js/components/Instances/Item.react.js
@@ -81,12 +81,13 @@ function Item(props) {
   }
   const searchParams = new URLSearchParams(window.location.search).toString();
   const instancePath = `/apps/${appID}/groups/${groupID}/instances/${instanceID}?${searchParams}`;
+  const instanceName = props.instance.alias || props.instance.id;
 
   return (
     <React.Fragment>
       <TableRow>
         <TableCell>
-          <Link to={instancePath} component={RouterLink}>{props.instance.id}</Link>
+          <Link to={instancePath} component={RouterLink}>{instanceName}</Link>
         </TableCell>
         <TableCell>
           {props.instance.ip}

--- a/frontend/src/js/components/Instances/Table.js
+++ b/frontend/src/js/components/Instances/Table.js
@@ -31,7 +31,7 @@ function Table(props) {
     <MuiTable>
       <TableHead>
         <TableRow>
-          <TableCell>Instance ID</TableCell>
+          <TableCell>Instance</TableCell>
           <TableCell>IP</TableCell>
           <TableCell>Current Status</TableCell>
           <TableCell>Version</TableCell>

--- a/frontend/src/js/components/Layouts/InstanceLayout.js
+++ b/frontend/src/js/components/Layouts/InstanceLayout.js
@@ -79,6 +79,7 @@ export default function InstanceLayout(props) {
         application={application}
         group={group}
         instance={instance}
+        onInstanceUpdated={() => onChange()}
       />
       }
     </React.Fragment>

--- a/frontend/src/js/components/Layouts/InstanceLayout.js
+++ b/frontend/src/js/components/Layouts/InstanceLayout.js
@@ -47,12 +47,13 @@ export default function InstanceLayout(props) {
 
   const applicationName = application ? application.name : '…';
   const groupName = group ? group.name : '…';
+  const instanceName = (instance && instance.alias) || instanceID;
 
   const searchParams = new URLSearchParams(window.location.search).toString();
   return (
     <React.Fragment>
       <SectionHeader
-        title={instanceID}
+        title={instanceName}
         breadcrumbs={[
           {
             path: '/apps',

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,11 @@ module github.com/kinvolk/nebraska
 
 go 1.13
 
+replace github.com/coreos/go-omaha => github.com/kinvolk/go-omaha v0.0.0-20201126073937-801f305b087b
+
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/coreos/go-omaha v0.0.0-20180327202221-e409d983eb60
+	github.com/coreos/go-omaha v0.0.0 // replaced with github.com/kinvolk/go-omaha
 	github.com/doug-martin/goqu/v9 v9.10.0
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 // indirect
@@ -25,7 +27,6 @@ require (
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/kevinburke/go-bindata v3.16.0+incompatible
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lib/pq v1.8.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,6 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
-github.com/coreos/go-omaha v0.0.0-20180327202221-e409d983eb60 h1:i2/gIetlz/BaiHhCvXy0gQkktU1Bdp+fCfbrf1DCqgA=
-github.com/coreos/go-omaha v0.0.0-20180327202221-e409d983eb60/go.mod h1:IU76HHVFspEz6YCsXufWBCTPBPbL86JSct4XvXfZPMA=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -427,6 +425,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kevinburke/go-bindata v3.16.0+incompatible h1:TFzFZop2KxGhqNwsyjgmIh5JOrpG940MZlm5gNbxr8g=
 github.com/kevinburke/go-bindata v3.16.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi30bslSp9YqD9pysLxunQDdb2CPM=
+github.com/kinvolk/go-omaha v0.0.0-20201126073937-801f305b087b h1:1E0fbipq7mALcBJQdsph3ZiQakqvNhiCUaR8IA8jyF0=
+github.com/kinvolk/go-omaha v0.0.0-20201126073937-801f305b087b/go.mod h1:w7EXkp1ldIEgguBmMVIiUWw1JqPK7PqzZgchPP3axMM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -604,6 +604,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/satori/go.uuid v1.1.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/pkg/api/activity_test.go
+++ b/pkg/api/activity_test.go
@@ -20,9 +20,9 @@ func TestGetActivity(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 	tGroup2, _ := a.AddGroup(&Group{Name: "group2", ApplicationID: tApp.ID, PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	tInstance, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	tInstance2, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.2", "1.0.0", tApp.ID, tGroup2.ID)
-	tFakeInstance, _ := a.RegisterInstance("{"+uuid.New().String()+"}", "10.0.0.2", "1.0.0", tApp.ID, tGroup2.ID)
+	tInstance, _ := a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance2, _ := a.RegisterInstance(uuid.New().String(), "", "10.0.0.2", "1.0.0", tApp.ID, tGroup2.ID)
+	tFakeInstance, _ := a.RegisterInstance("{"+uuid.New().String()+"}", "", "10.0.0.2", "1.0.0", tApp.ID, tGroup2.ID)
 
 	_ = a.newGroupActivityEntry(activityRolloutStarted, activitySuccess, tVersion, tApp.ID, tGroup.ID)
 	_ = a.newGroupActivityEntry(activityRolloutStarted, activitySuccess, tVersion, tApp.ID, tGroup2.ID)

--- a/pkg/api/applications_test.go
+++ b/pkg/api/applications_test.go
@@ -112,7 +112,7 @@ func TestGetApp(t *testing.T) {
 	tApp, _ := a.AddApp(&Application{Name: "test_app", TeamID: tTeam.ID})
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	_, _ = a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
 	app, err := a.GetApp(tApp.ID)
 	assert.NoError(t, err)
@@ -155,8 +155,8 @@ func TestGetAppsFiltered(t *testing.T) {
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 	realInstanceID := uuid.New().String()
 	fakeInstanceID := "{" + uuid.New().String() + "}"
-	_, _ = a.RegisterInstance(realInstanceID, "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	_, _ = a.RegisterInstance(fakeInstanceID, "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(realInstanceID, "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(fakeInstanceID, "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
 	// should ignore fake instance in Instances count
 	apps, err := a.GetApps(tTeam.ID, 1, 10)

--- a/pkg/api/bindata.go
+++ b/pkg/api/bindata.go
@@ -11,6 +11,7 @@
 // db/migrations/0007_add_package_arch.sql (1.558kB)
 // db/migrations/0008-arm-channels-groups.sql (3.854kB)
 // db/migrations/0009_group_track_names.sql (973B)
+// db/migrations/0010_add_instance_alias.sql (138B)
 
 package api
 
@@ -299,6 +300,26 @@ func dbMigrations0009_group_track_namesSql() (*asset, error) {
 	return a, nil
 }
 
+var _dbMigrations0010_add_instance_aliasSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x74\xcc\xb1\x0d\xc2\x40\x0c\x05\xd0\xde\x53\xfc\x2e\x20\x94\x06\x09\x9a\xb4\xac\xc0\x00\x9f\x3b\x03\x27\x39\xbe\xc8\x71\x60\x7d\x5a\x28\x58\xe0\x8d\x23\x0e\x73\x7b\x04\x53\x71\x5d\x44\x68\xa9\x81\xe4\xcd\x14\xcd\xd7\xa4\x17\x05\x6b\x45\xe9\xb6\xcd\x0e\x5a\xe3\x8a\x17\xa3\x3c\x19\xbb\xe3\xe9\xbc\x47\xd5\x3b\x37\x4b\x0c\xc3\x24\xf2\xed\x5d\xfa\xdb\xff\x88\x35\xfa\xf2\x43\x4e\xf2\x09\x00\x00\xff\xff\xbe\x58\x50\x30\x8a\x00\x00\x00")
+
+func dbMigrations0010_add_instance_aliasSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_dbMigrations0010_add_instance_aliasSql,
+		"db/migrations/0010_add_instance_alias.sql",
+	)
+}
+
+func dbMigrations0010_add_instance_aliasSql() (*asset, error) {
+	bytes, err := dbMigrations0010_add_instance_aliasSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "db/migrations/0010_add_instance_alias.sql", size: 138, mode: os.FileMode(0644), modTime: time.Unix(1, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb1, 0x64, 0xa5, 0xe1, 0xe2, 0x15, 0x0, 0x34, 0x49, 0x9f, 0xf, 0x63, 0xd8, 0xa1, 0x1, 0x56, 0x66, 0x9c, 0x69, 0xa2, 0xa6, 0x1a, 0xc9, 0x3d, 0x8e, 0xc4, 0x2d, 0xff, 0x9d, 0x1b, 0x12, 0x8}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -401,6 +422,7 @@ var _bindata = map[string]func() (*asset, error){
 	"db/migrations/0007_add_package_arch.sql":     dbMigrations0007_add_package_archSql,
 	"db/migrations/0008-arm-channels-groups.sql":  dbMigrations0008ArmChannelsGroupsSql,
 	"db/migrations/0009_group_track_names.sql":    dbMigrations0009_group_track_namesSql,
+	"db/migrations/0010_add_instance_alias.sql":   dbMigrations0010_add_instance_aliasSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -456,6 +478,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"0007_add_package_arch.sql":     &bintree{dbMigrations0007_add_package_archSql, map[string]*bintree{}},
 			"0008-arm-channels-groups.sql":  &bintree{dbMigrations0008ArmChannelsGroupsSql, map[string]*bintree{}},
 			"0009_group_track_names.sql":    &bintree{dbMigrations0009_group_track_namesSql, map[string]*bintree{}},
+			"0010_add_instance_alias.sql":   &bintree{dbMigrations0010_add_instance_aliasSql, map[string]*bintree{}},
 		}},
 		"sample_data.sql": &bintree{dbSample_dataSql, map[string]*bintree{}},
 	}},

--- a/pkg/api/db/migrations/0010_add_instance_alias.sql
+++ b/pkg/api/db/migrations/0010_add_instance_alias.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+
+alter table instance add column alias varchar(256) default '';
+
+-- +migrate Down
+
+alter table instance drop column alias;

--- a/pkg/api/events_test.go
+++ b/pkg/api/events_test.go
@@ -18,7 +18,7 @@ func TestRegisterEvent_InvalidParams(t *testing.T) {
 	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	tInstance, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance, _ := a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
 	err := a.RegisterEvent(uuid.New().String(), tApp.ID, tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
 	assert.Equal(t, ErrInvalidInstance, err)
@@ -32,7 +32,7 @@ func TestRegisterEvent_InvalidParams(t *testing.T) {
 	err = a.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, EventUpdateDownloadStarted, ResultSuccess, "", "")
 	assert.Equal(t, ErrNoUpdateInProgress, err)
 
-	_, _ = a.GetUpdatePackage(tInstance.ID, "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.GetUpdatePackage(tInstance.ID, "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
 	err = a.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, 1000, ResultSuccess, "", "")
 	assert.Equal(t, ErrInvalidEventTypeOrResult, err)
@@ -50,10 +50,10 @@ func TestRegisterEvent_TriggerEventConsequences(t *testing.T) {
 	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	tInstance, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	tInstance2, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.2", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance, _ := a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance2, _ := a.RegisterInstance(uuid.New().String(), "", "10.0.0.2", "1.0.0", tApp.ID, tGroup.ID)
 
-	_, err := a.GetUpdatePackage(tInstance.ID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(tInstance.ID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
 	err = a.RegisterEvent(tInstance.ID, "{"+tApp.ID+"}", tGroup.ID, EventUpdateDownloadStarted, ResultSuccess, "", "")
@@ -76,7 +76,7 @@ func TestRegisterEvent_TriggerEventConsequences(t *testing.T) {
 	instance, _ = a.GetInstance(tInstance.ID, tApp.ID)
 	assert.Equal(t, null.IntFrom(int64(InstanceStatusComplete)), instance.Application.Status)
 
-	_, err = a.GetUpdatePackage(tInstance2.ID, "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(tInstance2.ID, "", "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
 	err = a.RegisterEvent(tInstance2.ID, tApp.ID, tGroup.ID, EventUpdateComplete, ResultFailed, "", "")
@@ -96,9 +96,9 @@ func TestRegisterEvent_TriggerEventConsequences_FirstUpdateAttemptFailed(t *test
 	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
-	tInstance, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	tInstance, _ := a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
-	_, err := a.GetUpdatePackage(tInstance.ID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(tInstance.ID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
 	err = a.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, EventUpdateComplete, ResultFailed, "", "")

--- a/pkg/api/groups_test.go
+++ b/pkg/api/groups_test.go
@@ -167,9 +167,9 @@ func TestGetGroupsFiltered(t *testing.T) {
 	realInstanceID := uuid.New().String()
 	fakeInstanceID1 := "{" + uuid.New().String() + "}"
 	fakeInstanceID2 := "{" + uuid.New().String() + "}"
-	_, _ = a.RegisterInstance(realInstanceID, "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	_, _ = a.RegisterInstance(fakeInstanceID1, "10.0.0.1", "2.0.0", tApp.ID, tGroup.ID)
-	_, _ = a.RegisterInstance(fakeInstanceID2, "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(realInstanceID, "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(fakeInstanceID1, "", "10.0.0.1", "2.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(fakeInstanceID2, "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
 	groups, err := a.GetGroups(tApp.ID, 0, 0)
 	assert.NoError(t, err)
@@ -199,7 +199,7 @@ func TestGetVersionCountTimeline(t *testing.T) {
 	tGroup, _ := a.AddGroup(&Group{Name: "test_group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 	instanceID := uuid.New().String()
 
-	_, _ = a.RegisterInstance(instanceID, "10.0.0.1", version, tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(instanceID, "", "10.0.0.1", version, tApp.ID, tGroup.ID)
 
 	instance, err := a.GetInstance(instanceID, tApp.ID)
 	assert.NoError(t, err)
@@ -245,14 +245,14 @@ func TestGetStatusCountTimeline(t *testing.T) {
 	instanceID1 := uuid.New().String()
 	instanceID2 := uuid.New().String()
 
-	_, _ = a.RegisterInstance(instanceID1, "10.0.0.1", version, tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(instanceID1, "", "10.0.0.1", version, tApp.ID, tGroup.ID)
 
 	instance1, err := a.GetInstance(instanceID1, tApp.ID)
 	assert.NoError(t, err)
 
 	_ = a.grantUpdate(instance1, version)
 	_ = a.updateInstanceStatus(instanceID1, tApp.ID, InstanceStatusComplete)
-	_, _ = a.RegisterInstance(instanceID2, "10.0.0.2", version, tApp.ID, tGroup.ID)
+	_, _ = a.RegisterInstance(instanceID2, "", "10.0.0.2", version, tApp.ID, tGroup.ID)
 
 	instance2, err := a.GetInstance(instanceID2, tApp.ID)
 	assert.NoError(t, err)

--- a/pkg/api/instances.go
+++ b/pkg/api/instances.go
@@ -56,6 +56,7 @@ type Instance struct {
 	IP          string              `db:"ip" json:"ip"`
 	CreatedTs   time.Time           `db:"created_ts" json:"created_ts"`
 	Application InstanceApplication `db:"application" json:"application,omitempty"`
+	Alias       string              `db:"alias" json:"alias,omitempty"`
 }
 type InstancesWithTotal struct {
 	TotalInstances uint64      `json:"total"`

--- a/pkg/api/instances.go
+++ b/pkg/api/instances.go
@@ -357,6 +357,27 @@ func (api *API) GetInstancesCount(p InstancesQueryParams, duration string) (uint
 	return totalCount, nil
 }
 
+func (api *API) UpdateInstance(instanceID string, alias string) (*Instance, error) {
+	instance := &Instance{}
+	query, _, err := goqu.Update("instance").
+		Set(
+			goqu.Record{
+				"alias": alias,
+			},
+		).
+		Where(goqu.C("id").Eq(instanceID)).
+		Returning(goqu.T("instance").All()).
+		ToSQL()
+	if err != nil {
+		return nil, err
+	}
+	err = api.db.QueryRowx(query).StructScan(instance)
+	if err != nil {
+		return nil, err
+	}
+	return instance, nil
+}
+
 // validateApplicationAndGroup validates if the group provided belongs to the
 // provided application, returning the normalized uuid version of the appID and
 // groupID provided if both are valid and the group belongs to the given

--- a/pkg/api/updates.go
+++ b/pkg/api/updates.go
@@ -57,8 +57,8 @@ var (
 // GetUpdatePackage returns an update package for the instance/application
 // provided. The instance details and the application it's running will be
 // registered in Nebraska (or updated if it's already registered).
-func (api *API) GetUpdatePackage(instanceID, instanceIP, instanceVersion, appID, groupID string) (*Package, error) {
-	instance, err := api.RegisterInstance(instanceID, instanceIP, instanceVersion, appID, groupID)
+func (api *API) GetUpdatePackage(instanceID, instanceAlias, instanceIP, instanceVersion, appID, groupID string) (*Package, error) {
+	instance, err := api.RegisterInstance(instanceID, instanceAlias, instanceIP, instanceVersion, appID, groupID)
 	if err != nil {
 		logger.Error("GetUpdatePackage - could not register instance (propagates as ErrRegisterInstanceFailed)", err)
 		return nil, ErrRegisterInstanceFailed

--- a/pkg/api/updates_test.go
+++ b/pkg/api/updates_test.go
@@ -25,28 +25,28 @@ func TestGetUpdatePackage(t *testing.T) {
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 	tGroup2, _ := a.AddGroup(&Group{Name: "group2", ApplicationID: tApp2.ID, ChannelID: null.StringFrom(tChannel2.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
-	_, err := a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", "invalidApplicationID", tGroup.ID)
+	_, err := a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "1.0.0", "invalidApplicationID", tGroup.ID)
 	assert.Error(t, ErrInvalidApplicationOrGroup, err, "Invalid application id.")
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, "invalidGroupID")
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, "invalidGroupID")
 	assert.Error(t, err, "Invalid group id.")
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", uuid.New().String(), tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "1.0.0", uuid.New().String(), tGroup.ID)
 	assert.Error(t, err, "Non existent application id.")
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, uuid.New().String())
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, uuid.New().String())
 	assert.Error(t, err, "Non existent group id.")
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup2.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup2.ID)
 	assert.Error(t, err, "Group doesn't belong to the application provided.")
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1.0.0", tApp2.ID, tGroup2.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp2.ID, tGroup2.ID)
 	assert.Equal(t, ErrNoPackageFound, err, "Group's channel has no package bound.")
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.1.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "12.1.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrNoUpdatePackageAvailable, err, "Instance version is up to date.")
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "1010.5.0+2016-05-27-1832", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "1010.5.0+2016-05-27-1832", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrNoUpdatePackageAvailable, err, "Instance version is up to date.")
 }
 
@@ -58,7 +58,7 @@ func TestGetUpdatePackage_GroupNoChannel(t *testing.T) {
 	tApp, _ := a.AddApp(&Application{Name: "test_app", TeamID: tTeam.ID})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, PolicyUpdatesEnabled: false, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
-	_, _ = a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Error(t, ErrNoPackageFound)
 }
 
@@ -72,7 +72,7 @@ func TestGetUpdatePackage_UpdatesDisabled(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: false, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
-	_, err := a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrUpdatesDisabled, err)
 }
 
@@ -88,10 +88,10 @@ func TestGetUpdatePackage_MaxUpdatesPerPeriodLimitReached_SafeMode(t *testing.T)
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: safeMode, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
-	_, err := a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxUpdatesPerPeriodLimitReached, err, "Safe mode is enabled, first update should be completed before letting more through.")
 }
 
@@ -106,16 +106,16 @@ func TestGetUpdatePackage_MaxUpdatesPerPeriodLimitReached_LimitUpdated(t *testin
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 1, PolicyUpdateTimeout: "60 minutes"})
 
 	instanceID := uuid.New().String()
-	_, err := a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(instanceID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxUpdatesPerPeriodLimitReached, err, "Max 1 update per period, limit reached")
 
 	tGroup.PolicyMaxUpdatesPerPeriod = 2
 	_ = a.UpdateGroup(tGroup)
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 }
 
@@ -136,23 +136,23 @@ func TestGetUpdatePackage_MaxUpdatesLimitsReached(t *testing.T) {
 
 	newInstance1ID := uuid.New().String()
 
-	_, err := a.GetUpdatePackage(newInstance1ID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(newInstance1ID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxUpdatesPerPeriodLimitReached, err)
 
 	time.Sleep(periodInterval + extraWaitPeriod) // ensure that period interval is over but update timeout isn't
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxConcurrentUpdatesLimitReached, err, "Period interval is over, but there are still two updates not completed or failed.")
 
 	_ = a.updateInstanceStatus(newInstance1ID, tApp.ID, InstanceStatusComplete)
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 }
 
@@ -172,20 +172,20 @@ func TestGetUpdatePackage_MaxTimedOutUpdatesLimitReached_SafeMode(t *testing.T) 
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: periodIntervalSetting, PolicyMaxUpdatesPerPeriod: 1, PolicyUpdateTimeout: updateTimeoutSetting})
 
-	_, err := a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
 	time.Sleep(periodInterval + extraWaitPeriod) // ensure that period interval is over but update timeout isn't
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxConcurrentUpdatesLimitReached, err)
 
 	time.Sleep(updateTimeout - periodInterval + extraWaitPeriod) // ensure that update timeout is over
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxTimedOutUpdatesLimitReached, err)
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrUpdatesDisabled, err)
 }
 
@@ -206,20 +206,20 @@ func TestGetUpdatePackage_ResumeUpdates(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: periodIntervalSetting, PolicyMaxUpdatesPerPeriod: maxUpdatesPerPeriod, PolicyUpdateTimeout: updateTimeoutSetting})
 
-	_, err := a.GetUpdatePackage(uuid.New().String(), "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
 	time.Sleep(periodInterval + extraWaitPeriod) // ensure that period interval is over but update timeout isn't
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrMaxConcurrentUpdatesLimitReached, err)
 
 	time.Sleep(updateTimeout - periodInterval + extraWaitPeriod) // ensure that update timeout is over
 
-	_, err = a.GetUpdatePackage(uuid.New().String(), "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(uuid.New().String(), "", "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 }
 
@@ -233,13 +233,13 @@ func TestGetUpdatePackage_RolloutStats(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "test_group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 4, PolicyUpdateTimeout: "60 minutes"})
 
-	instance1, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	instance2, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
-	instance3, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	instance1, _ := a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	instance2, _ := a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	instance3, _ := a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
-	_, _ = a.GetUpdatePackage(instance1.ID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
-	_, _ = a.GetUpdatePackage(instance2.ID, "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
-	_, _ = a.GetUpdatePackage(instance3.ID, "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.GetUpdatePackage(instance1.ID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.GetUpdatePackage(instance2.ID, "", "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.GetUpdatePackage(instance3.ID, "", "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 
 	group, _ := a.GetGroup(tGroup.ID)
 	assert.True(t, group.RolloutInProgress)
@@ -257,8 +257,8 @@ func TestGetUpdatePackage_RolloutStats(t *testing.T) {
 	assert.Equal(t, int64(2), stats.OnHold.Int64)
 
 	_ = a.RegisterEvent(instance1.ID, tApp.ID, tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
-	_, _ = a.GetUpdatePackage(instance2.ID, "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
-	_, _ = a.GetUpdatePackage(instance3.ID, "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.GetUpdatePackage(instance2.ID, "", "10.0.0.2", "12.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.GetUpdatePackage(instance3.ID, "", "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 
 	group, _ = a.GetGroup(tGroup.ID)
 	assert.True(t, group.RolloutInProgress)
@@ -275,7 +275,7 @@ func TestGetUpdatePackage_RolloutStats(t *testing.T) {
 	assert.Equal(t, int64(2), stats.Complete.Int64)
 	assert.Equal(t, int64(1), stats.Error.Int64)
 
-	_, _ = a.GetUpdatePackage(instance3.ID, "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.GetUpdatePackage(instance3.ID, "", "10.0.0.3", "12.0.0", tApp.ID, tGroup.ID)
 	_ = a.RegisterEvent(instance3.ID, tApp.ID, tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
 
 	group, _ = a.GetGroup(tGroup.ID)
@@ -296,10 +296,10 @@ func TestGetUpdatePackage_UpdateInProgressOnInstance(t *testing.T) {
 
 	instanceID := uuid.New().String()
 
-	p1, err := a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	p1, err := a.GetUpdatePackage(instanceID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
-	p2, err := a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	p2, err := a.GetUpdatePackage(instanceID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, p1, p2)
 
@@ -310,7 +310,7 @@ func TestGetUpdatePackage_UpdateInProgressOnInstance(t *testing.T) {
 
 	err = a.updateInstanceStatus(instanceID, tApp.ID, InstanceStatusDownloading)
 	assert.NoError(t, err)
-	_, err = a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(instanceID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrUpdateInProgressOnInstance, err)
 }
 
@@ -326,7 +326,7 @@ func TestGetUpdatePackage_CheckVersionForGrantedUpdate(t *testing.T) {
 
 	instanceID := uuid.New().String()
 
-	_, err := a.GetUpdatePackage(instanceID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, err := a.GetUpdatePackage(instanceID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	assert.NoError(t, err)
 
 	instance, err := a.GetInstance(instanceID, tApp.ID)
@@ -336,7 +336,7 @@ func TestGetUpdatePackage_CheckVersionForGrantedUpdate(t *testing.T) {
 	assert.Equal(t, "12.1.0", instance.Application.LastUpdateVersion.String)
 	assert.Equal(t, "12.0.0", instance.Application.Version)
 
-	_, err = a.GetUpdatePackage(instanceID, "10.0.0.1", "12.1.0", tApp.ID, tGroup.ID)
+	_, err = a.GetUpdatePackage(instanceID, "", "10.0.0.1", "12.1.0", tApp.ID, tGroup.ID)
 	assert.Equal(t, ErrNoUpdatePackageAvailable, err)
 
 	instanceStatusHistory, err := a.GetInstanceStatusHistory(instanceID, tApp.ID, tGroup.ID, 1)
@@ -355,9 +355,9 @@ func TestGetUpdatePackage_InstanceStatusHistory(t *testing.T) {
 	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
 	tGroup, _ := a.AddGroup(&Group{Name: "test_group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 3, PolicyUpdateTimeout: "60 minutes"})
 
-	instance1, _ := a.RegisterInstance(uuid.New().String(), "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+	instance1, _ := a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 
-	_, _ = a.GetUpdatePackage(instance1.ID, "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+	_, _ = a.GetUpdatePackage(instance1.ID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
 	_ = a.RegisterEvent(instance1.ID, tApp.ID, tGroup.ID, EventUpdateDownloadStarted, ResultSuccess, "", "")
 	_ = a.RegisterEvent(instance1.ID, tApp.ID, tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
 

--- a/pkg/omaha/omaha.go
+++ b/pkg/omaha/omaha.go
@@ -118,14 +118,14 @@ func (h *Handler) buildOmahaResponse(omahaReq *omahaSpec.Request, ip string) (*o
 		}
 
 		if reqApp.Ping != nil {
-			if _, err := h.crAPI.RegisterInstance(reqApp.MachineID, ip, reqApp.Version, reqApp.ID, group); err != nil {
+			if _, err := h.crAPI.RegisterInstance(reqApp.MachineID, reqApp.MachineAlias, ip, reqApp.Version, reqApp.ID, group); err != nil {
 				logger.Warn("processPing", "error", err.Error())
 			}
 			respApp.AddPing()
 		}
 
 		if reqApp.UpdateCheck != nil {
-			pkg, err := h.crAPI.GetUpdatePackage(reqApp.MachineID, ip, reqApp.Version, reqApp.ID, group)
+			pkg, err := h.crAPI.GetUpdatePackage(reqApp.MachineID, reqApp.MachineAlias, ip, reqApp.Version, reqApp.ID, group)
 			if err != nil && err != api.ErrNoUpdatePackageAvailable {
 				respApp.Status = h.getStatusMessage(err)
 				respApp.AddUpdateCheck(omahaSpec.UpdateInternalError)


### PR DESCRIPTION
We want users to be able to rename instances in order to more easily identify them.

This PR adds a new `alias` column to the instance table, the respective update endpoint, and the UI changes.
