### PR TITLE
backend: Fix check_pkg_test.sh script to use env bash

### DIFF
--- a/backend/tools/check_pkg_test.sh
+++ b/backend/tools/check_pkg_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script checks if all the packages in the running directory or
 # below support skipping the tests if the NEBRASKA_SKIP_TESTS is


### PR DESCRIPTION
mapfile is not in older bash versions, so check_pkg_test.sh does not work.

On Mac for example, bash 5 can be installed but not as /bin/bash. /bin/bash is the ye-olde-system version of bash that does not support mapfile. This PR fix allows people who have a newer version of bash installed have `make` work. 

---

ps. An alternative to this PR would be to rewrite check_pkg_test.sh to not use mapfile... but if we're going to make it more portable, maybe it would be better to redo it in go or node? So instead of doing either of those, this PR/quick-fix at least makes it work on mac(and alt-shell users) for people who have bash 5 installed.