### PR TITLE
Optimise performance of analytics queries

### DIFF
--- a/pkg/api/bindata.go
+++ b/pkg/api/bindata.go
@@ -14,6 +14,7 @@
 // db/migrations/0010_add_instance_alias.sql (138B)
 // db/migrations/0011_add_composite_indexes.sql (760B)
 // db/migrations/0012_drop_unused_indexes.sql (696B)
+// db/migrations/0013_add_stats_indexes.sql (426B)
 
 package api
 
@@ -362,6 +363,26 @@ func dbMigrations0012_drop_unused_indexesSql() (*asset, error) {
 	return a, nil
 }
 
+var _dbMigrations0013_add_stats_indexesSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xac\x90\x4d\x0a\xc2\x30\x10\x85\xf7\x39\x45\x96\x15\xdb\x13\x74\xeb\x15\x5c\x0f\x43\x26\xb6\x83\x35\x13\x32\x53\xac\xb7\x97\x52\xea\x0f\x56\x70\xe1\x2e\x0f\xf2\x7d\x79\x79\x4d\xe3\xf7\x17\xee\x0a\x5a\xf4\xc7\xec\x5c\x28\x71\x3e\x72\xa2\x38\x79\x4e\x6a\x98\x42\x04\xcc\x79\xe0\x80\xc6\x92\xa0\x2b\x32\x66\x60\x82\x01\xd5\x20\xf4\x31\x9c\xe1\x24\x05\xc6\x4c\x68\x51\x61\x81\x80\x69\xf2\x92\x36\x15\xd5\xaa\xa8\xb7\x15\xf5\x03\x62\xda\xb5\xdf\x3a\xa9\xa1\x8d\x0a\x3d\xab\x49\xb9\xad\x71\xb9\x4b\x60\xfa\xd1\xe0\x1d\xa8\x96\x58\x3f\x81\xf9\xa9\xd7\x39\x0e\x72\x4d\xce\x51\x91\xfc\x9f\x39\xda\x6d\xd9\x2f\xff\x68\x9d\x73\xf7\x00\x00\x00\xff\xff\xed\xea\xb4\xcb\xaa\x01\x00\x00")
+
+func dbMigrations0013_add_stats_indexesSqlBytes() ([]byte, error) {
+	return bindataRead(
+		_dbMigrations0013_add_stats_indexesSql,
+		"db/migrations/0013_add_stats_indexes.sql",
+	)
+}
+
+func dbMigrations0013_add_stats_indexesSql() (*asset, error) {
+	bytes, err := dbMigrations0013_add_stats_indexesSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "db/migrations/0013_add_stats_indexes.sql", size: 426, mode: os.FileMode(0644), modTime: time.Unix(1, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xce, 0x3d, 0xd6, 0x1b, 0x3a, 0x65, 0xee, 0x1, 0x5a, 0x5a, 0x78, 0xa, 0xcd, 0xb5, 0xfe, 0x75, 0xd4, 0x88, 0xd5, 0x26, 0x78, 0x4, 0x8f, 0x12, 0x25, 0x50, 0xc7, 0x31, 0xc, 0x3c, 0x4f, 0x7b}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -467,6 +488,7 @@ var _bindata = map[string]func() (*asset, error){
 	"db/migrations/0010_add_instance_alias.sql":    dbMigrations0010_add_instance_aliasSql,
 	"db/migrations/0011_add_composite_indexes.sql": dbMigrations0011_add_composite_indexesSql,
 	"db/migrations/0012_drop_unused_indexes.sql":   dbMigrations0012_drop_unused_indexesSql,
+	"db/migrations/0013_add_stats_indexes.sql":     dbMigrations0013_add_stats_indexesSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -525,6 +547,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"0010_add_instance_alias.sql":    &bintree{dbMigrations0010_add_instance_aliasSql, map[string]*bintree{}},
 			"0011_add_composite_indexes.sql": &bintree{dbMigrations0011_add_composite_indexesSql, map[string]*bintree{}},
 			"0012_drop_unused_indexes.sql":   &bintree{dbMigrations0012_drop_unused_indexesSql, map[string]*bintree{}},
+			"0013_add_stats_indexes.sql":     &bintree{dbMigrations0013_add_stats_indexesSql, map[string]*bintree{}},
 		}},
 		"sample_data.sql": &bintree{dbSample_dataSql, map[string]*bintree{}},
 	}},

--- a/pkg/api/db/migrations/0013_add_stats_indexes.sql
+++ b/pkg/api/db/migrations/0013_add_stats_indexes.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+
+create index instance_application_group_id_last_check_for_updates_instan_idx on instance_application(group_id,last_check_for_updates,instance_id);
+
+create index instance_status_history_status_created_ts_idx on instance_status_history(status,created_ts);
+
+-- +migrate Down
+
+drop index instance_application_group_id_last_check_for_updates_instan_idx;
+
+drop index instance_status_history_status_created_ts_idx;
+
+

--- a/pkg/api/groups.go
+++ b/pkg/api/groups.go
@@ -4,11 +4,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"gopkg.in/guregu/null.v4"
 )
 
@@ -589,6 +591,29 @@ func (api *API) GetGroupVersionCountTimeline(groupID string, duration string) (m
 	if err != nil {
 		return nil, err
 	}
+
+	instanceQuery, _, err := goqu.From("instance_application").Select(goqu.L("array_agg(DISTINCT (\"instance_id\")) \"instance_id\"")).Where(goqu.C("group_id").Eq(groupID),
+		goqu.L(fmt.Sprintf("last_check_for_updates >= now() - interval '%s'", durationString)),
+		goqu.L(ignoreFakeInstanceCondition("instance_id"))).ToSQL()
+
+	if err != nil {
+		return nil, err
+	}
+	ids := []string{}
+	err = api.db.QueryRowx(instanceQuery).Scan(pq.Array(&ids))
+	if err != nil {
+		return nil, err
+	}
+	values := "VALUES "
+	for _, id := range ids {
+		values = values + fmt.Sprintf("('%s'),", id)
+	}
+	values = strings.TrimRight(values, ",")
+
+	if len(ids) == 0 {
+		values = values + "('')"
+	}
+
 	query := fmt.Sprintf(`
 	WITH time_series AS (SELECT * FROM generate_series(now() - interval '%[1]s', now(), INTERVAL '%[2]s') AS ts),
 		 recent_instances AS (SELECT instance_id, (CASE WHEN last_update_granted_ts 
@@ -596,7 +621,7 @@ func (api *API) GetGroupVersionCountTimeline(groupID string, duration string) (m
 			instance_application WHERE group_id=$1 AND 
 			last_check_for_updates >= now() - interval '%[1]s' AND %[3]s ORDER BY last_update_granted_ts DESC),
 		 instance_versions AS (SELECT instance_id, created_ts, version, status 
-			FROM instance_status_history WHERE instance_id IN (SELECT instance_id FROM recent_instances) 
+			FROM instance_status_history WHERE instance_id = ANY (%[5]s) 
 			AND status = 4 UNION (SELECT * FROM recent_instances) ORDER BY created_ts DESC)
 	SELECT ts, (CASE WHEN version IS NULL THEN '' ELSE version END), 
 	  sum(CASE WHEN version IS NOT null THEN 1 ELSE 0 END) total 
@@ -608,7 +633,7 @@ func (api *API) GetGroupVersionCountTimeline(groupID string, duration string) (m
 	GROUP BY 1,2
 	ORDER BY ts DESC;
 	`, durationString, interval, ignoreFakeInstanceCondition("instance_id"),
-		ignoreFakeInstanceCondition("instance_Id"))
+		ignoreFakeInstanceCondition("instance_Id"), values)
 	rows, err := api.db.Queryx(query, groupID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
1. Index: `instance_application_group_id_last_check_for_updates_instan_idx`
Improves the performance of GetGroupInstancesStats. Earlier the query goes through a `sequential scan`.
Before:
![image](https://user-images.githubusercontent.com/22731013/109174410-d6fd4400-77aa-11eb-9aa2-d61908fab519.png)

After:
![image](https://user-images.githubusercontent.com/22731013/109174448-df557f00-77aa-11eb-9e70-55367a430917.png)

Improvement `1s698ms` to `98ms`

2. `GetGroupVersionCountTimeline` is broken down into two queries.
The IN operator in the query is costly and performance varies based on the number of recent_instances. 
Refer: https://www.datadoghq.com/blog/100x-faster-postgres-performance-by-changing-1-line/

Old query: 16m23s
New: 2m50s (query 1: 3s393s+query 1: 2m47s)

Note: The performance improvement increases exponentially with the increase in the number of recent instances

