### PR TITLE
backend: Fix instance list filtering when filtered by status & version

### DIFF
--- a/backend/pkg/api/instances.go
+++ b/backend/pkg/api/instances.go
@@ -315,6 +315,9 @@ func (api *API) getInstanceApps(appID, instanceID string, duration postgresDurat
 	if p.Version != "" {
 		query = query.Where(goqu.C("version").Eq(p.Version))
 	}
+	if p.GroupID != "" {
+		query = query.Where(goqu.C("group_id").Eq(p.GroupID))
+	}
 	instanceAppsQuery, _, err := query.ToSQL()
 	if err != nil {
 		return nil, err

--- a/backend/pkg/api/instances.go
+++ b/backend/pkg/api/instances.go
@@ -304,13 +304,22 @@ func (api *API) GetInstance(instanceID, appID string) (*Instance, error) {
 
 	return &instance, nil
 }
-func (api *API) getInstanceApps(appID, instanceID string, duration postgresDuration, sortFilter string, orderOfSort sortOrder, limit, offset uint) ([]*InstanceApplication, error) {
+func (api *API) getInstanceApps(appID, instanceID string, duration postgresDuration, sortFilter string, orderOfSort sortOrder, limit, offset uint, p InstancesQueryParams) ([]*InstanceApplication, error) {
 	var instanceApps []*InstanceApplication
-	query, _, err := api.instanceAppQuery(appID, instanceID, duration, sortFilter, orderOfSort).Limit(limit).Offset(offset).ToSQL()
+	query := api.instanceAppQuery(appID, instanceID, duration, sortFilter, orderOfSort).Limit(limit).Offset(offset)
+	if p.Status == InstanceStatusUndefined {
+		query = query.Where(goqu.L("status IS NULL"))
+	} else if p.Status != 0 {
+		query = query.Where(goqu.C("status").Eq(p.Status))
+	}
+	if p.Version != "" {
+		query = query.Where(goqu.C("version").Eq(p.Version))
+	}
+	instanceAppsQuery, _, err := query.ToSQL()
 	if err != nil {
 		return nil, err
 	}
-	rows, err := api.db.Queryx(query)
+	rows, err := api.db.Queryx(instanceAppsQuery)
 	for rows.Next() {
 		var instanceApp InstanceApplication
 		err = rows.StructScan(&instanceApp)
@@ -419,7 +428,7 @@ func (api *API) GetInstances(p InstancesQueryParams, duration string) (Instances
 	if existsInInstanceAppTable {
 		var applications []*InstanceApplication
 		//first query instance app table
-		applications, err = api.getInstanceApps(p.ApplicationID, "", dbDuration, sortFilter, sortOrder, limit, offset)
+		applications, err = api.getInstanceApps(p.ApplicationID, "", dbDuration, sortFilter, sortOrder, limit, offset, p)
 		if err != nil {
 			return InstancesWithTotal{}, err
 		}

--- a/backend/pkg/api/instances_test.go
+++ b/backend/pkg/api/instances_test.go
@@ -129,6 +129,11 @@ func TestGetInstances(t *testing.T) {
 	assert.Equal(t, 1, len(result.Instances))
 	assert.Equal(t, 1, (int)(result.TotalInstances))
 
+	result, err = a.GetInstances(InstancesQueryParams{ApplicationID: tApp.ID, GroupID: tGroup.ID, Version: "1.0.0", Page: 1, PerPage: 10}, testDuration)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.Instances))
+	assert.Equal(t, "1.0.0", result.Instances[0].Application.Version)
+
 	_, _ = a.GetUpdatePackage(tInstance.ID, "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
 	_ = a.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, EventUpdateComplete, ResultSuccessReboot, "", "")
 


### PR DESCRIPTION
By default the sortFilter is found in the instance app table and when
mapping instanceApplications to instance we were not applying the
filters, this lead to wrong list of instances to be shown in the UI.

[ describe what reviewers need to do in order to validate this PR ]
Go to the instance list view apply the filters and you will see the correct list with filters getting applied 

## Testing done
YES

fixes #426 