### PR TITLE
Add field revisionHistoryLimit to deployment

### DIFF
--- a/charts/nebraska/Chart.yaml
+++ b/charts/nebraska/Chart.yaml
@@ -19,7 +19,7 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 0.1.8
+version: 0.1.9
 appVersion: "2.5.1"
 
 dependencies:

--- a/charts/nebraska/templates/deployment.yaml
+++ b/charts/nebraska/templates/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- include "nebraska.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   strategy:
     {{- toYaml .Values.strategy | nindent 4 }}
   selector:

--- a/charts/nebraska/values.yaml
+++ b/charts/nebraska/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
+revisionHistoryLimit: 5
 
 image:
   registry: ghcr.io


### PR DESCRIPTION
To specify how many old ReplicaSets for the Deployment user want to
retain, adding this field. Default is 10 if the field is removed.

closes: #494
Signed-off-by: knrt10 <kautilya@kinvolk.io>