### PR TITLE
backend: use postgres 13.18

### DIFF
--- a/backend/docker-compose.test.yaml
+++ b/backend/docker-compose.test.yaml
@@ -12,7 +12,7 @@
 
 services:
   postgres:
-    image: postgres:12.9
+    image: postgres:13.18
     ports:
       - "8001:5432"
     environment:


### PR DESCRIPTION
We need to update PG version on production environment from 13.13 to 13.18. Let's reflect this in the CI first before checking migration path. 