### PR TITLE
chart: remove extra quote in logout url

### DIFF
--- a/charts/nebraska/templates/deployment.yaml
+++ b/charts/nebraska/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
             - "-oidc-management-url={{ . }}"
               {{- end }}
               {{- with .Values.config.auth.oidc.logoutURL }}
-            - "-oidc-logout-url"={{ . }}"
+            - "-oidc-logout-url={{ . }}"
               {{- end }}
               {{- with .Values.config.auth.oidc.adminRoles }}
             - "-oidc-admin-roles={{ . }}"
@@ -180,7 +180,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "nebraska.fullname" . }}
-                  key: oidcSessionCryptKey   
+                  key: oidcSessionCryptKey
               {{- end }}
             {{- end }}
             {{- range $key, $value := .Values.extraEnvVars }}


### PR DESCRIPTION
# remove extra quote in logout url

Looks like there's an extra quote in the deployment manifest under logout url, which breaks rendering if `logoutURL` is set
when someone uses the oidc configuration

## How to use

Here's what happens on `main` currently if this is set:

```
helm template  --output-dir test-output/ . --set config.auth.mode=oidc --set config.auth.oidc.logoutURL=https://my.url.com/logout --set config.auth.oidc.clientID=fake --set config.auth.oidc.clientSecret=fake 

Error: YAML parse error on nebraska/templates/deployment.yaml: error converting YAML to JSON: yaml: line 45: did not find expected '-' indicator

Use --debug flag to render out invalid YAML
```

## Testing done

With this typo fix:

```
helm template  --output-dir test-output/ . --set config.auth.mode=oidc --set config.auth.oidc.logoutURL=https://my.url.com/logout --set config.auth.oidc.clientID=fake --set config.auth.oidc.clientSecret=fake

wrote test-output//nebraska/charts/postgresql/templates/secrets.yaml
wrote test-output//nebraska/templates/secrets.yaml
wrote test-output//nebraska/charts/postgresql/templates/svc-headless.yaml
wrote test-output//nebraska/charts/postgresql/templates/svc.yaml
wrote test-output//nebraska/templates/service.yaml
wrote test-output//nebraska/templates/deployment.yaml
wrote test-output//nebraska/charts/postgresql/templates/statefulset.yaml
wrote test-output//nebraska/templates/ingress.yaml
```

Rendered output:

```
          args:
            - "-client-title=Kinvolk Update Service"
            - "-client-logo=/nebraska/assets/kinvolk-logo.svg"
            - "-client-header-style=dark"
            - "-http-static-dir=/nebraska/static"
            - "-enable-syncer"
            - "-auth-mode=oidc"
            - "-oidc-logout-url=https://my.url.com/logout"
```
