### PR TITLE
Optimisations for slow queries in instance_application table

### DIFF
--- a/pkg/api/applications.go
+++ b/pkg/api/applications.go
@@ -147,7 +147,7 @@ func (api *API) DeleteApp(appID string) error {
 // GetApp returns the application identified by the id provided.
 func (api *API) GetApp(appID string) (*Application, error) {
 	var app Application
-	query, _, err := api.appsQuery().
+	query, _, err := goqu.From("application").
 		Where(goqu.C("id").Eq(appID)).ToSQL()
 	if err != nil {
 		return nil, err

--- a/pkg/api/bindata.go
+++ b/pkg/api/bindata.go
@@ -12,6 +12,7 @@
 // db/migrations/0008-arm-channels-groups.sql (3.854kB)
 // db/migrations/0009_group_track_names.sql (973B)
 // db/migrations/0010_add_instance_alias.sql (138B)
+// db/migrations/0011_add_index_instance_application.sql (447B)
 
 package api
 
@@ -320,6 +321,26 @@ func dbMigrations0010_add_instance_aliasSql() (*asset, error) {
 	return a, nil
 }
 
+var _dbMigrations0011_add_index_instance_applicationSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xa4\x90\x31\xae\xc2\x30\x0c\x86\xf7\x9c\x22\xea\xd4\xa7\x97\x9e\xa0\x2b\x57\x60\xb6\xa2\xc4\xaa\x2c\x95\x24\xb2\x4d\x29\xb7\x47\x05\x02\x2d\xea\x04\x5b\x64\xeb\xfb\xf2\xfb\xef\x3a\xfb\x7f\xa2\x81\xbd\xa2\x3d\x16\x63\x02\xe3\xf2\xa4\x14\x71\xb6\x94\x44\x7d\x0a\x08\xbe\x94\x91\x82\x57\xca\x09\x5e\x43\x8a\xdb\x79\x04\x8a\xb3\xcd\x69\x17\xb3\xed\x8a\x73\x5b\xee\xaf\xff\xf8\xd7\x07\xa5\x89\xf4\x0a\x61\xf4\x22\xf0\xd8\x45\x50\x01\xc1\x09\x79\xd9\x4c\xc8\xb2\xd0\x03\xe7\x73\x59\x45\xa9\x19\xaa\xc2\xb6\x77\x87\x7b\x3b\x5c\x75\xb8\xe6\x29\x69\x5c\xb5\xec\x04\x5b\x17\x74\xc8\x97\x64\x4c\xe4\x5c\xbe\x2f\xa8\xdf\x08\x7e\xbc\xb4\xbf\x05\x00\x00\xff\xff\xc4\x32\x78\x87\xbf\x01\x00\x00")
+
+func dbMigrations0011_add_index_instance_applicationSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_dbMigrations0011_add_index_instance_applicationSql,
+		"db/migrations/0011_add_index_instance_application.sql",
+	)
+}
+
+func dbMigrations0011_add_index_instance_applicationSql() (*asset, error) {
+	bytes, err := dbMigrations0011_add_index_instance_applicationSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "db/migrations/0011_add_index_instance_application.sql", size: 447, mode: os.FileMode(0644), modTime: time.Unix(1, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xea, 0xae, 0xcd, 0x92, 0xd3, 0xf9, 0x5, 0xd8, 0x82, 0x13, 0x6, 0xd5, 0x51, 0xfe, 0xac, 0x88, 0x40, 0xb1, 0xed, 0x75, 0xe8, 0x80, 0x87, 0x91, 0x12, 0xa0, 0x59, 0xcb, 0x72, 0xfc, 0x77, 0x80}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -411,18 +432,19 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"db/drop_all_tables.sql":                      dbDrop_all_tablesSql,
-	"db/sample_data.sql":                          dbSample_dataSql,
-	"db/migrations/0001_initial.sql":              dbMigrations0001_initialSql,
-	"db/migrations/0002_event_data.sql":           dbMigrations0002_event_dataSql,
-	"db/migrations/0003_longer_team_names.sql":    dbMigrations0003_longer_team_namesSql,
-	"db/migrations/0004_rename_coreos_action.sql": dbMigrations0004_rename_coreos_actionSql,
-	"db/migrations/0005_default_team_id.sql":      dbMigrations0005_default_team_idSql,
-	"db/migrations/0006_initial_application.sql":  dbMigrations0006_initial_applicationSql,
-	"db/migrations/0007_add_package_arch.sql":     dbMigrations0007_add_package_archSql,
-	"db/migrations/0008-arm-channels-groups.sql":  dbMigrations0008ArmChannelsGroupsSql,
-	"db/migrations/0009_group_track_names.sql":    dbMigrations0009_group_track_namesSql,
-	"db/migrations/0010_add_instance_alias.sql":   dbMigrations0010_add_instance_aliasSql,
+	"db/drop_all_tables.sql":                                dbDrop_all_tablesSql,
+	"db/sample_data.sql":                                    dbSample_dataSql,
+	"db/migrations/0001_initial.sql":                        dbMigrations0001_initialSql,
+	"db/migrations/0002_event_data.sql":                     dbMigrations0002_event_dataSql,
+	"db/migrations/0003_longer_team_names.sql":              dbMigrations0003_longer_team_namesSql,
+	"db/migrations/0004_rename_coreos_action.sql":           dbMigrations0004_rename_coreos_actionSql,
+	"db/migrations/0005_default_team_id.sql":                dbMigrations0005_default_team_idSql,
+	"db/migrations/0006_initial_application.sql":            dbMigrations0006_initial_applicationSql,
+	"db/migrations/0007_add_package_arch.sql":               dbMigrations0007_add_package_archSql,
+	"db/migrations/0008-arm-channels-groups.sql":            dbMigrations0008ArmChannelsGroupsSql,
+	"db/migrations/0009_group_track_names.sql":              dbMigrations0009_group_track_namesSql,
+	"db/migrations/0010_add_instance_alias.sql":             dbMigrations0010_add_instance_aliasSql,
+	"db/migrations/0011_add_index_instance_application.sql": dbMigrations0011_add_index_instance_applicationSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -469,16 +491,17 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"db": &bintree{nil, map[string]*bintree{
 		"drop_all_tables.sql": &bintree{dbDrop_all_tablesSql, map[string]*bintree{}},
 		"migrations": &bintree{nil, map[string]*bintree{
-			"0001_initial.sql":              &bintree{dbMigrations0001_initialSql, map[string]*bintree{}},
-			"0002_event_data.sql":           &bintree{dbMigrations0002_event_dataSql, map[string]*bintree{}},
-			"0003_longer_team_names.sql":    &bintree{dbMigrations0003_longer_team_namesSql, map[string]*bintree{}},
-			"0004_rename_coreos_action.sql": &bintree{dbMigrations0004_rename_coreos_actionSql, map[string]*bintree{}},
-			"0005_default_team_id.sql":      &bintree{dbMigrations0005_default_team_idSql, map[string]*bintree{}},
-			"0006_initial_application.sql":  &bintree{dbMigrations0006_initial_applicationSql, map[string]*bintree{}},
-			"0007_add_package_arch.sql":     &bintree{dbMigrations0007_add_package_archSql, map[string]*bintree{}},
-			"0008-arm-channels-groups.sql":  &bintree{dbMigrations0008ArmChannelsGroupsSql, map[string]*bintree{}},
-			"0009_group_track_names.sql":    &bintree{dbMigrations0009_group_track_namesSql, map[string]*bintree{}},
-			"0010_add_instance_alias.sql":   &bintree{dbMigrations0010_add_instance_aliasSql, map[string]*bintree{}},
+			"0001_initial.sql":                        &bintree{dbMigrations0001_initialSql, map[string]*bintree{}},
+			"0002_event_data.sql":                     &bintree{dbMigrations0002_event_dataSql, map[string]*bintree{}},
+			"0003_longer_team_names.sql":              &bintree{dbMigrations0003_longer_team_namesSql, map[string]*bintree{}},
+			"0004_rename_coreos_action.sql":           &bintree{dbMigrations0004_rename_coreos_actionSql, map[string]*bintree{}},
+			"0005_default_team_id.sql":                &bintree{dbMigrations0005_default_team_idSql, map[string]*bintree{}},
+			"0006_initial_application.sql":            &bintree{dbMigrations0006_initial_applicationSql, map[string]*bintree{}},
+			"0007_add_package_arch.sql":               &bintree{dbMigrations0007_add_package_archSql, map[string]*bintree{}},
+			"0008-arm-channels-groups.sql":            &bintree{dbMigrations0008ArmChannelsGroupsSql, map[string]*bintree{}},
+			"0009_group_track_names.sql":              &bintree{dbMigrations0009_group_track_namesSql, map[string]*bintree{}},
+			"0010_add_instance_alias.sql":             &bintree{dbMigrations0010_add_instance_aliasSql, map[string]*bintree{}},
+			"0011_add_index_instance_application.sql": &bintree{dbMigrations0011_add_index_instance_applicationSql, map[string]*bintree{}},
 		}},
 		"sample_data.sql": &bintree{dbSample_dataSql, map[string]*bintree{}},
 	}},

--- a/pkg/api/channels.go
+++ b/pkg/api/channels.go
@@ -134,7 +134,7 @@ func (api *API) DeleteChannel(channelID string) error {
 func (api *API) GetChannel(channelID string) (*Channel, error) {
 	var channel Channel
 
-	query, _, err := api.channelsQuery().
+	query, _, err := goqu.From("channel").
 		Where(goqu.C("id").Eq(channelID)).
 		ToSQL()
 	if err != nil {
@@ -159,7 +159,7 @@ func (api *API) GetChannel(channelID string) (*Channel, error) {
 func (api *API) getSpecificChannels(channelID ...string) ([]*Channel, error) {
 	var channels []*Channel
 
-	query, _, err := api.channelsQuery().
+	query, _, err := goqu.From("channel").
 		Where(goqu.Ex{"id": channelID}).
 		ToSQL()
 	if err != nil {

--- a/pkg/api/db/migrations/0011_add_index_instance_application.sql
+++ b/pkg/api/db/migrations/0011_add_index_instance_application.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+
+create index instance_application_instance_id_application_id_idx on instance_application (instance_id,application_id);
+
+create index activity_class_created_ts_severity_version_group_id_applica_idx on activity (class,created_ts,severity,"version",group_id,application_id);
+
+-- +migrate Down
+
+drop index instance_application_instance_id_application_id_idx;
+
+drop index activity_class_created_ts_severity_version_group_id_applica_idx;

--- a/pkg/api/groups.go
+++ b/pkg/api/groups.go
@@ -262,7 +262,7 @@ func (api *API) DeleteGroup(groupID string) error {
 func (api *API) GetGroup(groupID string) (*Group, error) {
 	var group Group
 
-	query, _, err := api.groupsQuery().
+	query, _, err := goqu.From("groups").
 		Where(goqu.C("id").Eq(groupID)).
 		ToSQL()
 	if err != nil {
@@ -308,7 +308,7 @@ func (api *API) GetGroupID(trackName string, arch Arch) (string, error) {
 		// before the generation because all writes are sequential.
 		if cachedGroupsRef == nil {
 			cachedGroups = make(map[GroupDescriptor]string)
-			query, _, err := api.groupsQuery().ToSQL()
+			query, _, err := goqu.From("groups").ToSQL()
 			var groups []*Group
 			if err == nil {
 				groups, err = api.getGroupsFromQuery(query)

--- a/pkg/api/instances.go
+++ b/pkg/api/instances.go
@@ -470,8 +470,7 @@ func (api *API) instanceAppQuery(appID, instanceID string, duration postgresDura
 	query := goqu.From("instance_application").
 		Select("version", "status", "last_check_for_updates", "last_update_version", "update_in_progress", "application_id", "group_id").
 		Where(goqu.C("instance_id").Eq(instanceID), goqu.C("application_id").Eq(appID)).
-		Where(goqu.L("last_check_for_updates > now() at time zone 'utc' - interval ?", duration)).
-		Where(goqu.L(ignoreFakeInstanceCondition("instance_id")))
+		Where(goqu.L("last_check_for_updates > now() at time zone 'utc' - interval ?", duration))
 	return query
 }
 


### PR DESCRIPTION
From the RDS performance insights, the query on instance_application table is slow. The composite index and removal of extra query parameters will boost the performance. See the attached pictures for the difference in query planner.

Query: 
---
SELECT "version", "status", "last_check_for_updates", "last_update_version", "update_in_progress", "application_id", "group_id" FROM "instance_application" WHERE (("instance_id" = ?) AND ("application_id" = ?) AND last_check_for_updates > now() at time zone ? - interval ? AND (instance_id IS NULL OR instance_id NOT SIMILAR TO ?))

Before composite index
![image](https://user-images.githubusercontent.com/22731013/104211690-64cedb00-545a-11eb-8901-20ea4ca82693.png)


After composite index
![image](https://user-images.githubusercontent.com/22731013/104211667-5d0f3680-545a-11eb-95d5-e7a11d000cf5.png)
---