### PR TITLE
Clarify up to date instances' status

### DIFF
--- a/backend/pkg/api/groups.go
+++ b/backend/pkg/api/groups.go
@@ -557,12 +557,30 @@ func (api *API) GetGroupInstancesStats(groupID, duration string) (*InstancesStat
 		return nil, err
 	}
 
+	group, err := api.GetGroup(groupID)
+	if err != nil {
+		return nil, err
+	}
+
+	packageVersion := ""
+
+	if group.Channel != nil && group.Channel.Package != nil {
+		packageVersion = group.Channel.Package.Version
+	}
+
+	undefinedExpr := goqu.L("case when status IS NULL then 1 else 0 end")
+	completedExpr := goqu.L("case when status = ? then 1 else 0 end", InstanceStatusComplete)
+	if packageVersion != "" {
+		undefinedExpr = goqu.L("case when version != ? and status IS NULL then 1 else 0 end", packageVersion)
+		completedExpr = goqu.L("case when (version = ? and status IS NULL) or (status = ?) then 1 else 0 end", packageVersion, InstanceStatusComplete)
+	}
+
 	query, _, err := goqu.From("instance_application").Select(
 		goqu.COUNT("*").As("total"),
-		goqu.COALESCE(goqu.SUM(goqu.L("case when status IS NULL then 1 else 0 end")), 0).As("undefined"),
+		goqu.COALESCE(goqu.SUM(undefinedExpr), 0).As("undefined"),
 		goqu.COALESCE(goqu.SUM(goqu.L("case when status = ? then 1 else 0 end", InstanceStatusError)), 0).As("error"),
 		goqu.COALESCE(goqu.SUM(goqu.L("case when status = ? then 1 else 0 end", InstanceStatusUpdateGranted)), 0).As("update_granted"),
-		goqu.COALESCE(goqu.SUM(goqu.L("case when status = ? then 1 else 0 end", InstanceStatusComplete)), 0).As("complete"),
+		goqu.COALESCE(goqu.SUM(completedExpr), 0).As("complete"),
 		goqu.COALESCE(goqu.SUM(goqu.L("case when status = ? then 1 else 0 end", InstanceStatusInstalled)), 0).As("installed"),
 		goqu.COALESCE(goqu.SUM(goqu.L("case when status = ? then 1 else 0 end", InstanceStatusDownloaded)), 0).As("downloaded"),
 		goqu.COALESCE(goqu.SUM(goqu.L("case when status = ? then 1 else 0 end", InstanceStatusDownloading)), 0).As("downloading"),


### PR DESCRIPTION
- groups: Replace GetGroupInstancesStats's query by goqu
- backend: Count up to date instances without history as complete
