### PR TITLE
Allow other result success cases to complete the update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ i18n:
 	cd frontend && npm run i18n
 
 run-backend: backend-binary
-	cd backend && ./bin/nebraska -auth-mode noop
+	cd backend && ./bin/nebraska -auth-mode noop -debug
 
 .PHONY: backend
 backend: run-generators backend-code-checks build-backend-binary

--- a/backend/pkg/api/events.go
+++ b/backend/pkg/api/events.go
@@ -164,8 +164,9 @@ func (api *API) triggerEventConsequences(instanceID, appID, groupID, lastUpdateV
 		return err
 	}
 
-	// TODO: should we also consider ResultSuccess in the next check? Flatcar ~ generic conflicts?
-	if etype == EventUpdateComplete && result == ResultSuccessReboot {
+	// We allow the plain ResultSuccess here only if the app is not Flatcar because Flatcar is relying on
+	// having only the update-complete logic on ResultSuccessReboot.
+	if etype == EventUpdateComplete && (result == ResultSuccessReboot || (appID != flatcarAppID && result == ResultSuccess)) {
 		if err := api.updateInstanceStatus(instanceID, appID, InstanceStatusComplete); err != nil {
 			logger.Error().Err(err).Msg("triggerEventConsequences - could not update instance status")
 		}

--- a/backend/pkg/api/events_test.go
+++ b/backend/pkg/api/events_test.go
@@ -108,3 +108,45 @@ func TestRegisterEvent_TriggerEventConsequences_FirstUpdateAttemptFailed(t *test
 	group, _ := a.GetGroup(tGroup.ID)
 	assert.Equal(t, false, group.PolicyUpdatesEnabled, "First update attempt failed.")
 }
+
+func TestRegisterEvent_CheckSuccessResult(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+
+	performUpdate := func(tApp *Application, tGroup *Group, resultType int) {
+		tInstance, err := a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+		assert.NoError(t, err)
+
+		_, err = a.GetUpdatePackage(tInstance.ID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+		assert.NoError(t, err)
+
+		err = a.RegisterEvent(tInstance.ID, "{"+tApp.ID+"}", tGroup.ID, EventUpdateDownloadStarted, ResultSuccess, "", "")
+		assert.NoError(t, err)
+		instance, _ := a.GetInstance(tInstance.ID, tApp.ID)
+		assert.Equal(t, null.IntFrom(int64(InstanceStatusDownloading)), instance.Application.Status)
+
+		err = a.RegisterEvent(tInstance.ID, tApp.ID, "{"+tGroup.ID+"}", EventUpdateDownloadFinished, ResultSuccess, "", "")
+		assert.NoError(t, err)
+		instance, _ = a.GetInstance(tInstance.ID, tApp.ID)
+		assert.Equal(t, null.IntFrom(int64(InstanceStatusDownloaded)), instance.Application.Status)
+
+		err = a.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, EventUpdateInstalled, ResultSuccess, "", "")
+		assert.NoError(t, err)
+		instance, _ = a.GetInstance(tInstance.ID, tApp.ID)
+		assert.Equal(t, null.IntFrom(int64(InstanceStatusInstalled)), instance.Application.Status)
+
+		err = a.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, EventUpdateComplete, resultType, "", "")
+		assert.NoError(t, err)
+		instance, _ = a.GetInstance(tInstance.ID, tApp.ID)
+		assert.Equal(t, null.IntFrom(int64(InstanceStatusComplete)), instance.Application.Status)
+	}
+
+	tTeam, _ := a.AddTeam(&Team{Name: "test_team"})
+	tApp, _ := a.AddApp(&Application{Name: "test_app", TeamID: tTeam.ID})
+	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
+	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
+	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+
+	performUpdate(tApp, tGroup, ResultSuccess)
+	performUpdate(tApp, tGroup, ResultSuccessReboot)
+}

--- a/backend/pkg/api/events_test.go
+++ b/backend/pkg/api/events_test.go
@@ -150,3 +150,46 @@ func TestRegisterEvent_CheckSuccessResult(t *testing.T) {
 	performUpdate(tApp, tGroup, ResultSuccess)
 	performUpdate(tApp, tGroup, ResultSuccessReboot)
 }
+
+func TestRegisterEvent_CheckFlatcarSuccessResult(t *testing.T) {
+	// If it's a Flatcar application, then the instances' updates are only considered to
+	// be complete if the instance has sent ResultSuccessReboot on completion.
+	a := newForTest(t)
+	defer a.Close()
+
+	performUpdate := func(tApp *Application, tGroup *Group, resultType, expectedInstanceStatus int) {
+		tInstance, err := a.RegisterInstance(uuid.New().String(), "", "10.0.0.1", "1.0.0", tApp.ID, tGroup.ID)
+		assert.NoError(t, err)
+
+		_, err = a.GetUpdatePackage(tInstance.ID, "", "10.0.0.1", "12.0.0", tApp.ID, tGroup.ID)
+		assert.NoError(t, err)
+
+		err = a.RegisterEvent(tInstance.ID, "{"+tApp.ID+"}", tGroup.ID, EventUpdateDownloadStarted, ResultSuccess, "11.0.0", "")
+		assert.NoError(t, err)
+		instance, _ := a.GetInstance(tInstance.ID, tApp.ID)
+		assert.Equal(t, null.IntFrom(int64(InstanceStatusDownloading)), instance.Application.Status)
+
+		err = a.RegisterEvent(tInstance.ID, tApp.ID, "{"+tGroup.ID+"}", EventUpdateDownloadFinished, ResultSuccess, "11.0.0", "")
+		assert.NoError(t, err)
+		instance, _ = a.GetInstance(tInstance.ID, tApp.ID)
+		assert.Equal(t, null.IntFrom(int64(InstanceStatusDownloaded)), instance.Application.Status)
+
+		err = a.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, EventUpdateInstalled, ResultSuccess, "11.0.0", "")
+		assert.NoError(t, err)
+		instance, _ = a.GetInstance(tInstance.ID, tApp.ID)
+		assert.Equal(t, null.IntFrom(int64(InstanceStatusInstalled)), instance.Application.Status)
+
+		err = a.RegisterEvent(tInstance.ID, tApp.ID, tGroup.ID, EventUpdateComplete, resultType, "11.0.0", "")
+		assert.NoError(t, err)
+		instance, _ = a.GetInstance(tInstance.ID, tApp.ID)
+		assert.Equal(t, null.IntFrom(int64(expectedInstanceStatus)), instance.Application.Status)
+	}
+
+	tApp, _ := a.GetApp(flatcarAppID)
+	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
+	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
+	tGroup, _ := a.AddGroup(&Group{Name: "group9", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+
+	performUpdate(tApp, tGroup, ResultSuccess, InstanceStatusInstalled)
+	performUpdate(tApp, tGroup, ResultSuccessReboot, InstanceStatusComplete)
+}


### PR DESCRIPTION
We had a [limit](https://github.com/kinvolk/nebraska/blob/main/backend/pkg/api/events.go#L167) on how we consider an update to be done because we were only contemplating how Flatcar behaves.

Yet, as far as understand from the [protocol](https://github.com/google/omaha/blob/master/doc/ServerProtocolV3.md), there are [3 different ways](https://pkg.go.dev/github.com/kinvolk/go-omaha/omaha#EventResult) to represent success and we should definitely consider them.

**Update:** Turns out the event types are stored in the DB and I don't want to add a migration to include the ResultSuccessRestartBrowser case, so I dropped support for this event result type. I could add a hack where I always query the ResultSuccess if there's ResultSuccessRestartBrowser, but I don't think it's worth it and instead we should look into whether it's worth having the event_type data in the DB in the first place (having the info in the source should be enough).

Another issue with not understanding all success result cases is that when using the (deprecated but still useful) `updateservicectl`, the fake instances would reach an "unknown" state because of this [corner case logic](https://github.com/kinvolk/nebraska/blob/main/backend/pkg/api/events.go#L108).
With this PR it will successfully consider those fake instances updates to be completed, and I don't think the PR will change anything in the Flatcar case because we are [using only "ResultReboot" AFAICS](https://github.com/kinvolk/update_engine/blob/312ab260fce283e84635b73d92dd6d526d1e3d96/src/update_engine/omaha_request_action.cc#L136
). I'd like @pothos to double check this is the case.