### PR TITLE
frontend: Prevent sending an empty version when fetching instances

### DIFF
--- a/frontend/src/api/API.ts
+++ b/frontend/src/api/API.ts
@@ -195,12 +195,19 @@ export default class API {
   static getInstances(
     applicationID: string,
     groupID: string,
-    queryOptions = {}
+    queryOptions: {
+      [key: string]: any;
+    } = {}
   ): Promise<Instances> {
     let url = BASE_URL + '/apps/' + applicationID + '/groups/' + groupID + '/instances';
 
     if (!_.isEmpty(queryOptions)) {
-      url += '?' + queryString.stringify(queryOptions);
+      let sanitizedOptions = queryOptions;
+      const { version, ...otherOptions } = queryOptions;
+      if (!version) {
+        sanitizedOptions = otherOptions;
+      }
+      url += '?' + queryString.stringify(sanitizedOptions);
     }
 
     return API.getJSON(url);

--- a/frontend/src/components/Footer.stories.tsx
+++ b/frontend/src/components/Footer.stories.tsx
@@ -1,0 +1,46 @@
+import { createStore } from '@reduxjs/toolkit';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import FooterComponent from './Footer';
+
+export default {
+  title: 'Footer',
+  component: FooterComponent,
+  argTypes: {},
+  decorators: [
+    Story => {
+      return (
+        <MemoryRouter>
+          <Story />
+        </MemoryRouter>
+      );
+    },
+  ],
+} as Meta;
+
+const Template: Story = args => {
+  // eslint-disable-next-line no-unused-vars
+  const store = createStore((state = { config: {} }, action) => state, {
+    config: {
+      ...args,
+    },
+  });
+  return (
+    <Provider store={store}>
+      <FooterComponent />
+    </Provider>
+  );
+};
+
+export const FooterNoOverride = Template.bind({});
+FooterNoOverride.args = {
+  title: '',
+  nebraska_version: '',
+};
+
+export const FooterOverride = Template.bind({});
+FooterOverride.args = {
+  title: 'Some Pro Update Service',
+  nebraska_version: '1.2.3',
+};

--- a/frontend/src/components/__snapshots__/Footer.stories.storyshot
+++ b/frontend/src/components/__snapshots__/Footer.stories.storyshot
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Footer Footer No Override 1`] = `
+<div
+  id="root"
+>
+  <div
+    class="MuiBox-root MuiBox-root"
+  >
+    Nebraska 
+  </div>
+</div>
+`;
+
+exports[`Storyshots Footer Footer Override 1`] = `
+<div
+  id="root"
+>
+  <div
+    class="MuiBox-root MuiBox-root"
+  >
+    Some Pro Update Service 1.2.3
+  </div>
+</div>
+`;


### PR DESCRIPTION
Sending an empty version is not allowed in the current API. That should be ideally prevented in the backend, but until then, this
patch removes an empty version from the query params in the respective API call.

@yolossn , I noticed that we could use an `allowEmptyValue` param for the version param and possibly others too, but the docs in swagger are not clear whether that option is going away: https://swagger.io/specification/

