### PR TITLE
chore(charts): update nebraska chart versions

### DIFF
--- a/charts/nebraska/Chart.yaml
+++ b/charts/nebraska/Chart.yaml
@@ -18,8 +18,8 @@ sources:
 maintainers:
   - name: flatcar
     url: https://flatcar.org/
-version: 1.5.1
-appVersion: "2.11.0"
+version: 1.6.0
+appVersion: "2.12.0"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
- Bump chart version from 1.5.1 to 1.6.0
- Update app version from 2.11.0 to 2.12.0