### PR TITLE
fix(auth): rm root from gh auth skipper to enforce login redirect

### DIFF
--- a/backend/pkg/middleware/auth.go
+++ b/backend/pkg/middleware/auth.go
@@ -9,7 +9,7 @@ import (
 	"github.com/flatcar/nebraska/backend/pkg/auth"
 )
 
-var commonPaths = []string{"/", "/health", "/v1/update", "/flatcar/*", "/assets/*", "/apps", "/apps/*", "/instances", "/instances/*", "/404"}
+var commonPaths = []string{"/health", "/config", "/v1/update", "/flatcar/*", "/assets/*", "/apps", "/apps/*", "/instances", "/instances/*", "/404"}
 
 func MatchesOneOfPatterns(path string, patterns ...string) bool {
 	for _, pattern := range patterns {
@@ -28,7 +28,7 @@ func NewAuthSkipper(auth string) middleware.Skipper {
 		}
 		switch auth {
 		case "oidc":
-			return MatchesOneOfPatterns(path, "/auth/callback", "/auth/error", "/config")
+			return MatchesOneOfPatterns(path, "/auth/callback", "/auth/error", "/")
 		case "github":
 			return MatchesOneOfPatterns(path, "/login/cb", "/login/webhook")
 		}

--- a/backend/pkg/middleware/auth_test.go
+++ b/backend/pkg/middleware/auth_test.go
@@ -110,8 +110,7 @@ func TestAuthSkipper_GitHub_SkippedPaths(t *testing.T) {
 		{"/instances", true, "instances path should be skipped for frontend"},
 		{"/instances/456", true, "instances with ID should be skipped for frontend"},
 		{"/404", true, "404 page should be skipped"},
-		{"/", true, "root path should be skipped"},
-		{"/config", false, "config endpoint should not be skipped for GitHub"},
+		{"/config", true, "config endpoint should not be skipped for GitHub"},
 		{"/api/apps", false, "API endpoints should not be skipped"},
 	}
 


### PR DESCRIPTION
The root got added to the list of endpoints to skip authentication for by accident with the previous [OIDC refactoring](https://github.com/flatcar/nebraska/pull/1092/files#diff-1024b787ca6798ef0df6551e988f06165e3798f905c726c697f7cb031e3ff544), which made the github mode to allow loading the SPA static content and have the SPA want to authenticate on subsequent fetch operations which are not capable to redirect automatically (they being fetch type queries).

<img width="1271" height="919" alt="Screenshot From 2025-09-18 22-13-57" src="https://github.com/user-attachments/assets/a82aea4a-d879-44e9-bfb2-8d3991eeb4f0" />

Document type queries can redirect however fetch type queries cannot, therefore the redirect failed. The solution was to restore the original behavior, which is that the backend checks if the client is authenticated even on the root, so that if not, it can respond with 307 and redirect to the github login page. This works because the first request is a document type query:

<img width="1271" height="919" alt="Screenshot From 2025-09-18 23-18-32" src="https://github.com/user-attachments/assets/44e1bba3-735e-460c-80b0-748994c7c1d4" />

