### PR TITLE
chart: add extraArgs functionality

### DIFF
--- a/charts/nebraska/templates/deployment.yaml
+++ b/charts/nebraska/templates/deployment.yaml
@@ -116,6 +116,13 @@ spec:
             - "-oidc-scopes={{ . }}"
               {{- end }}
             {{- end }}
+
+            {{- /* --- Extra Args --- */ -}}
+            {{- if .Values.extraArgs }}
+            {{- range .Values.extraArgs }}
+            - "{{ . }}"
+            {{- end }}
+            {{- end }}
           env:
             - name: DB_PASSWORD
               valueFrom:
@@ -180,7 +187,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "nebraska.fullname" . }}
-                  key: oidcSessionCryptKey   
+                  key: oidcSessionCryptKey
               {{- end }}
             {{- end }}
             {{- range $key, $value := .Values.extraEnvVars }}


### PR DESCRIPTION
# add extraArgs functionality

Outlined in #520, while the `README.md` outlines that an `extraArgs` list is available to pass additional flags to the `nebraska` binary, it doesn't actually exist in the `deployment.yaml` manifest. This PR resolves that.

## How to use

Populate `extraArgs`, and get the output templated in the `deployment.yaml` manifest as intended.

## Testing done

Borrowing from the example listed in [`values.yaml`](https://github.com/kinvolk/nebraska/blob/main/charts/nebraska/values.yaml#L79-L81), I tested the default chart first, which results in templates being rendered without `extraArgs` since the default is `[]`, then using the first example with:

```
helm template  --output-dir test-output/ . --set extraArgs\[0\]="-http-log"
```

resulting in the following deployment snippet being rendered:

```
          args:
            - "-client-title=Kinvolk Update Service"
            - "-client-logo=/nebraska/assets/kinvolk-logo.svg"
            - "-client-header-style=dark"
            - "-http-static-dir=/nebraska/static"
            - "-enable-syncer"
            - "-auth-mode=noop"
            - "-http-log"
```

This is also tested by setting the `values.yaml` to the first example, and getting the same output as above.

`values.yaml`:

```
extraArgs:
  - "-http-log"
```

rendered `deployment.yaml`:

```
          args:
            - "-client-title=Kinvolk Update Service"
            - "-client-logo=/nebraska/assets/kinvolk-logo.svg"
            - "-client-header-style=dark"
            - "-http-static-dir=/nebraska/static"
            - "-enable-syncer"
            - "-auth-mode=noop"
            - "-http-log"
```