### PR TITLE
Integration test improvements

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -40,7 +40,8 @@ test-service-down:
 	docker compose -f ./docker-compose.test.yaml down
 
 .PHONY: check-backend-with-container
-check-backend-with-container: test-service-up
+check-backend-with-container: test-service-down
+	$(MAKE) test-service-up
 	go clean -testcache && NEBRASKA_RUN_SERVER_TESTS=1 NEBRASKA_TEST_SERVER_URL="http://localhost:8002" NEBRASKA_DB_URL=$(CONTAINER_NEBRASKA_DB_URL) go test -p 1 ./...
 	$(MAKE) test-service-down
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -40,7 +40,7 @@ test-service-down:
 
 .PHONY: check-backend-with-container
 check-backend-with-container: test-service-up
-	go clean -testcache && go test -p 1 ./...
+	go clean -testcache && NEBRASKA_RUN_SERVER_TESTS=1 go test -p 1 ./...
 	$(MAKE) test-service-down
 
 run: bin/nebraska

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,6 +7,7 @@ DOCKER_CMD ?= "docker"
 DOCKER_REPO ?= "ghcr.io/kinvolk"
 DOCKER_IMAGE_NEBRASKA ?= "nebraska"
 VERSION ?=
+CONTAINER_NEBRASKA_DB_URL ?= "postgres://postgres:nebraska@127.0.0.1:8001/nebraska_tests?sslmode=disable&connect_timeout=10"
 ifeq ($(VERSION),)
 	## Adds a '-dirty' suffix to version string if there are uncommitted changes
 	changes := $(shell git status ./backend ./frontend --porcelain)
@@ -40,7 +41,7 @@ test-service-down:
 
 .PHONY: check-backend-with-container
 check-backend-with-container: test-service-up
-	go clean -testcache && NEBRASKA_RUN_SERVER_TESTS=1 go test -p 1 ./...
+	go clean -testcache && NEBRASKA_RUN_SERVER_TESTS=1 NEBRASKA_TEST_SERVER_URL="http://localhost:8002" NEBRASKA_DB_URL=$(CONTAINER_NEBRASKA_DB_URL) go test -p 1 ./...
 	$(MAKE) test-service-down
 
 run: bin/nebraska

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -32,7 +32,7 @@ check-code-coverage:
 
 .PHONY: test-service-up
 test-service-up:
-	docker compose -f ./docker-compose.test.yaml up -d
+	docker compose -f ./docker-compose.test.yaml up -d --build
 
 .PHONY: test-service-down
 test-service-down:

--- a/backend/docker-compose.test.yaml
+++ b/backend/docker-compose.test.yaml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:13.3
     ports:
-      - "5432:5432"
+      - "8001:5432"
     environment:
       POSTGRES_PASSWORD: nebraska
       POSTGRES_DB: nebraska_tests
@@ -21,7 +21,7 @@ services:
       context: ../
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8002:8000"
     depends_on:
       postgres:
         condition: service_healthy

--- a/backend/test/api/activity_test.go
+++ b/backend/test/api/activity_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func TestListActivity(t *testing.T) {
 		require.NotNil(t, activitiesDB)
 
 		// fetch activity from api
-		url := fmt.Sprintf("%s/api/activity?start=%s&end=%s", testServerURL, startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
+		url := fmt.Sprintf("%s/api/activity?start=%s&end=%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
 		method := "GET"
 
 		// response

--- a/backend/test/api/api_test.go
+++ b/backend/test/api/api_test.go
@@ -14,7 +14,7 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	if os.Getenv("NEBRASKA_SKIP_TESTS") != "" {
+	if os.Getenv("NEBRASKA_SKIP_TESTS") != "" || os.Getenv("NEBRASKA_RUN_SERVER_TESTS") == "" {
 		return
 	}
 

--- a/backend/test/api/api_test.go
+++ b/backend/test/api/api_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	testServerURL    = "http://localhost:8000"
-	defaultTestDbURL = "postgres://postgres:nebraska@127.0.0.1:5432/nebraska_tests?sslmode=disable&connect_timeout=10"
+	defaultTestServerURL = "http://localhost:8002"
+	defaultTestDbURL     = "postgres://postgres:nebraska@127.0.0.1:5432/nebraska_tests?sslmode=disable&connect_timeout=10"
 )
 
 func TestMain(m *testing.M) {
@@ -21,6 +21,11 @@ func TestMain(m *testing.M) {
 	if _, ok := os.LookupEnv("NEBRASKA_DB_URL"); !ok {
 		log.Printf("NEBRASKA_DB_URL not set, setting to default %q\n", defaultTestDbURL)
 		_ = os.Setenv("NEBRASKA_DB_URL", defaultTestDbURL)
+	}
+
+	if _, ok := os.LookupEnv("NEBRASKA_TEST_SERVER_URL"); !ok {
+		log.Printf("NEBRASKA_TEST_SERVER_URL not set, setting to default %q\n", defaultTestServerURL)
+		_ = os.Setenv("NEBRASKA_TEST_SERVER_URL", defaultTestServerURL)
 	}
 
 	a, err := api.New(api.OptionInitDB)

--- a/backend/test/api/app_test.go
+++ b/backend/test/api/app_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestListApp(t *testing.T) {
 		require.NotNil(t, appsDB)
 
 		// fetch apps from the API
-		url := fmt.Sprintf("%s/api/apps", testServerURL)
+		url := fmt.Sprintf("%s/api/apps", os.Getenv("NEBRASKA_TEST_SERVER_URL"))
 		method := "GET"
 
 		// TODO: will require change as response struct is changed in POC2 branch
@@ -50,7 +51,7 @@ func TestCreateApp(t *testing.T) {
 
 	t.Run("success_do_not_copy", func(t *testing.T) {
 		// Create App request
-		url := fmt.Sprintf("%s%s", testServerURL, "/api/apps")
+		url := fmt.Sprintf("%s%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), "/api/apps")
 		method := "POST"
 
 		appName := "test"
@@ -74,7 +75,7 @@ func TestCreateApp(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		// Create App request
-		url := fmt.Sprintf("%s/api/apps?clone_from=%s", testServerURL, app.ID)
+		url := fmt.Sprintf("%s/api/apps?clone_from=%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID)
 		method := "POST"
 
 		appName := "test_with_clone"
@@ -101,7 +102,7 @@ func TestGetApp(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		// fetch app by id request
-		url := fmt.Sprintf("%s/api/apps/%s", testServerURL, app.ID)
+		url := fmt.Sprintf("%s/api/apps/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID)
 		method := "GET"
 
 		// check response
@@ -123,7 +124,7 @@ func TestUpdateApp(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		// Update App Request
-		url := fmt.Sprintf("%s/api/apps/%s", testServerURL, app.ID)
+		url := fmt.Sprintf("%s/api/apps/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID)
 		method := "PUT"
 
 		name := "updated_name"
@@ -154,7 +155,7 @@ func TestDeleteApp(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		// Update App Request
-		url := fmt.Sprintf("%s/api/apps/%s", testServerURL, app.ID)
+		url := fmt.Sprintf("%s/api/apps/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID)
 		method := "DELETE"
 
 		httpDo(t, url, method, nil, http.StatusNoContent, "", nil)

--- a/backend/test/api/channel_test.go
+++ b/backend/test/api/channel_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestListChannels(t *testing.T) {
 		require.NotNil(t, channelsDB)
 
 		// fetch channels from API
-		url := fmt.Sprintf("%s/api/apps/%s/channels", testServerURL, app.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/channels", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID)
 		method := "GET"
 
 		// response
@@ -53,7 +54,7 @@ func TestCreateChannel(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		// create channel using the API
-		url := fmt.Sprintf("%s/api/apps/%s/channels", testServerURL, app.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/channels", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID)
 		method := "POST"
 
 		channelName := "test_channel"
@@ -82,7 +83,7 @@ func TestGetChannel(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		// fetch channel by id request
-		url := fmt.Sprintf("%s/api/apps/%s/channels/%s", testServerURL, app.ID, app.Channels[0].ID)
+		url := fmt.Sprintf("%s/api/apps/%s/channels/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID, app.Channels[0].ID)
 		method := "GET"
 
 		// response
@@ -113,7 +114,7 @@ func TestUpdateChannel(t *testing.T) {
 	payload, err := json.Marshal(channelDB)
 	require.NoError(t, err)
 
-	url := fmt.Sprintf("%s/api/apps/%s/channels/%s", testServerURL, channelDB.ApplicationID, channelDB.ID)
+	url := fmt.Sprintf("%s/api/apps/%s/channels/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), channelDB.ApplicationID, channelDB.ID)
 	method := "PUT"
 
 	// response
@@ -138,7 +139,7 @@ func TestDeleteChannel(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		channelDB := app.Channels[0]
-		url := fmt.Sprintf("%s/api/apps/%s/channels/%s", testServerURL, channelDB.ApplicationID, channelDB.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/channels/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), channelDB.ApplicationID, channelDB.ID)
 		method := "DELETE"
 
 		httpDo(t, url, method, nil, http.StatusNoContent, "", nil)

--- a/backend/test/api/config_test.go
+++ b/backend/test/api/config_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ import (
 
 func TestConfig(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		url := fmt.Sprintf("%s/config", testServerURL)
+		url := fmt.Sprintf("%s/config", os.Getenv("NEBRASKA_TEST_SERVER_URL"))
 		method := "GET"
 		// response
 		rMap := make(map[string]interface{})

--- a/backend/test/api/group_test.go
+++ b/backend/test/api/group_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestListGroups(t *testing.T) {
 		require.NotNil(t, groupsDB)
 
 		// fetch groups from API
-		url := fmt.Sprintf("%s/api/apps/%s/groups", testServerURL, app.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID)
 		method := "GET"
 
 		// response
@@ -52,7 +53,7 @@ func TestCreateGroup(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		// create group using the API
-		url := fmt.Sprintf("%s/api/apps/%s/groups", testServerURL, app.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID)
 		method := "POST"
 
 		groupName := "test_group"
@@ -81,7 +82,7 @@ func TestGetGroup(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		// fetch group by id request
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s", testServerURL, app.ID, app.Groups[0].ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID, app.Groups[0].ID)
 		method := "GET"
 
 		// response
@@ -112,7 +113,7 @@ func TestUpdateGroup(t *testing.T) {
 		payload, err := json.Marshal(groupDB)
 		require.NoError(t, err)
 
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s", testServerURL, groupDB.ApplicationID, groupDB.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), groupDB.ApplicationID, groupDB.ID)
 		method := "PUT"
 
 		// response
@@ -137,7 +138,7 @@ func TestDeleteGroup(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		groupDB := app.Groups[0]
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s", testServerURL, groupDB.ApplicationID, groupDB.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), groupDB.ApplicationID, groupDB.ID)
 		method := "DELETE"
 
 		httpDo(t, url, method, nil, http.StatusNoContent, "", nil)

--- a/backend/test/api/instance_test.go
+++ b/backend/test/api/instance_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestListInstances(t *testing.T) {
 		appWithInstance := getAppWithInstance(t, db)
 
 		// fetch instances from API
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/instances?status=0&version=&sort=2&sortOrder=0&page=1&perpage=10&duration=30d", testServerURL, appWithInstance.ID, appWithInstance.Groups[0].ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/instances?status=0&version=&sort=2&sortOrder=0&page=1&perpage=10&duration=30d", os.Getenv("NEBRASKA_TEST_SERVER_URL"), appWithInstance.ID, appWithInstance.Groups[0].ID)
 		method := "GET"
 
 		// response
@@ -60,7 +61,7 @@ func TestGetInstanceCount(t *testing.T) {
 		appWithInstance := getAppWithInstance(t, db)
 
 		// fetch instanceCount from API
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/instancescount?duration=30d", testServerURL, appWithInstance.ID, appWithInstance.Groups[0].ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/instancescount?duration=30d", os.Getenv("NEBRASKA_TEST_SERVER_URL"), appWithInstance.ID, appWithInstance.Groups[0].ID)
 		method := "GET"
 
 		// TODO: will require change as response struct is changed in POC2 branch
@@ -92,7 +93,7 @@ func TestGetInstance(t *testing.T) {
 		require.NoError(t, err)
 
 		// fetch instance from API
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/instances/%s", testServerURL, app.ID, app.Groups[0].ID, instanceDB.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/instances/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID, app.Groups[0].ID, instanceDB.ID)
 		method := "GET"
 
 		var instance api.Instance
@@ -126,7 +127,7 @@ func TestGetInstanceStatusHistory(t *testing.T) {
 		require.NoError(t, err)
 
 		// fetch instance status_history
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/instances/%s/status_history", testServerURL, app.ID, app.Groups[0].ID, instanceDB.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/instances/%s/status_history", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID, app.Groups[0].ID, instanceDB.ID)
 		method := "GET"
 
 		var instanceEvents []api.InstanceStatusHistoryEntry
@@ -154,7 +155,7 @@ func TestUpdateInstance(t *testing.T) {
 		require.NoError(t, err)
 
 		// fetch instance from API
-		url := fmt.Sprintf("%s/api/instances/%s", testServerURL, instanceDB.ID)
+		url := fmt.Sprintf("%s/api/instances/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), instanceDB.ID)
 		method := "PUT"
 
 		newAlias := "new_alias"

--- a/backend/test/api/omaha_test.go
+++ b/backend/test/api/omaha_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestOmaha(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		track := app.Groups[0].Track
 
-		url := fmt.Sprintf("%s/omaha", testServerURL)
+		url := fmt.Sprintf("%s/omaha", os.Getenv("NEBRASKA_TEST_SERVER_URL"))
 
 		method := "POST"
 
@@ -52,7 +53,7 @@ func TestOmaha(t *testing.T) {
 	})
 
 	t.Run("large_request_body", func(t *testing.T) {
-		url := fmt.Sprintf("%s/omaha", testServerURL)
+		url := fmt.Sprintf("%s/omaha", os.Getenv("NEBRASKA_TEST_SERVER_URL"))
 
 		method := "POST"
 

--- a/backend/test/api/package_test.go
+++ b/backend/test/api/package_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestListPackages(t *testing.T) {
 		require.NotNil(t, packagesDB)
 
 		// fetch packages from API
-		url := fmt.Sprintf("%s/api/apps/%s/packages", testServerURL, app.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/packages", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID)
 		method := "GET"
 
 		// response
@@ -52,7 +53,7 @@ func TestCreatePackage(t *testing.T) {
 		app := getRandomApp(t, db)
 
 		// create group using the API
-		url := fmt.Sprintf("%s/api/apps/%s/packages", testServerURL, app.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/packages", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID)
 		method := "POST"
 
 		packageName := "test_package"
@@ -88,7 +89,7 @@ func TestGetPackage(t *testing.T) {
 		require.NotNil(t, packagesDB)
 
 		// fetch group by id request
-		url := fmt.Sprintf("%s/api/apps/%s/packages/%s", testServerURL, packagesDB[0].ApplicationID, packagesDB[0].ID)
+		url := fmt.Sprintf("%s/api/apps/%s/packages/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), packagesDB[0].ApplicationID, packagesDB[0].ID)
 		method := "GET"
 
 		var packageResp api.Package
@@ -125,7 +126,7 @@ func TestUpdatePackage(t *testing.T) {
 		require.NoError(t, err)
 
 		// fetch group by id request
-		url := fmt.Sprintf("%s/api/apps/%s/packages/%s", testServerURL, packageDB.ApplicationID, packageDB.ID)
+		url := fmt.Sprintf("%s/api/apps/%s/packages/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), packageDB.ApplicationID, packageDB.ID)
 		method := "PUT"
 
 		var packageResp api.Package
@@ -155,7 +156,7 @@ func TestDeletePackage(t *testing.T) {
 		require.NotNil(t, packagesDB)
 
 		// delte package by id request
-		url := fmt.Sprintf("%s/api/apps/%s/packages/%s", testServerURL, packagesDB[0].ApplicationID, packagesDB[0].ID)
+		url := fmt.Sprintf("%s/api/apps/%s/packages/%s", os.Getenv("NEBRASKA_TEST_SERVER_URL"), packagesDB[0].ApplicationID, packagesDB[0].ID)
 		method := "DELETE"
 
 		httpDo(t, url, method, nil, http.StatusNoContent, "", nil)

--- a/backend/test/api/stats_test.go
+++ b/backend/test/api/stats_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func TestGroupVersionTimeline(t *testing.T) {
 		appWithInstance := getAppWithInstance(t, db)
 
 		// fetch group version timeline from API
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/version_timeline?duration=1d", testServerURL, appWithInstance.ID, appWithInstance.Groups[0].ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/version_timeline?duration=1d", os.Getenv("NEBRASKA_TEST_SERVER_URL"), appWithInstance.ID, appWithInstance.Groups[0].ID)
 		method := "GET"
 
 		// response
@@ -93,7 +94,7 @@ func TestGroupVersionBreakdown(t *testing.T) {
 		require.NotNil(t, breakdownDB)
 
 		// fetch version breakdown from API
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/version_breakdown", testServerURL, appWithInstance.ID, appWithInstance.Groups[0].ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/version_breakdown", os.Getenv("NEBRASKA_TEST_SERVER_URL"), appWithInstance.ID, appWithInstance.Groups[0].ID)
 		method := "GET"
 
 		// response
@@ -138,7 +139,7 @@ func TestGroupStatusTimeline(t *testing.T) {
 		require.NotNil(t, groupStatusCountTimelineDB)
 
 		// fetch group status timeleine from API
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/status_timeline?duration=1d", testServerURL, app.ID, app.Groups[0].ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/status_timeline?duration=1d", os.Getenv("NEBRASKA_TEST_SERVER_URL"), app.ID, app.Groups[0].ID)
 		method := "GET"
 
 		// response
@@ -198,7 +199,7 @@ func TestGroupInstanceStats(t *testing.T) {
 		require.NotNil(t, instanceStatsDB)
 
 		// fetch instances stats from API
-		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/instances_stats?duration=1d", testServerURL, appWithInstance.ID, appWithInstance.Groups[0].ID)
+		url := fmt.Sprintf("%s/api/apps/%s/groups/%s/instances_stats?duration=1d", os.Getenv("NEBRASKA_TEST_SERVER_URL"), appWithInstance.ID, appWithInstance.Groups[0].ID)
 		method := "GET"
 
 		// response

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,3 +72,47 @@ The Nebraska backend is written in Go. The backend source code is structured as 
 - **`cmd/nebraska`**: is the main backend process, exposing the functionality described above in the different packages through its http server. It provides several http endpoints used to drive most of the functionality of the dashboard as well as handling the Omaha updates and events requests received from your servers and applications.
 
 - **`cmd/initdb`**: is just a helper to reset your database, and causing the migrations to be re-run. `nebraska` will apply all database migrations automatically, so this process should only be used to wipe out all your data and start from a clean state (you should probably never need it).
+
+
+### Backend Testing
+
+Most unit tests like beside the code for example inside `backend/pkg/`.
+Tests which depend on a database mostly live in `backend/pkg/api`.
+Some "server" binary integration tests are separate, and live in `backend/test/api/`.
+
+#### Environment variables
+
+NEBRASKA_SKIP_TESTS, if set do not run slow tests like DB using tests.
+NEBRASKA_RUN_SERVER_TESTS, if set run the integration tests.
+
+#### Test make targets.
+
+There are a number of make targets setup to run different tests.
+
+##### make ci
+
+Run all the tests that are run on CI with github actions.
+
+##### make code-checks
+
+Just build it, run quick tests, and lint it.
+
+Does not run tests that require a testing db, or a test server.
+
+##### make check
+
+Run tests except for the integration tests by default. Requires a test database to be running.
+
+You can use `NEBRASKA_RUN_SERVER_TESTS=1 make check` to also test the server integration tests, 
+but you need to be running a server (with `make run-backend`).
+
+##### make check-backend-with-container
+
+Run tests inside a container, including the integration tests.
+
+It starts it's own test server and test database.
+
+##### make check-code-coverage
+
+Like make check, but it outputs test coverage information.
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -82,8 +82,12 @@ Some "server" binary integration tests are separate, and live in `backend/test/a
 
 #### Environment variables
 
-NEBRASKA_SKIP_TESTS, if set do not run slow tests like DB using tests.
-NEBRASKA_RUN_SERVER_TESTS, if set run the integration tests.
+Here are some test related environment variables.
+
+- NEBRASKA_SKIP_TESTS, if set do not run slow tests like DB using tests.
+- NEBRASKA_RUN_SERVER_TESTS, if set run the integration tests.
+- NEBRASKA_DB_URL, database connection URL.
+- NEBRASKA_TEST_SERVER_URL, where the test server is running "http://localhost:8000"
 
 #### Test make targets.
 


### PR DESCRIPTION
# Integration test improvements

- [x] Skip server integration tests by default with `make check` like with `make code-check`. So like before, make check only requires a running test db.
- [x] Start on docs related to backend testing. Document testing make targets, and document backend testing related environment variables.
- [x] Fix test-service-up to build image before starting, to prevent stale code being tested. This is not great at the moment, because of how the dockerfile is setup. A change in backend code, triggers frontend code to be rebuilt and vice versa. The PR https://github.com/kinvolk/nebraska/pull/537 should improve DX quite a bit when doing the checks in the container because it separates front end and backend well.
- [x] The localhost:8000 testing URL was the same as is used for the development server. I'm changing this to its own port, so that tests can be run with the container whilst the dev server is running.
- [x] With the NEBRASKA_DB_URL the test service starts with the same port as our docker run postgres. Meaning we can't run it at the same time. Bind for 0.0.0.0:5432 failed: port is already allocated So I'm probably going to change this to a separate port too. So make check-backend-with-container can run separately.  
- [x] Stops test services first, so that they do not keep running keeping state from previous test runs. So that other code changes and tests can not interfere with the latest test run.


# How to test

You can run the dev server, and have a test db at the same time as running `make check-backend-with-container`.

1) run a test db (in docker perhaps as per dev guide `docker run --rm -d --name nebraska-postgres-dev -p 5432:5432 -e POSTGRES_PASSWORD=nebraska postgres`)
2) `make run-backend` (to show that the tests can run whilst this is running and occupying a port)
3) Now `cd backend;make check-backend-with-container` should work, and it should run the integration tests. Before there would be errors about the shared ports being used.
4) `cd backend;make check` should work as long as you have a test db running (as before). It skips the server integration tests.
5) Should be able to run a single test separately. `cd backend && make test-service-down test-service-up && cd test/api && NEBRASKA_RUN_SERVER_TESTS=1 NEBRASKA_DB_URL="postgres://postgres:nebraska@127.0.0.1:8001/nebraska_tests?sslmode=disable&connect_timeout=10" go test -run TestListApp`
