### PR TITLE
backend: change docker-compose to docker compose

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Start postgres dependency
       run: |
-        docker-compose -f backend/docker-compose.test.yaml up -d postgres
+        docker compose -f backend/docker-compose.test.yaml up -d postgres
 
     - name: Test library
       env:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -33,11 +33,11 @@ check-code-coverage:
 
 .PHONY: test-service-up
 test-service-up:
-	docker-compose -f ./docker-compose.test.yaml up -d --build
+	docker compose -f ./docker-compose.test.yaml up -d --build
 
 .PHONY: test-service-down
 test-service-down:
-	docker-compose -f ./docker-compose.test.yaml down
+	docker compose -f ./docker-compose.test.yaml down
 
 .PHONY: check-backend-with-container
 check-backend-with-container: test-service-down

--- a/backend/docker-compose.test.yaml
+++ b/backend/docker-compose.test.yaml
@@ -1,14 +1,14 @@
 # Docker-compose file for interactive and for automated testing.
 #
 # Build docker image from local sources:
-#   docker-compose --file docker-compose.test.yaml build
+#   docker compose --file docker-compose.test.yaml build
 #
 # Run:
-#   docker-compose --file docker-compose.test.yaml run
+#   docker compose --file docker-compose.test.yaml run
 # Run with persistent storage:
-#   docker-compose --file docker-compose.test.yaml --file docker-compose.test-db-persist.yaml up
+#   docker compose --file docker-compose.test.yaml --file docker-compose.test-db-persist.yaml up
 #
-# See docker-compose.pg-persist.yaml for more informatino on persistent storage.
+# See docker-compose.pg-persist.yaml for more information on persistent storage.
 
 version: "3.9"
 

--- a/backend/test/api/README.md
+++ b/backend/test/api/README.md
@@ -2,7 +2,7 @@
 
 1. Run the docker compose file with the following command to get the service up and running.
 
-> docker-compose -f ./docker-compose.test.yaml up -d
+> docker compose -f ./docker-compose.test.yaml up -d
 
 2. Run the test using the following command
 


### PR DESCRIPTION
docker-compose has been dropped from Github Actions Ubuntu runners - let's use the new standard way.

See: https://github.com/actions/runner-images/blob/ubuntu22/20240730.2/images/ubuntu/Ubuntu2204-Readme.md

cc @flatcar/flatcar-maintainers 