### PR TITLE
Makefile: Ensure the test targets are run from the backend dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,13 @@ all: backend tools frontend
 
 .PHONY: check
 check:
+	cd backend && \
 	go test -p 1 ./...
 check-code-coverage:
+	cd backend && \
 	go test -p 1 -coverprofile=coverage.out ./...
 print-code-coverage:
+	cd backend && \
 	go tool cover -html=coverage.out
 container_id:
 	cd backend && \
@@ -91,6 +94,7 @@ backend-binary: run-generators build-backend-binary
 
 .PHONY: test-clean-work-tree-backend
 test-clean-work-tree-backend:
+	cd backend && \
 	@if ! git diff --quiet -- go.mod go.sum pkg cmd updaters tools/tools.go; then \
 	  echo; \
 	  echo 'Working tree of backend code is not clean'; \


### PR DESCRIPTION
Some targets were not updated when the backend code was moved into the
backend/ directory, and it was passing the CI tests still because the
diff that triggers the CI testing was running against files that did
not exist.
