### PR TITLE
chore: Split frontend and backend build parts

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -30,5 +30,5 @@ jobs:
 
     - name: Build, Lint & Check
       run: |
-        cd $GITHUB_WORKSPACE
-        make backend-ci
+        make ci
+      working-directory: backend

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -26,7 +26,7 @@ jobs:
       id: go
 
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build, Lint & Check
       run: |

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -13,9 +13,16 @@ jobs:
     name: Build Container Image
     runs-on: ubuntu-20.04
     steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Check out code
       uses: actions/checkout@v2
     - name: Build image
+      env:
+        DOCKER_BUILDKIT: 1
       run: |
         cd $GITHUB_WORKSPACE
         make container

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: [12.x, 14.x, 16.x]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -24,22 +24,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Install dependencies
+    - name: run ci
       run: |
-        make frontend-install-ci
-
-    - name: Run linter
-      run: |
-        make frontend-lint
-
-    - name: Run test
-      run: |
-        make frontend-test
-                
-    - name: Build Frontend
-      run: |
-        make frontend-build
-
-    - name: Run typecheck
-      run: |
-        make frontend-tsc
+        make ci
+      working-directory: frontend

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
 .DS_Store
 *.swp
 *sublime*
-frontend/node_modules
-frontend/yarn-error.log
-frontend/src/js/icons/*.json
-
-backend/bin
-coverage.out
-backend/tools/go-bindata
-backend/tools/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -17,37 +17,32 @@ ifeq ($(VERSION),)
 	endif
 endif
 
-LDFLAGS := "-X github.com/kinvolk/nebraska/backend/pkg/version.Version=$(VERSION) -extldflags "-static""
 .PHONY: all
 all: backend tools frontend
 
 .PHONY: check
 check:
-	cd backend && \
-	go test -p 1 ./...
+	$(MAKE) -C backend $@
+
+.PHONY: check-code-coverage
 check-code-coverage:
-	cd backend && \
-	go test -p 1 -coverprofile=coverage.out ./...
+	$(MAKE) -C backend $@
+
+.PHONY: coverage.out
 coverage.out:
-	make check-code-coverage
-print-code-coverage: coverage.out
-	cd backend && \
-	go tool cover -html=coverage.out
+	$(MAKE) -C backend $@
+
+.PHONY: print-code-coverage
+print-code-coverage:
+	$(MAKE) -C backend $@
+
+.PHONY: container_id
 container_id:
-	cd backend && \
-	./tools/setup_local_db.sh \
-		--id-file container_id.tmp \
-		--db-name nebraska_tests \
-		--password nebraska \
-		--pg-version 13.3
-	cd backend && mv container_id.tmp container_id
+	$(MAKE) -C backend $@
 
 .PHONY: check-backend-with-container
-check-backend-with-container: container_id
-	set -e; \
-	cd backend && \
-	trap "$(DOCKER_CMD) kill $$(cat container_id); $(DOCKER_CMD) rm $$(cat container_id); rm -f container_id" EXIT; \
-	go test -p 1 ./...
+check-backend-with-container:
+	$(MAKE) -C backend $@
 
 .PHONY: frontend
 frontend: frontend-install
@@ -88,35 +83,23 @@ i18n:
 	cd frontend && npm run i18n
 
 run-backend: backend-binary
-	cd backend && ./bin/nebraska -auth-mode noop -debug
+	$(MAKE) -C backend run
 
 .PHONY: backend
-backend: run-generators backend-code-checks build-backend-binary
+backend:
+	$(MAKE) -C backend
 
 .PHONY: backend-binary
-backend-binary: run-generators build-backend-binary
+backend-binary:
+	$(MAKE) -C backend build
 
 .PHONY: test-clean-work-tree-backend
 test-clean-work-tree-backend:
-	@cd backend && \
-	if ! git diff --quiet -- go.mod go.sum pkg cmd tools/tools.go; then \
-	  echo; \
-	  echo 'Working tree of backend code is not clean'; \
-	  echo; \
-	  git status; \
-	  exit 1; \
-	fi
+	$(MAKE) -C backend $@
 
 .PHONY: tools
 tools:
-	cd backend && go build -o bin/initdb ./cmd/initdb
-	cd backend && go build -o bin/userctl ./cmd/userctl
-
-backend/tools/go-bindata: backend/go.mod backend/go.sum
-	cd backend && go build -o ./tools/go-bindata github.com/kevinburke/go-bindata/go-bindata
-
-backend/tools/golangci-lint: backend/go.mod backend/go.sum
-	cd backend && go build -o ./tools/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
+	$(MAKE) -C backend $@
 
 .PHONY: image
 image:
@@ -131,31 +114,25 @@ image:
 container: image
 
 .PHONY: backend-ci
-backend-ci: backend test-clean-work-tree-backend check-backend-with-container
+backend-ci:
+	$(MAKE) -C backend ci
 
 .PHONY: run-generators
-run-generators: backend/tools/go-bindata
-	cd backend && PATH="$(abspath backend/tools):$${PATH}" go generate ./...
+run-generators:
+	$(MAKE) -C backend $@
 
 .PHONY: build-backend-binary
 build-backend-binary:
-	cd backend && go build -trimpath -ldflags ${LDFLAGS} -o bin/nebraska ./cmd/nebraska
+	$(MAKE) -C backend build
 
 .PHONY: backend-code-checks
-backend-code-checks: backend/tools/golangci-lint
-	# this is to get nice error messages when something doesn't
-	# build (both the project and the tests), golangci-lint's
-	# output in this regard in unreadable.
-	cd backend && go build ./...
-	cd backend && ./tools/check_pkg_test.sh
-	cd backend && NEBRASKA_SKIP_TESTS=1 go test ./... >/dev/null
-	cd backend && ./tools/golangci-lint run --fix
-	cd backend && go mod tidy
+backend-code-checks:
+	$(MAKE) -C backend code-checks
 
 .PHONY: swagger-install
 swagger-install:
-	go get -u github.com/swaggo/swag/cmd/swag
+	$(MAKE) -C backend tools/swag
 
 .PHONY: swagger-init
-swagger-init:  swagger-install
-	cd backend && swag init -g cmd/userctl/main.go -o api
+swagger-init:
+	$(MAKE) -C backend $@

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ frontend-tsc:
 i18n:
 	$(MAKE) -C frontend $@
 
+run:
+	$(MAKE) -j 2 run-frontend run-backend
+
 run-backend: backend-binary
 	$(MAKE) -C backend run
 

--- a/Makefile
+++ b/Makefile
@@ -45,42 +45,42 @@ check-backend-with-container:
 	$(MAKE) -C backend $@
 
 .PHONY: frontend
-frontend: frontend-install
-	cd frontend && npm run build
+frontend:
+	$(MAKE) -C frontend
 
 .PHONY: frontend-watch
 frontend-watch: run-frontend
 
 run-frontend:
-	cd frontend && npm start
+	$(MAKE) -C frontend run
 
 .PHONY: frontend-install
 frontend-install:
-	cd frontend && npm install
+	$(MAKE) -C frontend install
 
 .PHONY: frontend-install-ci
 frontend-install-ci:
-	cd frontend && npm ci
+	$(MAKE) -C frontend install-ci
 
 .PHONY: frontend-build
 frontend-build:
-	cd frontend && npm run build
+	$(MAKE) -C frontend build
 
 .PHONY: frontend-test
 frontend-test:
-	cd frontend && npm run test
+	$(MAKE) -C frontend test
 
 .PHONY: frontend-lint
 frontend-lint:
-	cd frontend && npm run lint
+	$(MAKE) -C frontend lint
 
 .PHONY: frontend-tsc
 frontend-tsc:
-	cd frontend && npm run tsc
+	$(MAKE) -C frontend tsc
 
 .PHONY: i18n
 i18n:
-	cd frontend && npm run i18n
+	$(MAKE) -C frontend $@
 
 run-backend: backend-binary
 	$(MAKE) -C backend run

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,5 @@
+bin
+coverage.out
+tools/go-bindata
+tools/golangci-lint
+tools/swag

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,104 @@
+GO111MODULE=on
+export GO111MODULE
+
+TAG := `git describe --tags --always`
+SHELL = /bin/bash
+DOCKER_CMD ?= "docker"
+DOCKER_REPO ?= "ghcr.io/kinvolk"
+DOCKER_IMAGE_NEBRASKA ?= "nebraska"
+VERSION ?=
+ifeq ($(VERSION),)
+	## Adds a '-dirty' suffix to version string if there are uncommitted changes
+	changes := $(shell git status ./backend ./frontend --porcelain)
+	ifeq ($(changes),)
+		VERSION := $(TAG)
+	else
+		VERSION := $(TAG)-dirty
+	endif
+endif
+
+LDFLAGS := "-w -X github.com/kinvolk/nebraska/backend/pkg/version.Version=$(VERSION) -extldflags \"-static\""
+.PHONY: all
+all: run-generators code-checks build
+
+.PHONY: check
+check:
+	go test -p 1 ./...
+
+coverage.out: check-code-coverage
+
+check-code-coverage:
+	go test -p 1 -coverprofile=coverage.out ./...
+
+container_id:
+	./tools/setup_local_db.sh \
+		--id-file container_id.tmp \
+		--db-name nebraska_tests \
+		--password nebraska \
+		--pg-version 13.3
+	mv container_id.tmp container_id
+
+.PHONY: check-backend-with-container
+check-backend-with-container: container_id
+	set -e; \
+	trap "$(DOCKER_CMD) kill $$(cat container_id); $(DOCKER_CMD) rm $$(cat container_id); rm -f container_id" EXIT; \
+	go test -p 1 ./...
+
+run: bin/nebraska
+	./bin/nebraska -auth-mode noop -debug
+
+.PHONY: build
+build: run-generators bin/nebraska
+
+.PHONY: test-clean-work-tree-backend
+test-clean-work-tree-backend:
+	if ! git diff --quiet -- go.mod go.sum pkg cmd tools/tools.go; then \
+	  echo; \
+	  echo 'Working tree of backend code is not clean'; \
+	  echo; \
+	  git status; \
+	  exit 1; \
+	fi
+
+.PHONY: tools
+tools: bin/initdb bin/userctl
+
+bin/initdb:
+	go build -o bin/initdb ./cmd/initdb
+
+bin/userctl:
+	go build -o bin/userctl ./cmd/userctl
+
+tools/go-bindata: go.mod go.sum
+	env GOBIN=$(CURDIR)/tools/ go install github.com/kevinburke/go-bindata/go-bindata@v3.22.0
+
+tools/golangci-lint: go.mod go.sum
+	env GOBIN=$(CURDIR)/tools/ go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+
+tools/swag:
+	env GOBIN=$(CURDIR)/tools/ go install github.com/swaggo/swag/cmd/swag@v1.7.4
+
+.PHONY: ci
+ci: build test-clean-work-tree-backend check-backend-with-container
+
+.PHONY: run-generators
+run-generators: tools/go-bindata
+	PATH="$(abspath tools):$${PATH}" go generate ./...
+
+bin/nebraska: run-generators
+	 go build -a -tags netgo -trimpath -ldflags ${LDFLAGS} -o bin/nebraska ./cmd/nebraska
+
+.PHONY: code-checks
+code-checks: tools/golangci-lint
+	# this is to get nice error messages when something doesn't
+	# build (both the project and the tests), golangci-lint's
+	# output in this regard in unreadable.
+	go build ./...
+	./tools/check_pkg_test.sh
+	NEBRASKA_SKIP_TESTS=1 go test ./... >/dev/null
+	./tools/golangci-lint run --fix
+	go mod tidy
+
+.PHONY: swagger-init
+swagger-init:  tools/swag
+	./tools/swag init -g cmd/userctl/main.go -o api

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+node_modules
+yarn-error.log
+src/js/icons/*.json

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,0 +1,42 @@
+.PHONY: frontend
+frontend: build
+
+.PHONY: watch
+watch: run
+
+.PHONY: run
+run: node_modules
+	npm start
+
+.PHONY: install
+install: node_modules
+
+.PHONY: install-ci
+install-ci:
+	npm ci
+
+.PHONY: build
+build: install
+	npm run build
+
+.PHONY: test
+test:
+	npm run test
+
+.PHONY: lint
+lint:
+	npm run lint
+
+.PHONY: tsc
+tsc:
+	npm run tsc
+
+.PHONY: i18n
+i18n:
+	npm run i18n
+
+.PHONY: ci
+ci: install-ci lint test build tsc
+
+node_modules:
+	npm install


### PR DESCRIPTION
# Split frontend and backend build parts

## Makefile

- `make` will call `Makefile` in _frontend_ and _backend_
- `make run` call `run` in both _frontend_ and _backend_

## Dockerfile

- use _distroless_ for run
  - use non-root user
- make binary static
  - and make it smaller
- use _node_ image for frontend build
- use caching
  - remove `non-cache` build parameter
  - improve `.dockerignore`
  - use docker/dockerfile:1.3 syntax for better caching