### PR TITLE
mod: remove explicit github.com/pkg/errors dependency

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/oapi-codegen/echo-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/rs/zerolog v1.34.0
 	github.com/rubenv/sql-migrate v1.8.0

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/providers/basicflag"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/nebraska/backend/pkg/random"
 )
@@ -71,12 +71,12 @@ const (
 func (c *Config) Validate() error {
 	if c.HostFlatcarPackages {
 		if c.FlatcarPackagesPath == "" {
-			return errors.New("Invalid Flatcar packages path. Please ensure you provide a valid path using -flatcar-packages-path")
+			return errors.New("invalid Flatcar packages path. Please ensure you provide a valid path using -flatcar-packages-path")
 		}
 
 		tmpFile, err := os.CreateTemp(c.FlatcarPackagesPath, "")
 		if err != nil {
-			return errors.New("Invalid Flatcar packages path: " + err.Error())
+			return fmt.Errorf("invalid Flatcar packages path: %w", err)
 		}
 		defer os.Remove(tmpFile.Name())
 
@@ -88,11 +88,11 @@ func (c *Config) Validate() error {
 	switch c.AuthMode {
 	case "github":
 		if c.GhClientID == "" || c.GhClientSecret == "" || c.GhReadOnlyTeams == "" || c.GhReadWriteTeams == "" {
-			return errors.New("Invalid github configuration")
+			return errors.New("invalid github configuration")
 		}
 	case "oidc":
 		if c.OidcClientID == "" || c.OidcClientSecret == "" || c.OidcIssuerURL == "" || c.OidcAdminRoles == "" || c.OidcViewerRoles == "" {
-			return errors.New("Invalid OIDC configuration")
+			return errors.New("invalid OIDC configuration")
 		}
 	}
 

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -14,7 +15,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	echomiddleware "github.com/oapi-codegen/echo-middleware"
-	"github.com/pkg/errors"
 
 	db "github.com/kinvolk/nebraska/backend/pkg/api"
 	"github.com/kinvolk/nebraska/backend/pkg/auth"
@@ -180,7 +180,7 @@ func setupAuthenticator(conf config.Config, sessionStore *sessions.Store, defaul
 
 		url, err := url.Parse(conf.NebraskaURL)
 		if err != nil {
-			return nil, errors.Wrap(err, "nebraska-url is invalid, can't generate oidc callback URL")
+			return nil, fmt.Errorf("nebraska-url is invalid, can't generate oidc callback URL: %w", err)
 		}
 
 		url.Path = "/login/cb"
@@ -245,7 +245,7 @@ func nebraskaAuthenticationFunc(authMode string) func(context.Context, *openapi3
 			if err != nil {
 				_, err := input.RequestValidationInput.Request.Cookie("github")
 				if err != nil {
-					return errors.Wrap(err, "github cookie not found")
+					return fmt.Errorf("github cookie not found: %w", err)
 				}
 			}
 			return nil
@@ -258,15 +258,15 @@ func nebraskaAuthenticationFunc(authMode string) func(context.Context, *openapi3
 func validateAuthorizationToken(input *openapi3filter.AuthenticationInput) error {
 	token := input.RequestValidationInput.Request.Header.Get("Authorization")
 	if token == "" {
-		return errors.New("Bearer token not found in request")
+		return errors.New("bearer token not found in request")
 	}
 	split := strings.Split(token, " ")
 	if len(split) == 2 {
 		if split[0] != "Bearer" {
-			return errors.New("Bearer token not found in request")
+			return errors.New("bearer token not found in request")
 		}
 	} else {
-		return errors.New("Invalid Bearer token")
+		return errors.New("invalid Bearer token")
 	}
 	return nil
 }


### PR DESCRIPTION
the 'wrap' of the error is supported in 'fmt' since a while now. Let's drop this explicit dependency.

It's still required from other dependencies:
```
$ go mod why github.com/pkg/errors
github.com/kinvolk/nebraska/backend/pkg/api
github.com/jackc/pgx/v4/stdlib
github.com/jackc/pgx/v4
github.com/jackc/pgx/v4.test
github.com/cockroachdb/apd
github.com/pkg/errors
```

---

Let's start to chase down useless dependency. This does not need a change log entry.

(related to: https://github.com/flatcar/nebraska/issues/1113) 