### PR TITLE
charts: Don't verify the version has been bumped when linting in CI

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,3 +1,4 @@
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 target-branch: main
+check-version-increment: false


### PR DESCRIPTION
So we don't have to bump the chart version every time we do changes, just for the lint to successfully run.