### PR TITLE
test WIP, testing buildkit PR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,18 @@
+Dockerfile
+.dockerignore
+
+.git
+.gitignore
+
+# frontend
 **/node_modules
 frontend/build
-docs/
-bin/nebraska
-backend/tools/
+
+# backend
 backend/bin
+backend/coverage.out
+backend/tools/go-bindata
+backend/tools/golangci-lint
+
+docs/
 charts/

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ tools:
 
 .PHONY: image
 image:
-	$(DOCKER_CMD) build \
+	DOCKER_BUILDKIT=1 $(DOCKER_CMD) build \
 		--no-cache \
 		--build-arg NEBRASKA_VERSION=$(VERSION) \
 		-t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NEBRASKA):$(VERSION)" \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -4,6 +4,7 @@ export GO111MODULE
 TAG := `git describe --tags --always`
 SHELL = /bin/bash
 DOCKER_CMD ?= "docker"
+DOCKER_COMPOSE_CMD = COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose
 DOCKER_REPO ?= "ghcr.io/kinvolk"
 DOCKER_IMAGE_NEBRASKA ?= "nebraska"
 VERSION ?=
@@ -32,11 +33,11 @@ check-code-coverage:
 
 .PHONY: test-service-up
 test-service-up:
-	docker compose -f ./docker-compose.test.yaml up -d
+	$(DOCKER_COMPOSE_CMD) -f ./docker-compose.test.yaml up -d
 
 .PHONY: test-service-down
 test-service-down:
-	docker compose -f ./docker-compose.test.yaml down
+	$(DOCKER_COMPOSE_CMD) -f ./docker-compose.test.yaml down
 
 .PHONY: check-backend-with-container
 check-backend-with-container: test-service-up


### PR DESCRIPTION
(This PR is just for testing...) 

- it uses some env vars https://www.docker.com/blog/faster-builds-in-compose-thanks-to-buildkit-support/ so that `make container` works locally, and that CI builds.

These changes should probably be added into this PR: https://github.com/kinvolk/nebraska/pull/537

- [ ] investigate the CI build failures