### PR TITLE
chart: decouple nebraska-url flag from host packages toggle

### DIFF
--- a/charts/nebraska/templates/deployment.yaml
+++ b/charts/nebraska/templates/deployment.yaml
@@ -71,11 +71,13 @@ spec:
             {{- if .Values.config.hostFlatcarPackages.enabled }}
             - "-host-flatcar-packages"
             - "-flatcar-packages-path={{ required "A valid 'packagesPath' is required when hosting Flatcar packages." .Values.config.hostFlatcarPackages.packagesPath }}"
-              {{- if .Values.config.hostFlatcarPackages.nebraskaURL }}
+            {{- end }}
+
+            {{- /* --- Nebraska URL settings ---*/}}
+            {{- if .Values.config.hostFlatcarPackages.nebraskaURL }}
             - "-nebraska-url={{ .Values.config.hostFlatcarPackages.nebraskaURL }}"
-              {{- else if .Values.ingress.enabled }}
+            {{- else if .Values.ingress.enabled }}
             - "-nebraska-url={{ printf "%s://%s"  (include "nebraska.ingressScheme" .) (index .Values.ingress.hosts 0) }}"
-              {{- end }}
             {{- end }}
 
             {{- /* --- Auth settings --- */}}
@@ -180,7 +182,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "nebraska.fullname" . }}
-                  key: oidcSessionCryptKey   
+                  key: oidcSessionCryptKey
               {{- end }}
             {{- end }}
             {{- range $key, $value := .Values.extraEnvVars }}


### PR DESCRIPTION
# decouple nebraska-url flag from host packages toggle

The need for this PR is outlined in #518.

At current, if I enable the ingress without enabling the host package, all links and redirects default to `localhost`, which breaks nebraska.

## How to use

The ingress by default is passed to the application through the `-nebraska-url` flag. If `.Values.config.hostFlatcarPackages.nebraskaURL` is set, it takes precedence.

## Testing done

I have templated locally with 

`helm template  --output-dir test-output/ . --debug`

outcome: `deployment.yaml` appends `- "-nebraska-url=http://flatcar.example.com"` to args

`helm template  --output-dir test-output/ . --set ingress.enabled=true --set ingress.hosts\[0\]="https://kinvolk.rocks"`

outcome: `deployment.yaml` appends `- "-nebraska-url=http://flatcar.example.com"`

I have installed the chart in this PR to a local cluster as well.

I am partially concerned with the default now being that `-nebraska-url` is always set, because the default `ingress.enabled` is true. For local installations, this should not be the case, but I believe that the default ingress should be disabled if that's the desired outcome. 
