### PR TITLE
chart: Update postgres dependency 12.5.x -> 12.9.x

### DIFF
--- a/charts/nebraska/Chart.lock
+++ b/charts/nebraska/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.3.8
-digest: sha256:1e05bf878e384a1b34cef8c93c6e98b6bfc68f8ef31f8a06c220ba49c8e627ca
-generated: "2021-03-03T14:06:51.357213+01:00"
+  version: 10.16.2
+digest: sha256:e09e206d81074a6540102fb62b8b12cf943c934c2af21e58ff8caa259690e87a
+generated: "2022-01-27T12:36:29.989805+01:00"

--- a/charts/nebraska/Chart.yaml
+++ b/charts/nebraska/Chart.yaml
@@ -19,11 +19,11 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 0.2.0
+version: 0.2.1
 appVersion: "2.5.1"
 
 dependencies:
   - name: postgresql
-    version: 10.3.8
+    version: 10.16.2
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled

--- a/charts/nebraska/README.md
+++ b/charts/nebraska/README.md
@@ -117,7 +117,7 @@ $ helm install my-nebraska nebraska/nebraska
 | `postgresql.postgresqlUsername`         | PostgreSQL user (creates a non-admin user when `postgresqlUsername` is not `postgres`)          | `postgres`             |
 | `postgresql.postgresqlPassword`         | PostgreSQL user password **Recommended to change it to something secure for security reasons.** | `changeIt`             |
 | `postgresql.postgresqlPostgresPassword` | PostgreSQL admin password (used when `postgresqlUsername` is not `postgres`)                    | `-`                    |
-| `postgresql.image.tag`                  | PostgreSQL Image tag                                                                            | `12.5.0-debian-10-r76` |
+| `postgresql.image.tag`                  | PostgreSQL Image tag                                                                            | `12.9.0-debian-10-r72` |
 | `postgresql.persistence.enabled`        | Enable persistence using PVC                                                                    | `false`                |
 | `postgresql.persistence.storageClass`   | PVC Storage Class for PostgreSQL volume                                                         | `nil`                  |
 | `postgresql.persistence.accessModes`    | PVC Access Mode for PostgreSQL volume                                                           | `["ReadWriteOnce"]`    |

--- a/charts/nebraska/values.yaml
+++ b/charts/nebraska/values.yaml
@@ -195,7 +195,7 @@ postgresql:
   postgresqlUsername: postgres
   postgresqlPassword: changeIt
   image:
-    tag: 12.5.0-debian-10-r76
+    tag: 12.9.0-debian-10-r72
   persistence:
     enabled: false
     storageClass:


### PR DESCRIPTION
# Update postgres dependency 12.5.x -> 12.9.x

Let's upgrade the postgres dependency to be in line with the current version from Bitnami.

Do you have a recommended postgres version to use together with nebraska? We could also use PG 13 or 14 if you want.

## How to use

nothing special

## Testing done

- [x] Manual testing in my own k8s environment.
- [x] Tests from pipeline are green
