### PR TITLE
chart: allow overriding the nebraska-url argument

### DIFF
--- a/charts/nebraska/templates/deployment.yaml
+++ b/charts/nebraska/templates/deployment.yaml
@@ -70,10 +70,10 @@ spec:
             {{- if .Values.config.hostFlatcarPackages.enabled }}
             - "-host-flatcar-packages"
             - "-flatcar-packages-path={{ required "A valid 'packagesPath' is required when hosting Flatcar packages." .Values.config.hostFlatcarPackages.packagesPath }}"
-              {{- if .Values.ingress.enabled }}
-            - "-nebraska-url={{ printf "%s://%s"  (include "nebraska.ingressScheme" .) (index .Values.ingress.hosts 0) }}"
-              {{- else if .Values.config.hostFlatcarPackages.nebraskaURL }}
+              {{- if .Values.config.hostFlatcarPackages.nebraskaURL }}
             - "-nebraska-url={{ .Values.config.hostFlatcarPackages.nebraskaURL }}"
+              {{- else if .Values.ingress.enabled }}
+            - "-nebraska-url={{ printf "%s://%s"  (include "nebraska.ingressScheme" .) (index .Values.ingress.hosts 0) }}"
               {{- end }}
             {{- end }}
 


### PR DESCRIPTION
# chart: allow overriding the nebraska-url argument

This changes changes the order of if-else statements in the deployment, making `.Values.config.hostFlatcarPackages.nebraskaURL` have precedence over the values generated from `.Values.ingress`

For our use case, this allows us to specify a `https` url rather than a `http` url, as our ingress controller implicitly adds and forces TLS, even when not specifying `spec.tls` in the `Ingress` resource. Another use case could be different internal and external hostnames when using a load balancer.

## How to use

Specify values of `ingress.enabled: true` and `config.hostFlatcarPackages.nebraskaURL: <some valid url>`. The specified URL now will be templated into the `Deployment` resource as the argument to `-nebraska-url`.

## Testing done

Using a values-file containing the following and more:
```
config:
  hostFlatcarPackages:
    nebraskaURL: "https://example.com"

ingress:
  enabled: true
  hosts:
    - nebraska.example.com
    - nebraska.example.org
  tls: []
```
Using the following command both without and with the change applied:
`helm template . -f ../../values.yml` 

The resulting template output without the change applied contained:
`- "-nebraska-url=http://nebraska.example.com"`

The resulting template output with the change applied contained:
`- "-nebraska-url=https://nebraska.example.com"`
