### PR TITLE
Dockerfile backend: Fix VERSION not in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,25 @@ ENV GOPATH=/go \
 	GOOS=linux 
 
 # Backend build
-FROM base-build as backend-build
+FROM base-build as version-build
+ARG NEBRASKA_VERSION=""
+
+WORKDIR /app/
+COPY ./.git ./.git
+COPY ./backend ./backend
+
 # We optionally allow to set the version to display for the image.
 # This is mainly used because when copying the source dir, docker will
 # ignore the files we requested it to, and thus produce a "dirty" build
 # as git status returns changes (when effectively for the built source
 # there's none).
 ENV VERSION=${NEBRASKA_VERSION}
+
+FROM version-build as backend-build
+
+# make version uses the existing VERSION if set, otherwise gets it from git
+RUN export VERSION=`make -f backend/Makefile version | tail -1` && echo "VERSION:$VERSION"
+
 WORKDIR /app/backend
 # COPY backend/go.mod backend/go.sum ./
 # RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -144,4 +144,3 @@ swagger-install:
 .PHONY: swagger-init
 swagger-init:
 	$(MAKE) -C backend $@
-

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -51,6 +51,10 @@ run: bin/nebraska
 .PHONY: build
 build: run-generators bin/nebraska
 
+.PHONY: version
+version:
+	echo $(VERSION)
+
 .PHONY: test-clean-work-tree-backend
 test-clean-work-tree-backend:
 	if ! git diff --quiet -- go.mod go.sum pkg cmd tools/tools.go; then \


### PR DESCRIPTION
# Version was not in container image

`make image` should now echo the VERSION that is used.

## Testing done

- [x] `make image` shows version
- [x] change a backend .go file, `make image` should not rebuild frontend
- [x] change a frontend file, `make image` should not rebuild backend
- [x] change a frontend file, `make image` should not reinstall frontend npm packages
- [x] passing version via build-arg works and is echoed during build `--build-arg NEBRASKA_VERSION=meow`
