### PR TITLE
backend/docker-compose: remove race condition and improve interactive dev experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.swp
 *sublime*
+backend/__postgres_testing_volume/

--- a/backend/docker-compose.pg-persist.yaml
+++ b/backend/docker-compose.pg-persist.yaml
@@ -1,0 +1,8 @@
+# Persistent postgres storage drop-in for interactive testing.
+# This drop-in will persist postgres data in $(pwd)/__postgres_testing_volume
+#  across restarts of docker-compose.
+
+services:
+  postgres:
+    volumes:
+      - ./__postgres_testing_volume:/var/lib/postgresql/data

--- a/backend/docker-compose.test.yaml
+++ b/backend/docker-compose.test.yaml
@@ -1,3 +1,15 @@
+# Docker-compose file for interactive and for automated testing.
+#
+# Build docker image from local sources:
+#   docker-compose --file docker-compose.test.yaml build
+#
+# Run:
+#   docker-compose --file docker-compose.test.yaml run
+# Run with persistent storage:
+#   docker-compose --file docker-compose.test.yaml --file docker-compose.test-db-persist.yaml up
+#
+# See docker-compose.pg-persist.yaml for more informatino on persistent storage.
+
 version: "3.9"
 
 services:
@@ -23,6 +35,10 @@ services:
       network: host
     ports:
       - "8002:8000"
+    # The "long form" depends_on silently fails in some scenarios (we've seen this with podman)
+    #  so the short form is added for compatibility.
+    depends_on:
+      - postgres
     depends_on:
       postgres:
         condition: service_healthy

--- a/backend/docker-compose.test.yaml
+++ b/backend/docker-compose.test.yaml
@@ -35,10 +35,8 @@ services:
       network: host
     ports:
       - "8002:8000"
-    # The "long form" depends_on silently fails in some scenarios (we've seen this with podman)
-    #  so the short form is added for compatibility.
-    depends_on:
-      - postgres
+    # Workaround for missing support for depends_on conditions in podman-compose:
+    restart: always
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
This change adds a dependency to the (nebraska) "server" service on the "postgres" service in docker-compose.test.yaml. Motivation of the change is to prevent a race condition where the "server" container starts faster than "postgres", fails to connect to the database, and shuts down.

Additionally, an optional persistent storage for postgres is added. DB contents can be persisted across docker-compose runs to aid manual, interactive testing. Usage instructions have been added to the YAML files as comments. The local directory used for persiting postgres data has been added to .gitignore to prevent accidental commits.

Tested locally with:
- `docker-compose --file docker-compose.test.yaml build`  (works as expected)
- `docker-compose --file docker-compose.test.yaml up` (works as expected)
- `docker-compose --file docker-compose.test.yaml --file docker-compose.pg-persist.yaml up`
   - create a new package, assign to a channel
   - `docker-compose --file docker-compose.test.yaml --file docker-compose.pg-persist.yaml down`
   - `docker-compose --file docker-compose.test.yaml --file docker-compose.pg-persist.yaml up`
   - Package still present in web interface
