### PR TITLE
Improve Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,18 @@
+Dockerfile
+.dockerignore
+
+.git
+.gitignore
+
+# frontend
 **/node_modules
 frontend/build
-docs/
-bin/nebraska
-backend/tools/
+
+# backend
 backend/bin
+backend/coverage.out
+backend/tools/go-bindata
+backend/tools/golangci-lint
+
+docs/
 charts/


### PR DESCRIPTION
# Improve Docker image

- [x] :chart_with_upwards_trend: caching
  - [x] separate front / back
  - [x] node_module caching
  - [x] go.mod caching  
- [x] :chart_with_downwards_trend: build time
  - [x] multistep build can be //
- [ ] :chart_with_downwards_trend: final size
  - [x] CGO_ENABLED=0
  - [ ] before 42M
- [x] :chart_with_upwards_trend: security
  - [x] run as user (not root)
- [x] :chart_with_upwards_trend: usability
  - [x] using `ENTRYPOINT`, only have to add some `ARGS` to customize run 

## How to use

- :warning: depends on #503 
- :warning:  Dockerkit should be installed (or any builder that accept `syntax = docker/dockerfile:1.3`)

