### PR TITLE
feat(artifacthub): Add repository metadata file

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,11 @@
+# Artifact Hub repository metadata file
+# This file enables verified publisher status for the Nebraska Helm chart
+# More info: https://artifacthub.io/docs/topics/repositories/#ownership-claim
+
+repositoryID: flatcar-nebraska
+
+owners:
+  - name: Flatcar Linux Team
+    email: maintainers@flatcar-linux.org
+  - name: Ervin Racz
+    email: ervcz@users.noreply.github.com


### PR DESCRIPTION
Move metadata file for artifacthub into main from gh-pages branch (https://github.com/flatcar/nebraska/pull/1098), because according [to docs](https://github.com/flatcar/nebraska/pull/new/fix/artifacthu-repo.yml), the "the artifacthub-repo.yml metadata file must be located at the repository URL's path".

- [ ] remove the file from gh-pages