### PR TITLE
backend: add wildcard to glob validations for validRedirectURL

### DIFF
--- a/backend/cmd/nebraska/auth/oidcauth.go
+++ b/backend/cmd/nebraska/auth/oidcauth.go
@@ -245,7 +245,7 @@ func (oa *oidcAuth) login(c *gin.Context) {
 	loginRedirectURL := c.Request.URL.Query().Get("login_redirect_url")
 	isValidRedirect := false
 	for _, redirectURL := range oa.validRedirectURLs {
-		if glob.Glob(redirectURL, loginRedirectURL) {
+		if glob.Glob(fmt.Sprintf("%s*", redirectURL), loginRedirectURL) {
 			isValidRedirect = true
 			break
 		}


### PR DESCRIPTION
# Add wildcard to glob validations for validRedirectURL

Please see #533 for a detailed description. The way that the loginRedirectURL query parameter is validated against entries in `validRedirectURLs` doesn't account for routes in `validRedirectURLs`. While an argument could be made that the user should append '*' to this flag, this isn't called out in any of the supporting documentation at current, nor am I sure it makes sense given how the check is setup.

## How to use

You would need to deploy nebraska with a valid oidc configuration and follow the repro in #533 

## Testing done

Results can be compared from [the changes in this pr](https://go.dev/play/p/VcTZJ4e3lzT) vs [the code as it stands](https://go.dev/play/p/_PZMalCIZDJ)
