### PR TITLE
frontend: Move the group's track above the description in edit form

### DIFF
--- a/frontend/src/js/components/Groups/EditDialog/GroupDetailsForm.tsx
+++ b/frontend/src/js/components/Groups/EditDialog/GroupDetailsForm.tsx
@@ -43,22 +43,22 @@ export default function GroupDetailsForm(props: {
         </Grid>
         <Grid item xs={12}>
           <Field
-            name="description"
-            component={TextField}
-            margin="dense"
-            label={t('groups|Description')}
-            fullWidth
-            defaultValue={values.description}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <Field
             name="track"
             component={TextField}
             margin="dense"
             label={t('groups|Track (identifier for clients, filled with the group ID if omitted)')}
             fullWidth
             defaultValue={values.track}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Field
+            name="description"
+            component={TextField}
+            margin="dense"
+            label={t('groups|Description')}
+            fullWidth
+            defaultValue={values.description}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
The group's track is more important than the group's description and
it's easy to miss as it is the last field in the form. So this patch
simply moves it above the description in the creation/edition form.
