### PR TITLE
chart - update chart to 0.1.10 to include recent changes

### DIFF
--- a/charts/nebraska/Chart.yaml
+++ b/charts/nebraska/Chart.yaml
@@ -19,7 +19,7 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 0.1.9
+version: 0.1.10
 appVersion: "2.5.1"
 
 dependencies:


### PR DESCRIPTION
# update chart to 0.1.10 to include recent changes

Can we please bump the chart so recent merges can be used?

## How to use

chart version can be specified when installing the chart

## Testing done

