### PR TITLE
DB Autovacuum, and Autoanalyze thresholds

### DIFF
--- a/backend/pkg/api/db/migrations/0017_autovac_thresholds.sql
+++ b/backend/pkg/api/db/migrations/0017_autovac_thresholds.sql
@@ -1,0 +1,104 @@
+-- +migrate Up
+
+ALTER TABLE
+    instance
+SET
+    (
+        autovacuum_analyze_scale_factor = 0,
+        autovacuum_analyze_threshold = 3666,
+        autovacuum_vacuum_scale_factor = 0,
+        autovacuum_vacuum_threshold = 7333
+    );
+
+
+ALTER TABLE
+    instance_application
+SET
+    (
+        autovacuum_analyze_scale_factor = 0,
+        autovacuum_analyze_threshold = 3666,
+        autovacuum_vacuum_scale_factor = 0,
+        autovacuum_vacuum_threshold = 7333
+    );
+
+ALTER TABLE
+    activity
+SET
+    (
+        autovacuum_analyze_scale_factor = 0,
+        autovacuum_analyze_threshold = 10000,
+        autovacuum_vacuum_scale_factor = 0,
+        autovacuum_vacuum_threshold = 20000
+    );
+
+ALTER TABLE
+    event
+SET
+    (
+        autovacuum_analyze_scale_factor = 0,
+        autovacuum_analyze_threshold = 950,
+        autovacuum_vacuum_scale_factor = 0,
+        autovacuum_vacuum_threshold = 1900
+    );
+
+ALTER TABLE
+    instance_status_history
+SET
+    (
+        autovacuum_analyze_scale_factor = 0,
+        autovacuum_analyze_threshold = 12500,
+        autovacuum_vacuum_scale_factor = 0,
+        autovacuum_vacuum_threshold = 25000
+    );
+
+-- +migrate Down
+
+ALTER TABLE
+    instance
+SET
+    (
+        autovacuum_analyze_scale_factor = 0.1,
+        autovacuum_analyze_threshold = 50,
+        autovacuum_vacuum_scale_factor = 0.2,
+        autovacuum_vacuum_threshold = 50
+    );
+
+ALTER TABLE
+    instance_application
+SET
+    (
+        autovacuum_analyze_scale_factor = 0.1,
+        autovacuum_analyze_threshold = 50,
+        autovacuum_vacuum_scale_factor = 0.2,
+        autovacuum_vacuum_threshold = 50
+    );
+
+ALTER TABLE
+    activity
+SET
+    (
+        autovacuum_analyze_scale_factor = 0.1,
+        autovacuum_analyze_threshold = 50,
+        autovacuum_vacuum_scale_factor = 0.2,
+        autovacuum_vacuum_threshold = 50
+    );
+
+ALTER TABLE
+    event
+SET
+    (
+        autovacuum_analyze_scale_factor = 0.1,
+        autovacuum_analyze_threshold = 50,
+        autovacuum_vacuum_scale_factor = 0.2,
+        autovacuum_vacuum_threshold = 50
+    );
+
+ALTER TABLE
+    instance_status_history
+SET
+    (
+        autovacuum_analyze_scale_factor = 0.1,
+        autovacuum_analyze_threshold = 50,
+        autovacuum_vacuum_scale_factor = 0.2,
+        autovacuum_vacuum_threshold = 50
+    );


### PR DESCRIPTION
This hopefully addresses the DB table/index bloat size issue https://github.com/kinvolk/nebraska/issues/507

Because autovacuum and autoanalyze are effectively disabled when tables
are very large. This is because the default is 20% of a table (and 10%
of a table for analyze).

Instead we change it to when about 5,000 rows change. This value was chosen
based on getting the autovacuum to run every day. Because it's large enough
to not cause the autovac to run all the time, but about the right size
to make a difference for query statistics and reducing table bloat.

The analyze threshold was chosen at half the autovacuum threshold
because the defaults are set at half.

Ultimately there should be some sort of auto-tuning done where the table growth/change rates are calculated and then these thresholds are updated. It has happened where a table gets a 5x growth over other months inside one month. It could be even greater. If it's only 10x growth then the autovac would only run 10 times per day, which is acceptable.


## Testing done

Ran some tests to reproduce index bloat without the thresholds. https://github.com/kinvolk/nebraska/issues/507#issuecomment-964522622 Then confirmed that table bloat was almost reduced entirely, auto analyze was running and index bloat was reduced to 2x compared to 10x observed.

- [x] Check the table growth rates.
- [x] Check if there are other tables to add to this list. Only the tables from the cleanup script were chosen.

