### PR TITLE
frontend: Fix labels for instance status area chart

### DIFF
--- a/frontend/src/js/components/Instances/Charts.tsx
+++ b/frontend/src/js/components/Instances/Charts.tsx
@@ -117,7 +117,7 @@ function ProgressDoughnut(props: ProgressDoughnutProps) {
             radius={radius}
             innerRadius={radius * 0.8}
             padAngle={0.5}
-            labels={undefined}
+            labels={() => null}
             style={{
               data: { fill: ({ datum }) => datum.color },
             }}


### PR DESCRIPTION
We don't want to show any label on instance status pie chart, the
correct way to not render any label is to pass a component to labels
prop which renders null.

## Testing done
Yes
