### PR TITLE
ci: rename build steps in gh actions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -15,7 +15,7 @@ on:
 jobs:
 
   build:
-    name: Lint & Build
+    name: Backend Build Steps
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-
+    name: Frontend Build Steps
     runs-on: ubuntu-24.04
 
     strategy:


### PR DESCRIPTION
Rename Build Steps in GitHub Actions to make it easier to identify them. For example, the frontend workflow not having a name set explicitly is called `build (22)`. The backend build steps are called `Lint & Build`.
![image](https://github.com/user-attachments/assets/33729d18-d048-46ce-a00e-c07a4b370dbe)


