### PR TITLE
WIP: Refine update progress reports

### DIFF
--- a/frontend/src/js/components/Groups/ItemExtended.tsx
+++ b/frontend/src/js/components/Groups/ItemExtended.tsx
@@ -264,6 +264,7 @@ function ItemExtended(props: {
                   <InstanceStatusArea
                     instanceStats={instancesStats}
                     period={updateProgressChartDuration.displayValue}
+                    groupHasVersion={!!group.channel?.package?.version}
                     href={{
                       pathname: `/apps/${props.appID}/groups/${props.groupID}/instances`,
                       search: `period=${updateProgressChartDuration.queryValue}`,

--- a/frontend/src/js/components/Instances/Charts.tsx
+++ b/frontend/src/js/components/Instances/Charts.tsx
@@ -209,35 +209,39 @@ export default function InstanceStatusArea(props: InstanceStatusAreaProps) {
       count: [{ key: 'complete' }],
     },
     {
-      status: 'InstanceStatusDownloaded',
-      count: [{ key: 'downloaded' }],
+      status: 'InstanceStatusNotUpdating',
+      count: [{ key: 'other_versions', label: t('instances|InstanceStatusOtherVersions') }],
     },
     {
-      status: 'InstanceStatusOther',
+      status: 'InstanceStatusOnHold',
+      count: [{ key: 'onhold' }],
+    },
+    {
+      status: 'InstanceStatusUpdating',
       count: [
-        { key: 'onhold', label: t('instances|InstanceStatusOnHold') },
-        { key: 'undefined', label: t('instances|InstanceStatusUndefined') },
-      ],
-    },
-    {
-      status: 'InstanceStatusInstalled',
-      count: [{ key: 'installed' }],
-    },
-    {
-      status: 'InstanceStatusDownloading',
-      count: [
-        { key: 'downloading', label: t('instances|InstanceStatusDownloading') },
         { key: 'update_granted', label: t('instances|InstanceStatusUpdateGranted') },
+        { key: 'downloading', label: t('instances|InstanceStatusDownloading') },
+        { key: 'downloaded', label: t('instances|InstanceStatusDownloaded') },
+        { key: 'installed', label: t('instances|InstanceStatusInstalled') },
       ],
     },
     {
       status: 'InstanceStatusError',
       count: [{ key: 'error' }],
     },
+    {
+      status: 'InstanceStatusTimedOut',
+      count: [{ key: 'timed_out' }],
+    },
   ];
 
-  statusDefs['InstanceStatusOther'] = { ...statusDefs['InstanceStatusUndefined'] };
-  statusDefs['InstanceStatusOther'].label = t('instances|Other');
+  statusDefs['InstanceStatusNotUpdating'] = { ...statusDefs['InstanceStatusUndefined'] };
+  statusDefs['InstanceStatusNotUpdating'].label = t('instances|Not updating');
+
+  statusDefs['InstanceStatusUpdating'] = {
+    ...statusDefs['InstanceStatusDownloading'],
+    label: t('instances|Updating'),
+  };
 
   const totalInstances = instanceStats ? instanceStats.total : 0;
 

--- a/frontend/src/js/components/Instances/Charts.tsx
+++ b/frontend/src/js/components/Instances/Charts.tsx
@@ -187,6 +187,7 @@ interface InstanceStatusAreaProps {
   instanceStats: InstanceStats | null;
   href?: object;
   period: string;
+  groupHasVersion: boolean;
 }
 
 interface InstanceStatusCount {
@@ -202,7 +203,7 @@ export default function InstanceStatusArea(props: InstanceStatusAreaProps) {
   const statusDefs = makeStatusDefs(theme);
   const { t } = useTranslation();
 
-  const { instanceStats, href, period } = props;
+  const { instanceStats, href, period, groupHasVersion } = props;
   const instanceStateCount: InstanceStatusCount[] = [
     {
       status: 'InstanceStatusComplete',
@@ -255,37 +256,46 @@ export default function InstanceStatusArea(props: InstanceStatusAreaProps) {
         <InstanceCountLabel countText={totalInstances} href={href} />
       </Grid>
       <Grid item container justify="space-between" xs={8}>
-        {instanceStateCount.map(({ status, count }, i) => {
-          // Sort the data entries so the smaller amounts are shown first.
-          count.sort((obj1, obj2) => {
-            const stats1 = instanceStats[obj1.key];
-            const stats2 = instanceStats[obj2.key];
-            if (stats1 === stats2) return 0;
-            if (stats1 < stats2) return -1;
-            return 1;
-          });
+        {!groupHasVersion ? (
+          <Empty>
+            <Trans ns="instances">
+              It's not possible to get an accurate report as the group has no channel/version
+              assigned to it.
+            </Trans>
+          </Empty>
+        ) : (
+          instanceStateCount.map(({ status, count }, i) => {
+            // Sort the data entries so the smaller amounts are shown first.
+            count.sort((obj1, obj2) => {
+              const stats1 = instanceStats[obj1.key];
+              const stats2 = instanceStats[obj2.key];
+              if (stats1 === stats2) return 0;
+              if (stats1 < stats2) return -1;
+              return 1;
+            });
 
-          return (
-            <Grid item key={i}>
-              <ProgressDoughnut
-                data={count.map(({ key, label = status }) => {
-                  const statusLabel = statusDefs[label].label;
-                  return {
-                    value: instanceStats[key] / instanceStats.total,
-                    color: statusDefs[label].color,
-                    description: t('{{statusLabel}}: {{stat, number}} instances', {
-                      statusLabel: statusLabel,
-                      stat: instanceStats[key],
-                    }),
-                  };
-                })}
-                width={140}
-                height={140}
-                {...statusDefs[status]}
-              />
-            </Grid>
-          );
-        })}
+            return (
+              <Grid item key={i}>
+                <ProgressDoughnut
+                  data={count.map(({ key, label = status }) => {
+                    const statusLabel = statusDefs[label].label;
+                    return {
+                      value: instanceStats[key] / instanceStats.total,
+                      color: statusDefs[label].color,
+                      description: t('{{statusLabel}}: {{stat, number}} instances', {
+                        statusLabel: statusLabel,
+                        stat: instanceStats[key],
+                      }),
+                    };
+                  })}
+                  width={140}
+                  height={140}
+                  {...statusDefs[status]}
+                />
+              </Grid>
+            );
+          })
+        )}
       </Grid>
     </Grid>
   ) : (

--- a/frontend/src/js/components/Instances/StatusDefs.ts
+++ b/frontend/src/js/components/Instances/StatusDefs.ts
@@ -1,11 +1,11 @@
 import alertCircleOutline from '@iconify/icons-mdi/alert-circle-outline';
 import checkCircleOutline from '@iconify/icons-mdi/check-circle-outline';
-import downloadCircleOutline from '@iconify/icons-mdi/download-circle-outline';
-import helpCircleOutline from '@iconify/icons-mdi/help-circle-outline';
+import clockAlertOutline from '@iconify/icons-mdi/clock-alert-outline';
+import closeCircleOutline from '@iconify/icons-mdi/close-circle-outline';
 import packageVariantClosed from '@iconify/icons-mdi/package-variant-closed';
 import pauseCircle from '@iconify/icons-mdi/pause-circle';
 import playCircle from '@iconify/icons-mdi/play-circle';
-import progressDownload from '@iconify/icons-mdi/progress-download';
+import refresh from '@iconify/icons-mdi/refresh';
 import { Theme } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 
@@ -21,7 +21,7 @@ function makeStatusDefs(theme: Theme): {
 
   return {
     InstanceStatusComplete: {
-      label: t('instances|Complete'),
+      label: t('instances|Up to date'),
       color: 'rgba(15,15,15,1)',
       icon: checkCircleOutline,
       queryValue: '4',
@@ -29,12 +29,12 @@ function makeStatusDefs(theme: Theme): {
     InstanceStatusDownloaded: {
       label: t('instances|Downloaded'),
       color: 'rgba(40,95,43,1)',
-      icon: downloadCircleOutline,
+      icon: refresh,
       queryValue: '6',
     },
     InstanceStatusOnHold: {
       label: t('instances|On Hold'),
-      color: theme.palette.grey['400'],
+      color: 'rgb(89, 89, 89)',
       icon: pauseCircle,
       queryValue: '8',
     },
@@ -47,19 +47,19 @@ function makeStatusDefs(theme: Theme): {
     InstanceStatusDownloading: {
       label: t('instances|Downloading'),
       color: 'rgba(17,40,141,1)',
-      icon: progressDownload,
+      icon: refresh,
       queryValue: '7',
     },
     InstanceStatusError: {
       label: t('instances|Error'),
       color: 'rgba(164,45,36,1)',
-      icon: alertCircleOutline,
+      icon: closeCircleOutline,
       queryValue: '3',
     },
     InstanceStatusUndefined: {
       label: t('instances|Unknown'),
       color: 'rgb(89, 89, 89)',
-      icon: helpCircleOutline,
+      icon: alertCircleOutline,
       queryValue: '1',
     },
     InstanceStatusUpdateGranted: {
@@ -67,6 +67,18 @@ function makeStatusDefs(theme: Theme): {
       color: theme.palette.sapphireColor,
       icon: playCircle,
       queryValue: '2',
+    },
+    InstanceStatusTimedOut: {
+      label: t('instances|Timed out'),
+      color: 'rgba(164,45,36,1)',
+      icon: clockAlertOutline,
+      queryValue: '8',
+    },
+    InstanceStatusOtherVersions: {
+      label: t('instances|Not updating to this version'),
+      color: 'rgb(89, 89, 89)',
+      icon: alertCircleOutline,
+      queryValue: '',
     },
   };
 }

--- a/frontend/src/js/utils/helpers.ts
+++ b/frontend/src/js/utils/helpers.ts
@@ -230,6 +230,26 @@ export function getInstanceStatus(statusID: number, version?: string) {
       explanation:
         'There was an update pending for the instance but it was put on hold because of the rollout policy',
     },
+    9: {
+      type: 'InstanceStatusTimedOut',
+      className: 'danger',
+      spinning: false,
+      icon: 'glyphicon glyphicon-remove',
+      description: 'Error updating',
+      bgColor: 'rgba(244, 67, 54, 0.1)',
+      textColor: '#F44336',
+      status: 'Error',
+      explanation: 'The instance reported an error while updating to version ' + version,
+    },
+    10: {
+      type: 'InstanceStatusOtherVersions',
+      className: '',
+      spinning: false,
+      icon: '',
+      description: '',
+      status: 'Undefined',
+      explanation: '',
+    },
   };
 
   const statusDetails = statusID ? status[statusID] : status[1];


### PR DESCRIPTION
I have been working on this PR to make the group's stats a bit more accurate to what the user perceives: the issue is that we are gathering any instances with a certain state (downloaded/downloading/update-granted/error), regardless of whether they are updated or have updated to the version that the group declares.
This may hint, for example, that there are 3 instances downloading (the group's version), when they may be actually downloading a previous version, if the group's channel has just updated to a newer package.

Also, instances that have pinged the group and are in the group's version, will have no status change, and this showed up as "undefined" but they're actually instances that are up to date.
Another thing that's added is that there was no way to show instances that have timed out, and this patch includes those.

**Important:** This PR is still missing some important things beyond the charts, like having a way to filter by "time out", etc. otherwise the instances list view will not be accurate.

So this is WIP ATM.

- groups: Replace GetGroupInstancesStats's query by goqu
- backend: Change how the groups' stats are calculated
- frontend: Update circular charts to the match update progress
- frontend: Add a notice to the group's charts area if there's no version
