### PR TITLE
release(helm): bump app to v2.11.0 and charts to v1.4.0

### DIFF
--- a/charts/nebraska/Chart.yaml
+++ b/charts/nebraska/Chart.yaml
@@ -19,8 +19,8 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 1.3.0
-appVersion: "2.10.0"
+version: 1.4.0
+appVersion: "2.11.0"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Summary
- Bump Helm chart version from 1.3.0 to 1.4.0
- Bump appVersion from 2.10.0 to 2.11.0

## Test plan
- [ ] Verify chart version numbers are correct
- [ ] Test Helm chart deployment with new versions