### PR TITLE
updater: Add debug flag to updater.

### DIFF
--- a/updater/omahaHandler.go
+++ b/updater/omahaHandler.go
@@ -3,6 +3,7 @@ package updater
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
 	"io"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
@@ -11,12 +12,14 @@ import (
 
 type HttpOmahaReqHandler struct {
 	url        string
+	debug      bool
 	httpClient *retryablehttp.Client
 }
 
-func NewHttpOmahaReqHandler(url string) *HttpOmahaReqHandler {
+func NewHttpOmahaReqHandler(url string, debug bool) *HttpOmahaReqHandler {
 	return &HttpOmahaReqHandler{
 		url,
+		debug,
 		retryablehttp.NewClient(),
 	}
 }
@@ -25,6 +28,10 @@ func (h *HttpOmahaReqHandler) Handle(req *omaha.Request) (*omaha.Response, error
 	requestByte, err := xml.Marshal(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if h.debug {
+		fmt.Println("Raw Request:\n", string(requestByte))
 	}
 
 	resp, err := h.httpClient.Post(h.url, "text/xml", bytes.NewReader(requestByte))
@@ -37,6 +44,12 @@ func (h *HttpOmahaReqHandler) Handle(req *omaha.Request) (*omaha.Response, error
 	respBody := &io.LimitedReader{R: resp.Body, N: 1024 * 1024}
 	contentType := resp.Header.Get("Content-Type")
 	omahaResp, err := omaha.ParseResponse(contentType, respBody)
+	if h.debug {
+		responseByte, err := xml.Marshal(omahaResp)
+		if err == nil {
+			fmt.Println("Raw Response:\n", string(responseByte))
+		}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/updater/omahaHandler_test.go
+++ b/updater/omahaHandler_test.go
@@ -30,7 +30,7 @@ func TestHttpOmahaHandler(t *testing.T) {
 	defer s.Destroy()
 	go s.Serve()
 
-	omahaRequestHandler := NewHttpOmahaReqHandler("http://127.0.0.1:6000/v1/update")
+	omahaRequestHandler := NewHttpOmahaReqHandler("http://127.0.0.1:6000/v1/update", false)
 
 	var omahaRequest omaha.Request
 

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -69,15 +69,16 @@ type Updater struct {
 
 	appID   string
 	channel string
+	debug   bool
 
 	omahaReqHandler OmahaRequestHandler
 }
 
-func New(omahaURL string, appID string, channel string, instanceID string, instanceVersion string) (*Updater, error) {
-	return NewWithOmahaRequestHandler(omahaURL, appID, channel, instanceID, instanceVersion, NewHttpOmahaReqHandler(omahaURL))
+func New(omahaURL string, appID string, channel string, instanceID string, instanceVersion string, debug bool) (*Updater, error) {
+	return NewWithOmahaRequestHandler(omahaURL, appID, channel, instanceID, instanceVersion, debug, NewHttpOmahaReqHandler(omahaURL, debug))
 }
 
-func NewWithOmahaRequestHandler(omahaURL string, appID string, channel string, instanceID string, instanceVersion string, handler OmahaRequestHandler) (*Updater, error) {
+func NewWithOmahaRequestHandler(omahaURL string, appID string, channel string, instanceID string, instanceVersion string, debug bool, handler OmahaRequestHandler) (*Updater, error) {
 	_, err := url.Parse(omahaURL)
 	if err != nil {
 		return nil, err
@@ -90,6 +91,7 @@ func NewWithOmahaRequestHandler(omahaURL string, appID string, channel string, i
 		appID:           appID,
 		instanceVersion: instanceVersion,
 		channel:         channel,
+		debug:           debug,
 		omahaReqHandler: handler,
 	}, nil
 }

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -79,7 +79,7 @@ func newUpdater(a *api.API, appID string, channel string, instanceID string, ins
 }
 
 func TestNewUpdater(t *testing.T) {
-	_, err := New("http://localhost:8000", "io.phony.App", "stable", "instance001", "0.1.0")
+	_, err := New("http://localhost:8000", "io.phony.App", "stable", "instance001", "0.1.0", false)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
At present it is difficult to debug errors, the
debug flag can be set to print the raw response
to stdout.

Signed-off-by: Santhosh Nagaraj S <santhosh@kinvolk.io>

