### PR TITLE
chart: Upgrade postgres dependency to latest major version

### DIFF
--- a/charts/nebraska/Chart.lock
+++ b/charts/nebraska/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.16.2
-digest: sha256:e09e206d81074a6540102fb62b8b12cf943c934c2af21e58ff8caa259690e87a
-generated: "2022-01-27T12:36:29.989805+01:00"
+  version: 11.9.1
+digest: sha256:fa46eb2489fd385d4cc5bae13f161897a8bff0fb0a281f42cd17953c735ff3fe
+generated: "2022-09-24T19:09:15.078346+02:00"

--- a/charts/nebraska/Chart.yaml
+++ b/charts/nebraska/Chart.yaml
@@ -19,11 +19,11 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 0.5.0
+version: 1.0.0
 appVersion: "2.8.0"
 
 dependencies:
   - name: postgresql
-    version: 10.16.2
+    version: 11.9.1
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled

--- a/charts/nebraska/README.md
+++ b/charts/nebraska/README.md
@@ -98,29 +98,29 @@ $ helm install my-nebraska nebraska/nebraska
 | `config.auth.oidc.sessionCryptKey`                    | Session key used for encrypting sessions in cookies to store OIDC info, will be generated if none is passed | `nil`                                    |
 | `config.database.host`                                | The host name of the database server                                                                                                 | `""` (use postgresql from Bitnami subchart)                             |
 | `config.database.port`                                | The port number the database server is listening on                                                                                  | `5432`                                                                  |
-| `config.database.dbname`                              | The database name                                                                                                                    | `{{ .Values.postgresql.postgresqlDatabase }}` (evaluated as a template) |
-| `config.database.username`                            | PostgreSQL user                                                                                                                      | `{{ .Values.postgresql.postgresqlUsername }}` (evaluated as a template) |
+| `config.database.dbname`                              | The database name                                                                                                                    | `{{ .Values.postgresql.auth.database }}` (evaluated as a template)      |
+| `config.database.username`                            | PostgreSQL user                                                                                                                      | `{{ .Values.postgresql.postgresqlUsername }}` (evaluated as a template)                                    |
 | `config.database.password`                            | PostgreSQL user password                                                                                                             | `""` (evaluated as a template)                                          |
 | `config.database.passwordExistingSecret.enabled`      | Enables setting PostgreSQL user password via an existing secret                                                                      | `true`                                                                  |
 | `config.database.passwordExistingSecret.name`         | Name of the existing secret                                                                                                          | `{{ .Release.Name }}-postgresql` (evaluated as a template)              |
-| `config.database.passwordExistingSecret.key`          | Key inside the existing secret containing the PostgreSQL user password                                                               | `postgresql-password`                                                   |
+| `config.database.passwordExistingSecret.key`          | Key inside the existing secret containing the PostgreSQL user password                                                               | `postgres-password`                                                     |
 | `extraArgs`                                           | Extra arguments to pass to Nebraska binary                                                                                           | `[]`                                                                    |
 | `extraEnvVars`                                        | Any extra environment variables you would like to pass on to the pod                                                                 | `{ "TZ": "UTC" }`                                                       |
 | `extraEnv`                                        | Any extra environment variables in the form of env spec to pass into the deployment pod                                                                 | `[]`                                                       |
 
 ### Postgresql dependency
 
-| Parameter                               | Description                                                                                     | Default                |
-|-----------------------------------------|-------------------------------------------------------------------------------------------------|------------------------|
-| `postgresql.enabled`                    | Enable Bitnami postgresql subchart and deploy database within this helm release                 | `true`                 |
-| `postgresql.postgresqlDatabase`         | PostgreSQL database                                                                             | `nebraska`             |
-| `postgresql.postgresqlUsername`         | PostgreSQL user (creates a non-admin user when `postgresqlUsername` is not `postgres`)          | `postgres`             |
-| `postgresql.postgresqlPassword`         | PostgreSQL user password **Recommended to change it to something secure for security reasons.** | `changeIt`             |
-| `postgresql.postgresqlPostgresPassword` | PostgreSQL admin password (used when `postgresqlUsername` is not `postgres`)                    | `-`                    |
-| `postgresql.image.tag`                  | PostgreSQL Image tag                                                                            | `12.9.0-debian-10-r72` |
-| `postgresql.persistence.enabled`        | Enable persistence using PVC                                                                    | `false`                |
-| `postgresql.persistence.storageClass`   | PVC Storage Class for PostgreSQL volume                                                         | `nil`                  |
-| `postgresql.persistence.accessModes`    | PVC Access Mode for PostgreSQL volume                                                           | `["ReadWriteOnce"]`    |
-| `postgresql.persistence.size`           | PVC Storage Request for PostgreSQL volume                                                       | `1Gi`                  |
+| Parameter                                                | Description                                                                                                   | Default                |
+|----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|------------------------|
+| `postgresql.enabled`                                     | Enable Bitnami postgresql subchart and deploy database within this helm release                               | `true`                 |
+| `postgresql.auth.database`                               | PostgreSQL database                                                                                           | `nebraska`             |
+| `postgresql.auth.postgresPassword`                       | PostgreSQL password of user "postgres" **Recommended to change it to something secure for security reasons.** | `changeIt`             |
+| `postgresql.image.tag`                                   | PostgreSQL Image tag                                                                                          | `13.8.0-debian-11-r18` |
+| `postgresql.primary.persistence.enabled`                 | Enable persistence using PVC                                                                                  | `false`                |
+| `postgresql.primary.persistence.storageClass`            | PVC Storage Class for PostgreSQL volume                                                                       | `nil`                  |
+| `postgresql.primary.persistence.accessModes`             | PVC Access Mode for PostgreSQL volume                                                                         | `["ReadWriteOnce"]`    |
+| `postgresql.primary.persistence.size`                    | PVC Storage Request for PostgreSQL volume                                                                     | `1Gi`                  |
+| `postgresql.serviceAccount.create`                       | Enable creation of ServiceAccount for PostgreSQL pod                                                          | `true`                 |
+| `postgresql.serviceAccount.automountServiceAccountToken` | Can be set to false if pods using this serviceAccount do not need to use K8s API                              | `false`                |
 
 ... for more options see https://github.com/bitnami/charts/tree/master/bitnami/postgresql

--- a/charts/nebraska/values.yaml
+++ b/charts/nebraska/values.yaml
@@ -70,13 +70,13 @@ config:
   database:
     host: ""
     port: 5432
-    dbname: '{{ .Values.postgresql.postgresqlDatabase }}'
-    username: '{{ .Values.postgresql.postgresqlUsername }}'
+    dbname: '{{ .Values.postgresql.auth.database }}'
+    username: '{{ .Values.postgresql.auth.username }}'
     password: ""
     passwordExistingSecret:
       enabled: true
       name: '{{ .Release.Name }}-postgresql'
-      key: postgresql-password
+      key: postgres-password
 
 extraArgs: []
   # - "-http-log"
@@ -191,14 +191,19 @@ readinessProbe:
 # ... for more options see https://github.com/bitnami/charts/tree/master/bitnami/postgresql
 postgresql:
   enabled: true
-  postgresqlDatabase: nebraska
-  postgresqlUsername: postgres
-  postgresqlPassword: changeIt
+  auth:
+    username: postgres
+    database: nebraska
+    postgresPassword: changeIt
   image:
-    tag: 12.9.0-debian-10-r72
-  persistence:
-    enabled: false
-    storageClass:
-    accessModes:
-      - ReadWriteOnce
-    size: 1Gi
+    tag: 13.8.0-debian-11-r18
+  primary:
+    persistence:
+      enabled: false
+      storageClass:
+      accessModes:
+        - ReadWriteOnce
+      size: 1Gi
+  serviceAccount:
+    create: true
+    automountServiceAccountToken: false


### PR DESCRIPTION
# Upgrade to latest postgresql dependency

Bitnami released a new major version of the postgresql dependency. As major chart upgrades are sometimes tricky, let's upgrade that dependency before additional majors arrive.

## How to use

Nothing special.

## Testing done

Pushed the helm chart to my own helm repository (chartmuseum) and upgraded my nebraska instance.
