### PR TITLE
cmd/nebraska/main: unify logger usage

### DIFF
--- a/backend/cmd/nebraska/main.go
+++ b/backend/cmd/nebraska/main.go
@@ -3,47 +3,59 @@ package main
 import (
 	"fmt"
 
-	"github.com/labstack/gommon/log"
 	"github.com/rs/zerolog"
 
 	db "github.com/flatcar/nebraska/backend/pkg/api"
 	"github.com/flatcar/nebraska/backend/pkg/config"
+	"github.com/flatcar/nebraska/backend/pkg/logger"
 	"github.com/flatcar/nebraska/backend/pkg/metrics"
 	"github.com/flatcar/nebraska/backend/pkg/server"
 	"github.com/flatcar/nebraska/backend/pkg/syncer"
 )
 
+var l = logger.New("main")
+
 func main() {
 	// config parse
 	conf, err := config.Parse()
 	if err != nil {
-		log.Fatal("Error parsing config, err: ", err)
+		l.Fatal().
+			Err(err).
+			Msg("Error parsing config")
 	}
 
 	// validate config
 	err = conf.Validate()
 	if err != nil {
-		log.Fatal("Config is invalid, err: ", err)
+		l.Fatal().
+			Err(err).
+			Msg("Config is invalid")
 	}
 
 	if conf.RollbackDBTo != "" {
 		db, err := db.New()
 		if err != nil {
-			log.Fatal("DB connection err: ", err)
+			l.Fatal().
+				Err(err).
+				Msg("Failed to create a DB connection for migrating down")
 		}
 
 		count, err := db.MigrateDown(conf.RollbackDBTo)
 		if err != nil {
-			log.Fatal("DB migration down err: ", err)
+			l.Fatal().
+				Err(err).
+				Msg("Failed to perform DB down-migration")
 		}
-		log.Infof("DB migration down successful, migrated %d levels down", count)
+		l.Info().Msgf("DB migration down successful, migrated %d levels down", count)
 		return
 	}
 
 	// create new DB
 	db, err := db.NewWithMigrations()
 	if err != nil {
-		log.Fatal("DB connection err: ", err)
+		l.Fatal().
+			Err(err).
+			Msg("Failed to create a DB connection")
 	}
 
 	// setup logger
@@ -57,7 +69,9 @@ func main() {
 	if conf.EnableSyncer {
 		syncer, err := syncer.Setup(conf, db)
 		if err != nil {
-			log.Fatal("Syncer setup error:", err)
+			l.Fatal().
+				Err(err).
+				Msg("Failed to set up syncer")
 		}
 		go syncer.Start()
 		defer syncer.Stop()
@@ -66,14 +80,18 @@ func main() {
 	// setup and instrument metrics
 	err = metrics.RegisterAndInstrument(db)
 	if err != nil {
-		log.Fatal("Metrics register error:", err)
+		l.Fatal().
+			Err(err).
+			Msg("Failed to register metrics")
 	}
 
 	server, err := server.New(conf, db)
 	if err != nil {
-		log.Fatal("Server setup error:", err)
+		l.Fatal().
+			Err(err).
+			Msg("Failed to create a server")
 	}
 
 	// run server
-	log.Fatal(server.Start(fmt.Sprintf(":%d", conf.ServerPort)))
+	l.Fatal().Err(server.Start(fmt.Sprintf(":%d", conf.ServerPort)))
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/knadh/koanf v1.5.0
 	github.com/labstack/echo-contrib v0.17.4
 	github.com/labstack/echo/v4 v4.13.4
-	github.com/labstack/gommon v0.4.2
 	github.com/lib/pq v1.10.9
 	github.com/oapi-codegen/echo-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.1.1
@@ -151,6 +150,7 @@ require (
 	github.com/kkHAIKE/contextcheck v1.1.6 // indirect
 	github.com/kulti/thelper v0.6.3 // indirect
 	github.com/kunwardeep/paralleltest v1.0.14 // indirect
+	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/lasiar/canonicalheader v1.1.2 // indirect
 	github.com/ldez/exptostd v0.4.4 // indirect
 	github.com/ldez/gomoddirectives v0.7.0 // indirect


### PR DESCRIPTION
This adds the 'logger' usage in 'main.go' to only use one 'log' provider.

---

It removes an explicit dependency to `github.com/labstack/gommon/log` as well.

Before:
```
$ ./bin/nebraska
2025-07-02T18:13:43+02:00 DBG Unknown format context=api logFormat=
2025-07-02T18:13:43+02:00 DBG Unknown format context=nebraska logFormat=
2025-07-02T18:13:43+02:00 DBG Unknown format context=omaha logFormat=
2025-07-02T18:13:43+02:00 DBG Unknown format context=syncer logFormat=
2025-07-02T18:13:43+02:00 DBG Unknown format context=auth logFormat=
2025-07-02T18:13:43+02:00 DBG Unknown format context=nebraska logFormat=
2025-07-02T18:13:43+02:00 DBG Unknown format context=nebraska logFormat=
{"time":"2025-07-02T18:13:43.841872855+02:00","level":"FATAL","prefix":"-","file":"main.go","line":"26","message":"Config is invalid, err: Invalid OIDC configuration"}
```

After:
```
$ ./bin/nebraska
2025-07-02T18:17:50+02:00 DBG Unknown format context=api logFormat=
2025-07-02T18:17:50+02:00 DBG Unknown format context=nebraska logFormat=
2025-07-02T18:17:50+02:00 DBG Unknown format context=omaha logFormat=
2025-07-02T18:17:50+02:00 DBG Unknown format context=syncer logFormat=
2025-07-02T18:17:50+02:00 DBG Unknown format context=auth logFormat=
2025-07-02T18:17:50+02:00 DBG Unknown format context=nebraska logFormat=
2025-07-02T18:17:50+02:00 DBG Unknown format context=nebraska logFormat=
2025-07-02T18:17:50+02:00 DBG Unknown format context=main logFormat=
2025-07-02T18:17:50+02:00 FTL Config is invalid error="Invalid OIDC configuration" context=main
```

One can still get back to the JSON format with:
```
$ NEBRASKA_LOG_FORMAT=json ./bin/nebraska
{"level":"fatal","error":"Invalid OIDC configuration","time":"2025-07-02T18:17:56+02:00","context":"main","message":"Config is invalid"}\
```

(related to #1113)