### PR TITLE
frontend: Change how the package is shown in Channel/EditDialog

### DIFF
--- a/frontend/src/js/components/Common/AutoCompletePicker.tsx
+++ b/frontend/src/js/components/Common/AutoCompletePicker.tsx
@@ -170,6 +170,7 @@ interface AutoCompletePickerProps {
 export default function AutoCompletePicker(props: AutoCompletePickerProps) {
   const [showPicker, setShowPicker] = React.useState(false);
   const [selectedValue, setSelectedValue] = React.useState(props.defaultValue);
+  const [currentValue, setCurrentValue] = React.useState(props.defaultValue);
   const suggestions = props.getSuggestions;
   const { onBottomScrolled } = props;
   const { t } = useTranslation();
@@ -188,6 +189,7 @@ export default function AutoCompletePicker(props: AutoCompletePickerProps) {
 
   function handleSelect() {
     setShowPicker(false);
+    setCurrentValue(selectedValue);
     props.onSelect(selectedValue);
   }
 
@@ -217,7 +219,7 @@ export default function AutoCompletePicker(props: AutoCompletePickerProps) {
           inputProps={{
             className: classes.pickerButtonInput,
           }}
-          value={selectedValue}
+          value={currentValue}
           placeholder={props.placeholder}
           readOnly
         />


### PR DESCRIPTION
The field showing the package in the mentioned component was showing
a newly selected package (from the package selection popup) even when
the used clicked "cancel".

This patch fixes that by using a different state for setting the
mentioned value (rather than the one that reflects the user's
changes).
