### PR TITLE
fix(frontend:regex): mitigate regex inefficiency

### DIFF
--- a/frontend/src/__tests__/utils/regex.spec.ts
+++ b/frontend/src/__tests__/utils/regex.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+
+import { REGEX_REVERSE_DOMAIN_ID } from '../../utils/regex';
+
+describe('reverseDomainIdRegex', () => {
+  const regex = REGEX_REVERSE_DOMAIN_ID;
+
+  test.each([
+    // valid examples
+    ['com.example', true],
+    ['org.my-app', true],
+    ['net.service1', true],
+    ['a.b', true],
+    ['A.B1', true],
+    ['abc.def-ghi', true],
+    ['MyCompany.MyApp', true],
+
+    // invalid examples
+    ['a', false], // only one segment
+    ['com.', false], // ends with a dot
+    ['.example', false], // starts with a dot
+    ['com..example', false], // double dots
+    ['com.-example', false], // segment starts with dash
+    ['com.exa-', false], // segment ends with dash
+    ['1com.example', false], // first segment starts with digit
+    ['com.exa$mple', false], // invalid character
+    ['com.exa mple', false], // space not allowed
+    ['com..example', false], // empty segment
+  ])('validates "%s"', (input, expected) => {
+    expect(regex.test(input)).toBe(expected);
+  });
+});

--- a/frontend/src/components/Applications/ApplicationEdit.tsx
+++ b/frontend/src/components/Applications/ApplicationEdit.tsx
@@ -12,6 +12,7 @@ import * as Yup from 'yup';
 
 import { Application } from '../../api/apiDataTypes';
 import { applicationsStore } from '../../stores/Stores';
+import { REGEX_REVERSE_DOMAIN_ID } from '../../utils/regex';
 
 export interface ApplicationEditProps {
   create?: any;
@@ -152,10 +153,7 @@ export default function ApplicationEdit(props: ApplicationEditProps) {
       // * All characters must be alphanumeric, or a dash.
       // Each segment must start with a letter.
       // Each segment must not end with a dash.
-      .matches(
-        /^[a-zA-Z]+([a-zA-Z0-9-]*[a-zA-Z0-9])*(\.[a-zA-Z]+([a-zA-Z0-9-]*[a-zA-Z0-9])*)+$/,
-        t('common|reverse_domain_id_error')
-      )
+      .matches(REGEX_REVERSE_DOMAIN_ID, t('common|reverse_domain_id_error'))
       .nullable(),
     description: Yup.string().max(
       maxDescChars,

--- a/frontend/src/utils/regex.ts
+++ b/frontend/src/utils/regex.ts
@@ -2,3 +2,5 @@
 export const REGEX_SEMVER =
   /^((\d+)\.(\d+)\.(\d+))(?:-([\dA-Za-z\-]+(?:\.[\dA-Za-z\-]+)*))?(?:\+([\dA-Za-z\-]+(?:\.[\dA-Za-z\-]+)*))?$/;
 export const REGEX_SIZE = /^[0-9]{0,20}$/;
+export const REGEX_REVERSE_DOMAIN_ID =
+  /^[A-Za-z](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+$/;


### PR DESCRIPTION
Fixes: https://github.com/flatcar/nebraska/security/code-scanning/41

- Extract reverse domain ID regex into shared constant for maintainability
- Replace vulnerable nested quantifier pattern with safer non-capturing groups
- Add comprehensive test suite to validate regex behavior
