### PR TITLE
frontend: fix small typo to default applications message

### DIFF
--- a/frontend/src/js/components/Applications/List.tsx
+++ b/frontend/src/js/components/Applications/List.tsx
@@ -74,7 +74,7 @@ function List(props: { classes: Record<'root', string> }) {
         entries = (
           <Empty>
             <Trans ns="applications">
-              Ops, it looks like you have not created any application yet..
+              Oops, it looks like you have not created any application yet..
               <br />
               <br /> Now is a great time to create your first one, just click on the plus symbol
               above.


### PR DESCRIPTION
# fix small typo to default applications message

This is a typo fix for the default page, when no Applications are present. This usually isn't shown, but I'm seeing it with an issue with my roles, so I thought I would submit I PR. Hope this is helpful.

![Screen Shot 2021-11-24 at 11 26 58 AM](https://user-images.githubusercontent.com/4894582/143286501-1c56e64e-16bf-4726-a3dd-98afd99409b4.png)

## How to use

Shows up when no applications exist, or the user has insufficient roles.

## Testing done

Not sure what the stub is to run this, happy to test if necessary. Not sure how to use the typescript tool chain to run this locally.
