### PR TITLE
backend: Don't fetch group stats in events unless it's really needed

### DIFF
--- a/pkg/api/events.go
+++ b/pkg/api/events.go
@@ -210,12 +210,12 @@ func (api *API) triggerEventConsequences(instanceID, appID, groupID, lastUpdateV
 			logger.Error("triggerEventConsequences - could not add instance activity", err)
 		}
 
-		updatesStats, err := api.getGroupUpdatesStats(group)
-		if err != nil {
-			return err
-		}
-		if updatesStats.UpdatesToCurrentVersionAttempted == 1 {
-			if api.disableUpdatesOnFailedRollout {
+		if api.disableUpdatesOnFailedRollout {
+			updatesStats, err := api.getGroupUpdatesStats(group)
+			if err != nil {
+				return err
+			}
+			if updatesStats.UpdatesToCurrentVersionAttempted == 1 {
 				if err := api.disableUpdates(groupID); err != nil {
 					logger.Error("triggerEventConsequences - could not disable updates", err)
 				}


### PR DESCRIPTION
The group's stats take a while to fetch, and they were being fetched
only to be used solely if the "disableUpdatesOnFailedRollout" is true.
So the group's stats should rather be gathered only if the mentioned
setting is true which is much quicker to check, and moreover, this
setting is only true during the tests.

This patch thus switches the order of fetching the group's stats +
checking the mentioned setting, which should make things faster.
