### PR TITLE
frontend: Fix persistent chart tooltip 

### DIFF
--- a/frontend/src/js/components/Instances/Charts.tsx
+++ b/frontend/src/js/components/Instances/Charts.tsx
@@ -122,12 +122,14 @@ function ProgressDoughnut(props: ProgressDoughnutProps) {
             animationDuration={1000}
             animationEasing={'ease-in-out'}
             onMouseOver={(dataum, index) => {
-              setHoverData(dataum);
-              setShowTooltip(true);
-              // Highlight the bit on hover, if it's not
-              // the remaining percentage.
-              if (dataum.x !== 'remain') {
-                setActiveIndex(index);
+              if (!showTooltip) {
+                setHoverData(dataum);
+                setShowTooltip(true);
+                // Highlight the bit on hover, if it's not
+                // the remaining percentage.
+                if (dataum.x !== 'remain') {
+                  setActiveIndex(index);
+                }
               }
             }}
             onMouseOut={() => {


### PR DESCRIPTION
Set the tooltip only when the tooltip boolean is not turned on
## Testing done
Go to the GroupExtended View and hover over InstanceStatusArea Charts quickly jump from one chart to other and the tooltip would not remain persistent.
fixes #424 