### PR TITLE
backend: Do not fail when trying to log without a session

### DIFF
--- a/cmd/nebraska/controller.go
+++ b/cmd/nebraska/controller.go
@@ -60,6 +60,10 @@ type controllerConfig struct {
 
 func loggerWithUsername(l zerolog.Logger, c *gin.Context) zerolog.Logger {
 	session := ginsessions.GetSession(c)
+	if session == nil {
+		return logger
+	}
+
 	username := session.Get("username")
 
 	return logger.With().Str("username", username.(string)).Logger()


### PR DESCRIPTION
We have the noop auth backend which has no session set, and due to the
recent changes to set the user in the log context, it was failing.
