### PR TITLE
frontend: Get a high number of packages until we add real pagination

### DIFF
--- a/frontend/src/components/Packages/List.tsx
+++ b/frontend/src/components/Packages/List.tsx
@@ -33,7 +33,8 @@ function List(props: { appID: string }) {
   React.useEffect(() => {
     applicationsStore().addChangeListener(onChange);
     if (!packages) {
-      API.getPackages(props.appID)
+      // @todo: Request the pagination according to the page configuration in the table below.
+      API.getPackages(props.appID, '', { perpage: 1000 })
         .then(result => {
           if (_.isNull(result.packages)) {
             setPackages([]);


### PR DESCRIPTION
Due to how the backend changed how the items can get fetched (making
the pagination mandatory), the list of packages gotten by default was
just 10.

We should fix this by applying a real pagination in the packages'
list, but until then, this patch requests a high number of packages
so the UX is a bit better until we fix the pagination in the UI.
