### PR TITLE
backend test: Fix lint issues

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,6 +5,7 @@ on:
     - 'backend/cmd/**'
     - 'backend/pkg/**'
     - 'backend/tools/**'
+    - 'backend/test/**'
     - 'backend/go.mod'
     - 'backend/go.sum'
     - 'updaters/**'

--- a/backend/test/api/activity_test.go
+++ b/backend/test/api/activity_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kinvolk/nebraska/backend/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kinvolk/nebraska/backend/pkg/api"
 )
 
 func TestListActivity(t *testing.T) {

--- a/backend/test/api/app_test.go
+++ b/backend/test/api/app_test.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kinvolk/nebraska/backend/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kinvolk/nebraska/backend/pkg/api"
 )
 
 func TestListApp(t *testing.T) {

--- a/backend/test/api/channel_test.go
+++ b/backend/test/api/channel_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 
 	"github.com/jinzhu/copier"
-	"github.com/kinvolk/nebraska/backend/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kinvolk/nebraska/backend/pkg/api"
 )
 
 func TestListChannels(t *testing.T) {
@@ -103,7 +104,8 @@ func TestUpdateChannel(t *testing.T) {
 
 	// update channel request
 	var channelDB api.Channel
-	copier.Copy(&channelDB, app.Channels[0])
+	err := copier.Copy(&channelDB, app.Channels[0])
+	require.NoError(t, err)
 
 	channelName := "test_channel"
 	channelDB.Name = channelName

--- a/backend/test/api/group_test.go
+++ b/backend/test/api/group_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 
 	"github.com/jinzhu/copier"
-	"github.com/kinvolk/nebraska/backend/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kinvolk/nebraska/backend/pkg/api"
 )
 
 func TestListGroups(t *testing.T) {
@@ -102,7 +103,8 @@ func TestUpdateGroup(t *testing.T) {
 
 		// update group request
 		var groupDB api.Group
-		copier.Copy(&groupDB, app.Groups[0])
+		err := copier.Copy(&groupDB, app.Groups[0])
+		require.NoError(t, err)
 
 		groupName := "test_group"
 		groupDB.Name = groupName

--- a/backend/test/api/helper_test.go
+++ b/backend/test/api/helper_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kinvolk/nebraska/backend/pkg/api"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kinvolk/nebraska/backend/pkg/api"
 )
 
 // newDBForTest is a helper function that

--- a/backend/test/api/instance_test.go
+++ b/backend/test/api/instance_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/kinvolk/nebraska/backend/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kinvolk/nebraska/backend/pkg/api"
 )
 
 func TestListInstances(t *testing.T) {

--- a/backend/test/api/omaha_test.go
+++ b/backend/test/api/omaha_test.go
@@ -14,14 +14,12 @@ import (
 )
 
 func TestOmaha(t *testing.T) {
-
 	// establish db connection
 	db := newDBForTest(t)
 
 	app := getAppWithInstance(t, db)
 
 	t.Run("success", func(t *testing.T) {
-
 		track := app.Groups[0].Track
 
 		url := fmt.Sprintf("%s/omaha", testServerURL)

--- a/backend/test/api/package_test.go
+++ b/backend/test/api/package_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 
 	"github.com/jinzhu/copier"
-	"github.com/kinvolk/nebraska/backend/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kinvolk/nebraska/backend/pkg/api"
 )
 
 func TestListPackages(t *testing.T) {
@@ -114,7 +115,8 @@ func TestUpdatePackage(t *testing.T) {
 
 		// update package request
 		var packageDB api.Package
-		copier.Copy(&packageDB, packagesDB[0])
+		err = copier.Copy(&packageDB, packagesDB[0])
+		require.NoError(t, err)
 
 		packageVersion := "20.2.2"
 		packageDB.Version = packageVersion

--- a/backend/test/api/stats_test.go
+++ b/backend/test/api/stats_test.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/kinvolk/nebraska/backend/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kinvolk/nebraska/backend/pkg/api"
 )
 
 func TestGroupVersionTimeline(t *testing.T) {
@@ -180,7 +181,6 @@ func TestGroupStatusTimeline(t *testing.T) {
 		}
 
 		assert.Equal(t, dbStatusCountMap, respStatusCountMap)
-
 	})
 }
 


### PR DESCRIPTION
Some lint issues slipped in because backend/test was not matched in the backend workflow.
