### PR TITLE
Multistage docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ tools:
 .PHONY: image
 image:
 	$(DOCKER_CMD) build \
-		--no-cache \
+		--network=host \
 		--build-arg NEBRASKA_VERSION=$(VERSION) \
 		-t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NEBRASKA):$(VERSION)" \
 		-t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NEBRASKA):latest" \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -87,7 +87,7 @@ run-generators: tools/go-bindata
 	PATH="$(abspath tools):$${PATH}" go generate ./...
 
 bin/nebraska: run-generators
-	 go build -a -tags netgo -trimpath -ldflags ${LDFLAGS} -o bin/nebraska ./cmd/nebraska
+	go build -a -tags netgo -trimpath -ldflags ${LDFLAGS} -o bin/nebraska ./cmd/nebraska
 
 .PHONY: code-checks
 code-checks: tools/golangci-lint


### PR DESCRIPTION
This PR is based on the inital work by @guilhem on https://github.com/kinvolk/nebraska/pull/537. Instead of docker buildkit the docker layer caching is used for caching the dependency download on each build.