### PR TITLE
backend: Fix flatcar packages path bug

### DIFF
--- a/backend/pkg/middleware/auth.go
+++ b/backend/pkg/middleware/auth.go
@@ -11,14 +11,14 @@ func NewAuthSkipper(auth string) middleware.Skipper {
 	return func(c echo.Context) bool {
 		switch auth {
 		case "oidc":
-			paths := []string{"/health", "/login", "/config", "/*", "/login/cb", "/login/token", "/v1/update"}
+			paths := []string{"/health", "/login", "/config", "/*", "/flatcar/*", "/login/cb", "/login/token", "/v1/update"}
 			for _, path := range paths {
 				if c.Path() == path {
 					return true
 				}
 			}
 		case "github":
-			paths := []string{"/health", "/v1/update", "/login/cb", "/login/webhook"}
+			paths := []string{"/health", "/v1/update", "/login/cb", "/login/webhook", "/flatcar/*"}
 			for _, path := range paths {
 				if c.Path() == path {
 					return true

--- a/backend/test/api/flatcar_package_test.go
+++ b/backend/test/api/flatcar_package_test.go
@@ -1,0 +1,97 @@
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kinvolk/nebraska/backend/pkg/config"
+	"github.com/kinvolk/nebraska/backend/pkg/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostFlatcarPackage(t *testing.T) {
+	currentDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	serverPort := uint(6000)
+	serverPortStr := fmt.Sprintf(":%d", serverPort)
+
+	conf := &config.Config{
+		HostFlatcarPackages: true,
+		FlatcarPackagesPath: currentDir,
+		AuthMode:            "noop",
+		ServerPort:          serverPort,
+	}
+
+	db := newDBForTest(t)
+
+	t.Run("file_exists", func(t *testing.T) {
+		server, err := server.New(conf, db)
+		require.NotNil(t, server)
+		require.NoError(t, err)
+
+		//nolint:errcheck
+		go server.Start(serverPortStr)
+
+		//nolint:errcheck
+		defer server.Shutdown(context.Background())
+
+		// create a temp file
+		fileName := fmt.Sprintf("%s.txt", uuid.NewString())
+		file, err := os.Create(path.Join(currentDir, fileName))
+		require.NoError(t, err)
+
+		fileString := "This is a test"
+		_, err = file.WriteString(fileString)
+		require.NoError(t, err)
+		err = file.Close()
+		require.NoError(t, err)
+
+		_, err = waitServerReady(fmt.Sprintf("http://localhost:%d", serverPort))
+		require.NoError(t, err)
+
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/flatcar/%s", serverPort, fileName))
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, fileString, string(bodyBytes))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// delete the temp file
+		err = os.Remove(path.Join(currentDir, fileName))
+		require.NoError(t, err)
+	})
+
+	t.Run("file_not_exists", func(t *testing.T) {
+		server, err := server.New(conf, db)
+		require.NotNil(t, server)
+		require.NoError(t, err)
+
+		fileName := fmt.Sprintf("%s.txt", uuid.NewString())
+
+		//nolint:errcheck
+		go server.Start(serverPortStr)
+
+		//nolint:errcheck
+		defer server.Shutdown(context.Background())
+
+		_, err = waitServerReady(fmt.Sprintf("http://localhost:%d", serverPort))
+		require.NoError(t, err)
+
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/flatcar/%s", serverPort, fileName))
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}


### PR DESCRIPTION
This patch fixes a bug that redirected the
flatcar packages request to the index.html
file.

Signed-off-by: Santhosh Nagaraj S <santhosh@kinvolk.io>
