### PR TITLE
Humanize policy numbers

### DIFF
--- a/frontend/src/js/components/Groups/Item.tsx
+++ b/frontend/src/js/components/Groups/Item.tsx
@@ -4,6 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import CheckIcon from '@material-ui/icons/Check';
 import CloseIcon from '@material-ui/icons/Close';
 import ScheduleIcon from '@material-ui/icons/Schedule';
+import { TFunction } from 'i18next';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import _ from 'underscore';
@@ -29,6 +30,13 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.success.main,
   },
 }));
+
+export function formatUpdateLimits(t: TFunction, group: Group) {
+  return t('groups|Max {{policy_max_updates_per_period, number}} / {{policy_period_interval}}', {
+    policy_max_updates_per_period: group.policy_max_updates_per_period,
+    policy_period_interval: group.policy_period_interval,
+  });
+}
 
 function Item(props: {
   group: Group;
@@ -148,15 +156,7 @@ function Item(props: {
             <Grid item>
               <CardFeatureLabel>{t('groups|Rollout Policy')}</CardFeatureLabel>
               <Box p={1} mb={1}>
-                <CardLabel>
-                  {t(
-                    'groups|Max {{policy_max_updates_per_period, number}} / {{policy_period_interval}}',
-                    {
-                      policy_max_updates_per_period: props.group.policy_max_updates_per_period,
-                      policy_period_interval: props.group.policy_period_interval,
-                    }
-                  )}
-                </CardLabel>
+                <CardLabel>{formatUpdateLimits(t, props.group)}</CardLabel>
               </Box>
             </Grid>
             <Grid item container>

--- a/frontend/src/js/components/Groups/Item.tsx
+++ b/frontend/src/js/components/Groups/Item.tsx
@@ -150,7 +150,7 @@ function Item(props: {
               <Box p={1} mb={1}>
                 <CardLabel>
                   {t(
-                    'groups|Max {{policy_max_updates_per_period, number}} / {{policy_period_interval, number}}',
+                    'groups|Max {{policy_max_updates_per_period, number}} / {{policy_period_interval}}',
                     {
                       policy_max_updates_per_period: props.group.policy_max_updates_per_period,
                       policy_period_interval: props.group.policy_period_interval,

--- a/frontend/src/js/components/Groups/Item.tsx
+++ b/frontend/src/js/components/Groups/Item.tsx
@@ -31,7 +31,13 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+// From this number, we stop rate limiting in the backend
+const MAX_UPDATES_PER_TIME_PERIOD = 900000;
+
 export function formatUpdateLimits(t: TFunction, group: Group) {
+  if (group.policy_max_updates_per_period >= MAX_UPDATES_PER_TIME_PERIOD) {
+    return t('groups|Unlimited number of parallel updates');
+  }
   return t('groups|Max {{policy_max_updates_per_period, number}} / {{policy_period_interval}}', {
     policy_max_updates_per_period: group.policy_max_updates_per_period,
     policy_period_interval: group.policy_period_interval,

--- a/frontend/src/js/components/Groups/ItemExtended.tsx
+++ b/frontend/src/js/components/Groups/ItemExtended.tsx
@@ -19,6 +19,7 @@ import MoreMenu from '../Common/MoreMenu';
 import TimeIntervalLinks from '../Common/TimeIntervalLinks';
 import InstanceStatusArea from '../Instances/Charts';
 import { StatusCountTimeline, VersionCountTimeline } from './Charts';
+import { formatUpdateLimits } from './Item';
 
 const useStyles = makeStyles(theme => ({
   link: {
@@ -224,11 +225,7 @@ function ItemExtended(props: {
                     <Grid item>
                       <CardFeatureLabel>{t('groups|Updates Policy')}</CardFeatureLabel>
                       <Box my={1}>
-                        <CardLabel>
-                          {`Max ${group.policy_max_updates_per_period || 0} updates per ${
-                            group.policy_period_interval || 0
-                          }`}
-                        </CardLabel>
+                        <CardLabel>{formatUpdateLimits(t, group)}</CardLabel>
                       </Box>
                     </Grid>
                     <Grid item>


### PR DESCRIPTION
- frontend: Fix type of argument in Group/Item's translation
- frontend: Share the format for rate policy in Groups/Item|ItemExtended
- frontend: Inform the user of unlimited updates in the update policy

![Screenshot from 2021-07-01 12-30-52](https://user-images.githubusercontent.com/1029635/124117619-42606680-da68-11eb-9ab2-3922f8ddfba8.png)
