### PR TITLE
feat(packages): implement paginated package list

### DIFF
--- a/backend/pkg/api/packages.go
+++ b/backend/pkg/api/packages.go
@@ -353,6 +353,7 @@ func (api *API) GetPackages(appID string, page, perPage uint64, searchVersion *s
 	if err != nil {
 		return nil, err
 	}
+
 	return api.getPackagesFromQuery(queryString)
 }
 

--- a/backend/pkg/handler/packages.go
+++ b/backend/pkg/handler/packages.go
@@ -19,6 +19,7 @@ func (h *Handler) PaginatePackages(ctx echo.Context, appIDorProductID string, pa
 	if params.Perpage == nil {
 		params.Perpage = &defaultPerPage
 	}
+
 	appID, err := h.db.GetAppID(appIDorProductID)
 	if err != nil {
 		return appNotFoundResponse(ctx, appIDorProductID)

--- a/frontend/src/__tests__/Common/PackagesList.spec.tsx
+++ b/frontend/src/__tests__/Common/PackagesList.spec.tsx
@@ -6,12 +6,15 @@ vi.mock('../../stores/Stores', () => ({
     getApplication: vi.fn(),
     addChangeListener: vi.fn(),
     removeChangeListener: vi.fn(),
+    getPackageQueryParams: vi.fn(),
+    getAndUpdatePackages: vi.fn(),
   })),
 }));
 
 vi.mock('../../api/API', async () => ({
   ...(await vi.importActual('../../api/API')),
-  getPackages: vi.fn().mockResolvedValue({ packages: [] }),
+  getPackages: vi.fn().mockResolvedValue({ packages: [], totalCount: 0 }),
+  getApplication: vi.fn().mockResolvedValue({}),
 }));
 
 import '../../i18n/config.ts';

--- a/frontend/src/api/apiDataTypes.ts
+++ b/frontend/src/api/apiDataTypes.ts
@@ -73,6 +73,8 @@ export interface FlatcarAction {
   package_id?: string;
 }
 
+export type Packages = { totalCount: number; items: Package[] };
+
 export interface Application {
   id: string;
   name: string;
@@ -82,7 +84,7 @@ export interface Application {
   team_id: string;
   groups: Group[];
   channels: Channel[];
-  packages: Package[];
+  packages: Packages | null | undefined;
   instances: {
     count: number;
   };

--- a/frontend/src/components/Channels/ChannelEdit.tsx
+++ b/frontend/src/components/Channels/ChannelEdit.tsx
@@ -51,7 +51,7 @@ export default function ChannelEdit(props: ChannelEditProps) {
   const [channelColor, setChannelColor] = React.useState(defaultColor);
   const [packages, setPackages] = React.useState<{ total: number; packages: Package[] }>({
     packages: [],
-    total: props.data.packages ? -1 : 0,
+    total: 0,
   });
   const defaultArch = 1;
   const [arch, setArch] = React.useState(defaultArch);


### PR DESCRIPTION
## Implement paginated package list

- Remove packages fetching from channel components
- Simplify channel list loading logic
- Add API integration for fetching packages with pagination
- Update package table to use server-side pagination instead of client-side slicing

Should fix: https://github.com/flatcar/nebraska/issues/599

## How to use

The packages list becomes truly paginated. Prior to this change, the frontend would request a list of 1000 packages from the server. This refactoring also solves the problem of the package table not getting refreshed after creation, deletion or update operations.

## Testing done

- Frontend tests should pass.
- Created more than 10 packages so that pagination can be tested
- Deleted and edited one or two packages, so that re-redenders are tested.


