### PR TITLE
CI: append commit hash to staging tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,18 @@
 GO111MODULE=on
 export GO111MODULE
 
-TAG := `git describe --tags --always --exclude 'nebraska-helm*'`
+BASE_TAG := $(shell git describe --tags --always --exclude 'nebraska-helm*' 2>/dev/null)
+
+# We work only with one staging tag as per the one staging environment for Nebraska.
+# Appending the short hash code helps checking the new deployments by
+# asserting the version label in the footer that the hash changed.
+TAG := $(shell \
+    if [ "$(BASE_TAG)" = "staging" ]; then \
+        echo "staging-$$(git rev-parse --short HEAD)"; \
+    else \
+        echo "$(BASE_TAG)"; \
+    fi)
+
 SHELL = /bin/bash
 DOCKER_CMD ?= "docker"
 DOCKER_REPO ?= "ghcr.io/flatcar"

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,7 +1,18 @@
 GO111MODULE=on
 export GO111MODULE
 
-TAG := `git describe --tags --always --exclude 'nebraska-helm*'`
+BASE_TAG := $(shell git describe --tags --always --exclude 'nebraska-helm*' 2>/dev/null)
+
+# We work only with one staging tag as per the one staging environment for Nebraska.
+# Appending the short hash code helps checking the new deployments by
+# asserting the version label in the footer that the hash changed.
+TAG := $(shell \
+    if [ "$(BASE_TAG)" = "staging" ]; then \
+        echo "staging-$$(git rev-parse --short HEAD)"; \
+    else \
+        echo "$(BASE_TAG)"; \
+    fi)
+
 SHELL = /bin/bash
 DOCKER_CMD ?= "docker"
 DOCKER_REPO ?= "ghcr.io/flatcar"


### PR DESCRIPTION
# Append commit hash to staging tag

This PR updates the version label generation logic in the Makefile to improve transparency with staging deployments.
Currently only the `staging` label appears in the footer of Nebraska, which makes it hard to quickly check that the new deployment was successful, which could be useful in case of deployments with changes that come with no visual sign.

![image](https://github.com/user-attachments/assets/016764b8-a305-4664-b6dc-56bf30c250eb)

With this change, the `staging` label will be appended with the `short` commit hash of the latest commit in the staging branch. For example `Nebraska staging-37f905f`

## Testing done

Re-run the `make run-backend` with different tags locally. 

`git tag -d staging`
`git tag -a staging` 

One scenario to test is being exectly on the staging commit, another one would be to be ahead of the staging commit.

