### PR TITLE
Support Podman in docker-compose setup

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -33,11 +33,11 @@ check-code-coverage:
 
 .PHONY: test-service-up
 test-service-up:
-	docker compose -f ./docker-compose.test.yaml up -d --build
+	docker-compose -f ./docker-compose.test.yaml up -d --build
 
 .PHONY: test-service-down
 test-service-down:
-	docker compose -f ./docker-compose.test.yaml down
+	docker-compose -f ./docker-compose.test.yaml down
 
 .PHONY: check-backend-with-container
 check-backend-with-container: test-service-down

--- a/backend/test/api/README.md
+++ b/backend/test/api/README.md
@@ -2,7 +2,7 @@
 
 1. Run the docker compose file with the following command to get the service up and running.
 
-> docker compose -f ./docker-compose.test.yaml up -d
+> docker-compose -f ./docker-compose.test.yaml up -d
 
 2. Run the test using the following command
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,16 +55,16 @@ opened browser page should automatically refresh.
 
 ## Docker compose V2
 
-You may be missing the `docker compose` plugin, which is required to run some tests.
+You may be missing `docker-compose`, which is required to run some tests.
 
 ```bash
-docker compose version
+docker-compose version
 
 cd backend
 make check-backend-with-container
 ```
 
-If so, see https://docs.docker.com/compose/cli-command/#install-on-linux
+If so, see https://docs.docker.com/compose/install/other/ or https://github.com/containers/podman-compose (with setting up a `docker-compose` symlink)
 
 # Development Concepts
 


### PR DESCRIPTION
The "docker compose" subcommand to run docker-compose does not work when "docker" is a symlink to "podman" and "docker-compose" is a symlink to "podman-compose".
Use "docker-compose" instead of the subcommand to support running with Podman and give a hint in the docs on podman-compose.

## How to use

With the mentioned symlinks.

## Testing done

Tested `make test-service-up`