### PR TITLE
chore(deps): update dependabot check frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       day: "monday"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/backend"


### PR DESCRIPTION
# Update dependabot check frequency from daily to weekly

This PR updates our Dependabot configuration to check for dependency updates weekly instead of daily. The change reduces CI noise and resource usage while still maintaining regular dependency hygiene. Also added explicit grouping for npm dependencies to make future updates more efficient.

## How to use
1. Review the `.github/dependabot.yml` changes
2. Verify the new `interval: "weekly"` setting replaces daily checks
3. Confirm npm dependency groupping pattern