### PR TITLE
Db API fixes

### DIFF
--- a/backend/pkg/api/instances.go
+++ b/backend/pkg/api/instances.go
@@ -409,9 +409,6 @@ func (api *API) GetInstances(p InstancesQueryParams, duration string) (Instances
 		return InstancesWithTotal{}, err
 	}
 	defer rows.Close()
-	if err := rows.Err(); err != nil {
-		return InstancesWithTotal{}, err
-	}
 	for rows.Next() {
 		var instance Instance
 		err = rows.Scan(&instance.ID, &instance.IP, &instance.CreatedTs, &instance.Alias,
@@ -422,6 +419,9 @@ func (api *API) GetInstances(p InstancesQueryParams, duration string) (Instances
 			return InstancesWithTotal{}, err
 		}
 		instances = append(instances, &instance)
+	}
+	if err := rows.Err(); err != nil {
+		return InstancesWithTotal{}, err
 	}
 	result := InstancesWithTotal{
 		TotalInstances: totalCount,


### PR DESCRIPTION
# DB API fixes

Some DB API usage fixes that could potentially fix some db connection leaks.

## How to use

This tries to be a bit more careful to follow the API usage guidelines to avoid connection leaks. From the sqlx docs:

https://jmoiron.github.io/sqlx/#connectionPool

> It is easy to get into trouble by accidentally holding on to connections. To prevent this:
> 
> - Ensure you Scan() every Row object
> - Ensure you either Close() or fully-iterate via Next() every Rows object
> - Ensure every transaction returns its connection via Commit() or Rollback()

