### PR TITLE
frontend: Prevent issue when the client config is not stored

### DIFF
--- a/frontend/src/js/components/Header.tsx
+++ b/frontend/src/js/components/Header.tsx
@@ -132,7 +132,7 @@ export default function Header() {
 
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<HTMLButtonElement | null>(null);
   const [config, setConfig] = React.useState<NebraskaConfig>(
-    JSON.parse(localStorage.getItem('nebraska_config') || "") as NebraskaConfig
+    JSON.parse(localStorage.getItem('nebraska_config') || "{}") as NebraskaConfig
   );
 
   function handleMenu(event: React.MouseEvent<HTMLButtonElement>) {


### PR DESCRIPTION
The frontend was trying to parse an empty string if the client config
was not yet stored locally, and this resulted in an error.
Effectively, this prevented getting the UI when accessing Nebraska for
the first time (in whatever the deployment URL was).
