### PR TITLE
Update frontend github workflow node (LTS, current) and Ubuntu LTS

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,15 +5,16 @@ on:
     paths:
     - 'frontend/**'
     - 'Makefile'
+    - '.github/**'
 
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
# Update frontend github workflow node (LTS, current) and Ubuntu LTS

Removes the older unsupported node version, and adds the LTS and the current (16 future LTS) node version for testing.
Additionally it changes the Ubuntu version to run the tests under to the current LTS version (20.4).

So we test the previous node LTS (12), the current LTS(14), and the future LTS (16 to see if our libraries work there).

## Testing done

This changes what is tested on CI.
