### PR TITLE
Potential fix for code scanning alert no. 59: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,4 +1,6 @@
 name: Build Backend
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/flatcar/nebraska/security/code-scanning/59](https://github.com/flatcar/nebraska/security/code-scanning/59)

To resolve the problem, add an explicit `permissions` block to restrict the permissions granted to the GITHUB_TOKEN during workflow execution. The best practice is to assign the least privileges necessary. For workflows that only need to check out code and build/test, setting `contents: read` at the workflow root or job level is sufficient.

Since there is only one job, it's most effective to add `permissions: contents: read` at the root level (directly after `name:` or after `on:`), which will apply to all jobs by default.

**Edit needed:**  
- In `.github/workflows/backend.yml`, add  
  ```yaml
  permissions:
    contents: read
  ```  
  after the `name` and before the `on` block (line 2).

No other imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
