### PR TITLE
backend: reauthenticate if refresh token fails

### DIFF
--- a/backend/cmd/nebraska/auth/oidcauth.go
+++ b/backend/cmd/nebraska/auth/oidcauth.go
@@ -350,8 +350,8 @@ func (oa *oidcAuth) Authenticate(c *gin.Context) (teamID string, replied bool) {
 			ts := oa.oauthConfig.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken.(string)})
 			newToken, err := ts.Token()
 			if err != nil {
-				logger.Error().Str("request_id", requestID).AnErr("error", err).Msg("ID Token refresh error")
-				httpError(c, http.StatusInternalServerError)
+				logger.Warn().Str("request_id", requestID).AnErr("error", err).Msg("Failed to use refresh token, reauthenticating")
+				httpError(c, http.StatusUnauthorized)
 				return "", true
 			}
 


### PR DESCRIPTION
OAuth 2.0 refresh tokens are optional and even if provided
they can be invalidated at any time by the IDP.
This just reauthenticates if a valid token cannot be
obtained.

## How to use

Users don't get an Internal Server Error if no new token can be obtained and instead are just reauthenticated.

## Testing done

This has been running for a few months on an instance I'm operating with an IDP which doesn't
give out refresh tokens when not asking for offline_access. Previously I reliably got an internal server error
within a short time, now it works.
