### PR TITLE
chart: Add option for separate /v1/update and /flatcar ingress

### DIFF
--- a/charts/nebraska/Chart.yaml
+++ b/charts/nebraska/Chart.yaml
@@ -19,7 +19,7 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 0.1.1
+version: 0.1.2
 appVersion: "2.3.2"
 
 dependencies:

--- a/charts/nebraska/templates/update-ingress.yaml
+++ b/charts/nebraska/templates/update-ingress.yaml
@@ -46,7 +46,12 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
             {{- end }}
+          {{- if $.Values.config.hostFlatcarPackages.enabled }}
+          {{- if regexFind ( printf "://%s(:[0-9]+)?/" . ) ( default "" $.Values.config.hostFlatcarPackages.nebraskaURL ) }}
+          - path: {{ regexReplaceAll "^[^/]+://[^/]+" $.Values.config.hostFlatcarPackages.nebraskaURL "" | trimAll "/" }}/flatcar
+          {{- else }}
           - path: /flatcar
+          {{- end }}
             backend:
             {{- if semverCompare ">=1.19-0" $kubeGitVersion }}
               service:
@@ -58,5 +63,6 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
             {{- end }}
+          {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/nebraska/templates/update-ingress.yaml
+++ b/charts/nebraska/templates/update-ingress.yaml
@@ -1,0 +1,62 @@
+{{- if and .Values.ingress.enabled .Values.ingress.update.enabled }}
+{{- $fullName := include "nebraska.fullname" . }}
+{{- $svcPort := .Values.service.port }}
+{{- $kubeGitVersion := .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.19-0" $kubeGitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $kubeGitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName | trunc 56 | trimSuffix "-" }}-update
+  labels:
+    {{- include "nebraska.labels" . | nindent 4 }}
+  {{- with .Values.ingress.update.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /v1/update
+            backend:
+            {{- if semverCompare ">=1.19-0" $kubeGitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            pathType: ImplementationSpecific
+            {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+            {{- end }}
+          - path: /flatcar
+            backend:
+            {{- if semverCompare ">=1.19-0" $kubeGitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            pathType: ImplementationSpecific
+            {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+            {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/nebraska/values.yaml
+++ b/charts/nebraska/values.yaml
@@ -116,6 +116,11 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  update:
+    # Create a separate ingress for the /v1/update and /flatcar paths,
+    # with it's own annotations.
+    enabled: false
+    annotations: {}
   hosts:
     - flatcar.example.com
   tls: []


### PR DESCRIPTION
# Add option for separate /v1/update and /flatcar ingress

Optionally add an extra ingress handling paths /v1/update and /flatcar,
allowing different whitelisting options to the user interface and the
update endpoints.

# How to use

Enable extra ingress and set different annotations. Example `values.yaml` snippet:

```
ingress:
  enabled: true
  annotations:
    # address anonymized
    nginx.ingress.kubernetes.io/whitelist-source-range: 172.23.68.21
  update:
    enabled: true
    annotations: {}
```

# Testing done

Web interface is only accessible from `172.23.68.21`, flatcar nodes from anywhere can be upgraded.
