### PR TITLE
backend: update echo prom to new library

### DIFF
--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/labstack/echo-contrib/prometheus"
+
+	"github.com/labstack/echo-contrib/echoprometheus"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	echomiddleware "github.com/oapi-codegen/echo-middleware"
@@ -64,8 +66,8 @@ func New(conf *config.Config, db *db.API) (*echo.Echo, error) {
 		return nil, fmt.Errorf("swagger config error: %w", err)
 	}
 
-	p := prometheus.NewPrometheus(serviceName, nil)
-	p.Use(e)
+	e.Use(echoprometheus.NewMiddleware(serviceName))
+	e.GET("/metrics", echoprometheus.NewHandler())
 
 	// setup authenticator
 	defaultTeam, err := db.GetTeam()


### PR DESCRIPTION
# backend: use updated echo prometheus library

`echo` has an updated `prometheus` library that they recommend moving toward. While the [existing library](https://github.com/labstack/echo-contrib/tree/master/prometheus) isn't outright labeled as outdated, most documentation points at migrating to the [new library](https://github.com/labstack/echo-contrib/tree/master/echoprometheus).

## How to use

Startup Nebraska/backend as expected. Hit the `/metrics` endpoint and verify that the expected metrics are in place.

## Testing done

`make ci` to ensure no existing code is impacted. A quick glance at metrics appears to show the same `metrics` output

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.