### PR TITLE
fix: patch critical form-data vulnerability CVE-2025-7783

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Security
+- **form-data@4.0.3 → v4.0.4**
+  - Fixes CVE-2025-7783 (GHSA-fjxv-7rqg-78g4): Critical vulnerability (CVSS 9.4) where form-data uses Math.random() for selecting multipart/form-data boundary values. This predictable randomness could allow attackers to inject additional parameters into requests (HTTP Parameter Pollution), potentially making arbitrary requests to internal systems. Affected versions: <2.5.4, 3.0.0-3.0.3, 4.0.0-4.0.3. Fixed in: 2.5.4, 3.0.4, 4.0.4. Updated via npm audit fix. ([#1146](https://github.com/flatcar/nebraska/pull/1146))
 - **github.com/go-viper/mapstructure/v2 → v2.3.0**  
   - Fixes GHSA-fv92-fjc5-jj9h: Prevents sensitive information leakage in error messages during type conversion failures (https://github.com/flatcar/nebraska/pull/1099)
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6787,7 +6787,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
# Fix critical form-data vulnerability CVE-2025-7783

Summary

This PR patches a critical security vulnerability (CVSS 9.4) in the form-data npm package that could allow attackers to perform HTTP Parameter Pollution attacks.

### Details

- CVE: CVE-2025-7783
- GitHub Advisory: GHSA-fjxv-7rqg-78g4
- Severity: Critical (CVSS 9.4)
- Affected Package: mailto:form-data@4.0.3 (transitive dependency via @iconify/tools → axios)

### Vulnerability Description

The vulnerability stems from using Math.random() for selecting multipart/form-data boundary values. This predictable randomness could allow attackers to:
- Inject additional parameters into HTTP requests
- Potentially make arbitrary requests to internal systems
- Perform HTTP Parameter Pollution (HPP) attacks

## Fix

Updated form-data from 4.0.3 to 4.0.4 by running npm audit fix.

### Changes

- Updated frontend/package-lock.json to use mailto:form-data@4.0.4
- Updated CHANGELOG.md with security fix details

### Testing

- Ran npm audit - no vulnerabilities found
- Verified mailto:form-data@4.0.4 is installed in dependency tree
- Frontend builds successfully

References
- https://github.com/flatcar/nebraska/security/dependabot/203