### PR TITLE
frontend/Makefile: Add dependencies for npm install

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -67,5 +67,5 @@ test-oidc-ci:
 .PHONY: ci
 ci: install-ci lint test install-playwright test-storybook-ci test-playwright-ci test-oidc-ci tsc build 
 
-node_modules:
+node_modules: package-lock.json package.json
 	npm install


### PR DESCRIPTION
The node_modules folder needs to be updated when the package.json file changes. This was not encoded as dependency and the rule wasn't "phony" either, so that we get build errors each time the package.json changes. Add the package.json file and the lock file as dependencies for the rule so that when the files are newer than the node_modules folder, we run "npm install" automatically. We could also use a "phony" rule but since the build is already slow we can skip the npm invocation if it doesn't need to run.

## How to use/Testing done

With this change I could switch branches and `make` didn't throw an error anymore.