### PR TITLE
Add `--ca-file` flag for custom TLS trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 ### Added
 
+- **Custom CA Certificate for OIDC Provider TLS:** Added `--oidc-ca-file` flag to trust additional CA certificates for OIDC provider TLS verification (e.g., internal CA, Let's Encrypt staging). Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.auth.oidc.caFile` in the Helm chart.
 - **Multi-Step Updates with Floor Packages:** Added support for mandatory intermediate update versions (floor packages) that clients must install before reaching the target version. This enables safe migration paths for breaking changes by ensuring clients update through specific versions in order. Floor packages can be configured per channel with optional reasons and are architecture-specific. ([#1195](https://github.com/flatcar/nebraska/pull/1195))
 - **Nebraska backend is able to use OIDC userinfo endpoint:** Some OIDC providers do not return group membership inside the access token. The Nebraska frontend passes this access token via the header `Authorization: Bearer <token>` to the backend which can then (optionally) call the OIDC provider's userinfo endpoint to gather group membership. ([#1279](https://github.com/flatcar/nebraska/pull/1279))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 ### Added
 
-- **Custom CA Certificate for OIDC Provider TLS:** Added `--oidc-ca-file` flag to trust additional CA certificates for OIDC provider TLS verification (e.g., internal CA, Let's Encrypt staging). Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.auth.oidc.caFile` in the Helm chart.
+- **Custom CA Certificate for TLS:** Added `--ca-file` flag to trust additional CA certificates for TLS verification (e.g., internal CA, Let's Encrypt staging). Applies to the OIDC provider client and the syncer. Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.caFile` in the Helm chart.
 - **Multi-Step Updates with Floor Packages:** Added support for mandatory intermediate update versions (floor packages) that clients must install before reaching the target version. This enables safe migration paths for breaking changes by ensuring clients update through specific versions in order. Floor packages can be configured per channel with optional reasons and are architecture-specific. ([#1195](https://github.com/flatcar/nebraska/pull/1195))
 - **Nebraska backend is able to use OIDC userinfo endpoint:** Some OIDC providers do not return group membership inside the access token. The Nebraska frontend passes this access token via the header `Authorization: Bearer <token>` to the backend which can then (optionally) call the OIDC provider's userinfo endpoint to gather group membership. ([#1279](https://github.com/flatcar/nebraska/pull/1279))
 

--- a/backend/cmd/nebraska/main.go
+++ b/backend/cmd/nebraska/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flatcar/nebraska/backend/pkg/metrics"
 	"github.com/flatcar/nebraska/backend/pkg/server"
 	"github.com/flatcar/nebraska/backend/pkg/syncer"
+	"github.com/flatcar/nebraska/backend/pkg/tlsutil"
 )
 
 var l = logger.New("main")
@@ -31,6 +32,14 @@ func main() {
 			Err(err).
 			Msg("Config is invalid")
 	}
+
+	caPool, err := tlsutil.LoadCAPool(conf.CAFile)
+	if err != nil {
+		l.Fatal().
+			Err(err).
+			Msg("Failed to load CA certificates")
+	}
+	conf.CACertPool = caPool
 
 	if conf.RollbackDBTo != "" {
 		db, err := db.New()

--- a/backend/pkg/auth/oidc.go
+++ b/backend/pkg/auth/oidc.go
@@ -2,12 +2,9 @@ package auth
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"slices"
 	"strings"
 
@@ -24,7 +21,7 @@ type OIDCAuthConfig struct {
 	ViewerRoles   []string
 	RolesPath     string
 	UseUserInfo   bool
-	CAFile        string
+	HTTPClient    *http.Client
 }
 
 type oidcAuth struct {
@@ -42,31 +39,8 @@ type oidcAuth struct {
 func NewOIDCAuthenticator(config *OIDCAuthConfig) (Authenticator, error) {
 	ctx := context.Background()
 
-	var httpClient *http.Client
-	if config.CAFile != "" {
-		pool, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, fmt.Errorf("error loading system CA pool: %w", err)
-		}
-
-		caCert, err := os.ReadFile(config.CAFile)
-		if err != nil {
-			return nil, fmt.Errorf("error reading oidc-ca-file %q: %w", config.CAFile, err)
-		}
-
-		if !pool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("oidc-ca-file %q contains no valid PEM certificates", config.CAFile)
-		}
-
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport.TLSClientConfig = &tls.Config{
-			RootCAs: pool,
-		}
-
-		httpClient = &http.Client{
-			Transport: transport,
-		}
-		ctx = oidc.ClientContext(ctx, httpClient)
+	if config.HTTPClient != nil {
+		ctx = oidc.ClientContext(ctx, config.HTTPClient)
 	}
 
 	// setup oidc provider
@@ -93,7 +67,7 @@ func NewOIDCAuthenticator(config *OIDCAuthConfig) (Authenticator, error) {
 		viewerRoles:   config.ViewerRoles,
 		rolesPath:     config.RolesPath,
 		useUserInfo:   config.UseUserInfo,
-		httpClient:    httpClient,
+		httpClient:    config.HTTPClient,
 	}
 
 	return oidcAuthenticator, nil

--- a/backend/pkg/auth/oidc.go
+++ b/backend/pkg/auth/oidc.go
@@ -2,12 +2,14 @@ package auth
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
-
+	"os"
 	"slices"
+	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/labstack/echo/v4"
@@ -22,6 +24,7 @@ type OIDCAuthConfig struct {
 	ViewerRoles   []string
 	RolesPath     string
 	UseUserInfo   bool
+	CAFile        string
 }
 
 type oidcAuth struct {
@@ -33,10 +36,38 @@ type oidcAuth struct {
 	viewerRoles   []string
 	rolesPath     string
 	useUserInfo   bool
+	httpClient    *http.Client
 }
 
 func NewOIDCAuthenticator(config *OIDCAuthConfig) (Authenticator, error) {
 	ctx := context.Background()
+
+	var httpClient *http.Client
+	if config.CAFile != "" {
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("error loading system CA pool: %w", err)
+		}
+
+		caCert, err := os.ReadFile(config.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("error reading oidc-ca-file %q: %w", config.CAFile, err)
+		}
+
+		if !pool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("oidc-ca-file %q contains no valid PEM certificates", config.CAFile)
+		}
+
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{
+			RootCAs: pool,
+		}
+
+		httpClient = &http.Client{
+			Transport: transport,
+		}
+		ctx = oidc.ClientContext(ctx, httpClient)
+	}
 
 	// setup oidc provider
 	provider, err := oidc.NewProvider(ctx, config.IssuerURL)
@@ -62,6 +93,7 @@ func NewOIDCAuthenticator(config *OIDCAuthConfig) (Authenticator, error) {
 		viewerRoles:   config.ViewerRoles,
 		rolesPath:     config.RolesPath,
 		useUserInfo:   config.UseUserInfo,
+		httpClient:    httpClient,
 	}
 
 	return oidcAuthenticator, nil
@@ -157,6 +189,10 @@ func (oa *oidcAuth) rolesFromUserInfo(ctx context.Context, rawToken string, role
 	roles := []string{}
 	if rolesPath == "" {
 		return roles, nil
+	}
+
+	if oa.httpClient != nil {
+		ctx = oidc.ClientContext(ctx, oa.httpClient)
 	}
 
 	userInfo, err := oa.provider.UserInfo(ctx, oauth2.StaticTokenSource(&oauth2.Token{

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	OidcLogoutURL     string `koanf:"oidc-logout-url"`
 	OidcAudience      string `koanf:"oidc-audience"`
 	OidcUseUserInfo   bool   `koanf:"oidc-use-userinfo"`
+	OidcCAFile        string `koanf:"oidc-ca-file"`
 }
 
 const (
@@ -88,6 +89,11 @@ func (c *Config) Validate() error {
 	case "oidc":
 		if c.OidcClientID == "" || c.OidcIssuerURL == "" || c.OidcAdminRoles == "" || c.OidcViewerRoles == "" {
 			return errors.New("invalid OIDC configuration")
+		}
+		if c.OidcCAFile != "" {
+			if _, err := os.Stat(c.OidcCAFile); err != nil {
+				return fmt.Errorf("invalid oidc-ca-file: %w", err)
+			}
 		}
 	}
 
@@ -127,6 +133,7 @@ func Parse() (*Config, error) {
 	f.String("oidc-logout-url", "", "OIDC logout URL (optional fallback when end_session_endpoint is not available in discovery)")
 	f.String("oidc-audience", "", "OIDC audience parameter for the access token")
 	f.Bool("oidc-use-userinfo", false, "Use OIDC UserInfo endpoint for role extraction (for providers that don't include roles in access token)")
+	f.String("oidc-ca-file", "", "path to a PEM-encoded CA certificate file to trust for OIDC provider TLS verification (additive to system CAs, supports multiple certs in one file)")
 	f.String("sync-update-url", "https://public.update.flatcar-linux.net/v1/update/", "Flatcar update URL to sync from")
 	f.String("sync-interval", "1h", "Sync check interval (the minimum depends on the number of channels to sync, e.g., 8m for 8 channels incl. different architectures)")
 	f.String("client-logo", "", "Client app logo, should be a path to svg file")

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/x509"
 	"errors"
 	"flag"
 	"fmt"
@@ -51,7 +52,8 @@ type Config struct {
 	OidcLogoutURL     string `koanf:"oidc-logout-url"`
 	OidcAudience      string `koanf:"oidc-audience"`
 	OidcUseUserInfo   bool   `koanf:"oidc-use-userinfo"`
-	OidcCAFile        string `koanf:"oidc-ca-file"`
+	CAFile            string `koanf:"ca-file"`
+	CACertPool        *x509.CertPool
 }
 
 const (
@@ -90,10 +92,11 @@ func (c *Config) Validate() error {
 		if c.OidcClientID == "" || c.OidcIssuerURL == "" || c.OidcAdminRoles == "" || c.OidcViewerRoles == "" {
 			return errors.New("invalid OIDC configuration")
 		}
-		if c.OidcCAFile != "" {
-			if _, err := os.Stat(c.OidcCAFile); err != nil {
-				return fmt.Errorf("invalid oidc-ca-file: %w", err)
-			}
+	}
+
+	if c.CAFile != "" {
+		if _, err := os.Stat(c.CAFile); err != nil {
+			return fmt.Errorf("invalid ca-file: %w", err)
 		}
 	}
 
@@ -133,7 +136,7 @@ func Parse() (*Config, error) {
 	f.String("oidc-logout-url", "", "OIDC logout URL (optional fallback when end_session_endpoint is not available in discovery)")
 	f.String("oidc-audience", "", "OIDC audience parameter for the access token")
 	f.Bool("oidc-use-userinfo", false, "Use OIDC UserInfo endpoint for role extraction (for providers that don't include roles in access token)")
-	f.String("oidc-ca-file", "", "path to a PEM-encoded CA certificate file to trust for OIDC provider TLS verification (additive to system CAs, supports multiple certs in one file)")
+	f.String("ca-file", "", "path to a PEM-encoded CA certificate file to trust for TLS verification (additive to system CAs, supports multiple certs in one file)")
 	f.String("sync-update-url", "https://public.update.flatcar-linux.net/v1/update/", "Flatcar update URL to sync from")
 	f.String("sync-interval", "1h", "Sync check interval (the minimum depends on the number of channels to sync, e.g., 8m for 8 channels incl. different architectures)")
 	f.String("client-logo", "", "Client app logo, should be a path to svg file")

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -194,6 +194,7 @@ func setupAuthenticator(conf config.Config, sessionStore *sessions.Store, defaul
 			ViewerRoles:   strings.Split(conf.OidcViewerRoles, ","),
 			RolesPath:     conf.OidcRolesPath,
 			UseUserInfo:   conf.OidcUseUserInfo,
+			CAFile:        conf.OidcCAFile,
 		}
 		return auth.NewOIDCAuthenticator(oidcAuthConfig)
 	}

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/flatcar/nebraska/backend/pkg/sessions/memcache"
 	memcachegob "github.com/flatcar/nebraska/backend/pkg/sessions/memcache/gob"
 	"github.com/flatcar/nebraska/backend/pkg/sessions/securecookie"
+	"github.com/flatcar/nebraska/backend/pkg/tlsutil"
 )
 
 const serviceName = "nebraska"
@@ -194,7 +195,7 @@ func setupAuthenticator(conf config.Config, sessionStore *sessions.Store, defaul
 			ViewerRoles:   strings.Split(conf.OidcViewerRoles, ","),
 			RolesPath:     conf.OidcRolesPath,
 			UseUserInfo:   conf.OidcUseUserInfo,
-			CAFile:        conf.OidcCAFile,
+			HTTPClient:    tlsutil.NewHTTPClient(conf.CACertPool),
 		}
 		return auth.NewOIDCAuthenticator(oidcAuthConfig)
 	}

--- a/backend/pkg/syncer/syncer.go
+++ b/backend/pkg/syncer/syncer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/flatcar/nebraska/backend/pkg/api"
 	"github.com/flatcar/nebraska/backend/pkg/config"
 	"github.com/flatcar/nebraska/backend/pkg/logger"
+	"github.com/flatcar/nebraska/backend/pkg/tlsutil"
 )
 
 const (
@@ -74,6 +75,7 @@ type Config struct {
 	PackagesURL       string
 	FlatcarUpdatesURL string
 	CheckFrequency    time.Duration
+	HTTPClient        *http.Client
 }
 
 // Setup creates a new syncer from config and db connection, and returns it.
@@ -82,6 +84,8 @@ func Setup(conf *config.Config, db *api.API) (*Syncer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid Check Frequency value: %w", err)
 	}
+
+	httpClient := tlsutil.NewHTTPClient(conf.CACertPool)
 
 	if conf.SyncerPkgsURL == "" && conf.HostFlatcarPackages {
 		conf.SyncerPkgsURL = conf.NebraskaURL + "/flatcar/"
@@ -94,6 +98,7 @@ func Setup(conf *config.Config, db *api.API) (*Syncer, error) {
 		PackagesURL:       conf.SyncerPkgsURL,
 		FlatcarUpdatesURL: conf.FlatcarUpdatesURL,
 		CheckFrequency:    checkFrequency,
+		HTTPClient:        httpClient,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error setting up syncer: %w", err)
@@ -125,7 +130,11 @@ func New(conf *Config) (*Syncer, error) {
 		bootIDs:           make(map[channelDescriptor]string, 8),
 		channelsIDs:       make(map[channelDescriptor]string, 8),
 		versions:          make(map[channelDescriptor]string, 8),
-		httpClient:        &http.Client{},
+		httpClient:        conf.HTTPClient,
+	}
+
+	if s.httpClient == nil {
+		s.httpClient = &http.Client{}
 	}
 
 	if err := s.initialize(); err != nil {
@@ -736,7 +745,7 @@ func (s *Syncer) downloadPackage(update *omaha.UpdateResponse, pkgName, sha1Base
 	updateURL.Path = path.Join(updateURL.Path, pkgName)
 
 	pkgURL := updateURL.String()
-	resp, err := http.Get(pkgURL)
+	resp, err := s.httpClient.Get(pkgURL)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/tlsutil/tlsutil.go
+++ b/backend/pkg/tlsutil/tlsutil.go
@@ -1,0 +1,50 @@
+// Package tlsutil provides helpers for building HTTP clients with custom CA trust.
+package tlsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// LoadCAPool reads PEM-encoded certificates from caFile and returns a cert pool
+// containing both the system CAs and the custom ones.
+// Returns nil, nil when caFile is empty.
+func LoadCAPool(caFile string) (*x509.CertPool, error) {
+	if caFile == "" {
+		return nil, nil
+	}
+
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("error loading system CA pool: %w", err)
+	}
+
+	caCert, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reading ca-file %q: %w", caFile, err)
+	}
+
+	if !pool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("ca-file %q contains no valid PEM certificates", caFile)
+	}
+
+	return pool, nil
+}
+
+// NewHTTPClient creates an *http.Client that trusts the provided cert pool.
+// Returns nil when pool is nil.
+func NewHTTPClient(pool *x509.CertPool) *http.Client {
+	if pool == nil {
+		return nil
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		RootCAs: pool,
+	}
+
+	return &http.Client{Transport: transport}
+}

--- a/backend/test/auth/oidc/ca_file_test.go
+++ b/backend/test/auth/oidc/ca_file_test.go
@@ -1,0 +1,137 @@
+package auth_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jinzhu/copier"
+	"github.com/oauth2-proxy/mockoidc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flatcar/nebraska/backend/pkg/config"
+	"github.com/flatcar/nebraska/backend/pkg/server"
+	"github.com/flatcar/nebraska/backend/pkg/tlsutil"
+)
+
+type testCA struct {
+	certPEM   []byte
+	serverTLS *tls.Config
+}
+
+func newTestCA(t *testing.T, addr string) *testCA {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	host, _, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP(host)},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
+
+	return &testCA{
+		certPEM:   certPEM,
+		serverTLS: &tls.Config{Certificates: []tls.Certificate{tlsCert}},
+	}
+}
+
+func (ca *testCA) writeCAFile(t *testing.T) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "ca-*.pem")
+	require.NoError(t, err)
+	_, err = f.Write(ca.certPEM)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+func startTLSOIDCServer(t *testing.T) (*mockoidc.MockOIDC, *testCA) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	ca := newTestCA(t, ln.Addr().String())
+	tlsLn := tls.NewListener(ln, ca.serverTLS)
+
+	m, err := mockoidc.NewServer(nil)
+	require.NoError(t, err)
+	err = m.Start(tlsLn, ca.serverTLS)
+	require.NoError(t, err)
+
+	return m, ca
+}
+
+func TestCAFileOIDCSetup(t *testing.T) {
+	t.Run("tls_oidc_with_ca_file_succeeds", func(t *testing.T) {
+		oidcServer, ca := startTLSOIDCServer(t)
+		defer oidcServer.Shutdown() //nolint:errcheck
+
+		var testConfig config.Config
+		err := copier.Copy(&testConfig, conf)
+		require.NoError(t, err)
+
+		caFile := ca.writeCAFile(t)
+		testConfig.CAFile = caFile
+		testConfig.OidcIssuerURL = oidcServer.Issuer()
+
+		caPool, err := tlsutil.LoadCAPool(caFile)
+		require.NoError(t, err)
+		testConfig.CACertPool = caPool
+
+		db := newDBForTest(t)
+		srv, err := server.New(&testConfig, db)
+		assert.NotNil(t, srv)
+		assert.NoError(t, err)
+	})
+
+	t.Run("tls_oidc_without_ca_file_fails", func(t *testing.T) {
+		oidcServer, _ := startTLSOIDCServer(t)
+		defer oidcServer.Shutdown() //nolint:errcheck
+
+		var testConfig config.Config
+		err := copier.Copy(&testConfig, conf)
+		require.NoError(t, err)
+
+		testConfig.OidcIssuerURL = oidcServer.Issuer()
+
+		db := newDBForTest(t)
+		srv, err := server.New(&testConfig, db)
+		assert.Nil(t, srv)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error setting up oidc provider")
+		assert.Contains(t, err.Error(), "certificate signed by unknown authority")
+	})
+}

--- a/charts/nebraska/README.md
+++ b/charts/nebraska/README.md
@@ -28,6 +28,7 @@ The OIDC implementation has been refactored to use Authorization Code Flow with 
 **Added Configuration Options:**
 - `config.auth.oidc.audience` - Optional, required for Auth0
 - `config.auth.oidc.useUserInfo` - Use UserInfo endpoint for role extraction (for providers that don't include roles in access token)
+- `config.auth.oidc.caFile` - Path to a PEM-encoded CA certificate file to trust for OIDC provider TLS verification
 
 **All Other Options Remain:** `clientID`, `issuerURL`, `managementURL`, `logoutURL`, `adminRoles`, `viewerRoles`, `rolesPath`, `scopes`
 
@@ -191,6 +192,7 @@ $ kubectl exec -ti pod/nebraska-postgresql-0 -- psql < backup.sql
 | `config.auth.oidc.scopes`                             | comma-separated list of scopes to be used in OIDC | `nil`  |
 | `config.auth.oidc.audience`                           | OIDC audience (required for Auth0, optional for others) | `nil`  |
 | `config.auth.oidc.useUserInfo`                        | Use UserInfo endpoint for role extraction (for providers that don't include roles in access token) | `false`  |
+| `config.auth.oidc.caFile`                             | Path to a PEM-encoded CA certificate file to trust for OIDC provider TLS verification (additive to system CAs) | `nil`  |
 | `config.database.host`                                | The host name of the database server                                                                                                 | `""` (use postgresql from Bitnami subchart)                             |
 | `config.database.port`                                | The port number the database server is listening on                                                                                  | `5432`                                                                  |
 | `config.database.sslMode`                             | The mode of the database connection                                                                                                  | `disable`                                                               |

--- a/charts/nebraska/README.md
+++ b/charts/nebraska/README.md
@@ -28,7 +28,7 @@ The OIDC implementation has been refactored to use Authorization Code Flow with 
 **Added Configuration Options:**
 - `config.auth.oidc.audience` - Optional, required for Auth0
 - `config.auth.oidc.useUserInfo` - Use UserInfo endpoint for role extraction (for providers that don't include roles in access token)
-- `config.auth.oidc.caFile` - Path to a PEM-encoded CA certificate file to trust for OIDC provider TLS verification
+- `config.caFile` - Path to a PEM-encoded CA certificate file to trust for TLS verification
 
 **All Other Options Remain:** `clientID`, `issuerURL`, `managementURL`, `logoutURL`, `adminRoles`, `viewerRoles`, `rolesPath`, `scopes`
 
@@ -171,6 +171,7 @@ $ kubectl exec -ti pod/nebraska-postgresql-0 -- psql < backup.sql
 | `config.hostFlatcarPackages.persistence.storageClass` | PVC Storage Class for PostgreSQL volume                                                                                              | `nil`                                                                   |
 | `config.hostFlatcarPackages.persistence.accessModes`  | PVC Access Mode for PostgreSQL volume                                                                                                | `["ReadWriteOnce"]`                                                     |
 | `config.hostFlatcarPackages.persistence.size`         | PVC Storage Request for PostgreSQL volume                                                                                            | `10Gi`                                                                  |
+| `config.caFile`                                       | Path to a PEM-encoded CA certificate file to trust for TLS verification (additive to system CAs, used for OIDC and syncer) | `nil`  |
 | `config.auth.mode`                                    | Authentication mode, available modes: `noop`, `github`, `oidc`                                                                               | `noop`                                                                  |
 | `config.auth.github.clientID`                         | GitHub client ID used for authentication                                                                                             | `nil`                                                                   |
 | `config.auth.github.clientSecret`                     | GitHub client secret used for authentication                                                                                         | `nil`                                                                   |
@@ -192,7 +193,6 @@ $ kubectl exec -ti pod/nebraska-postgresql-0 -- psql < backup.sql
 | `config.auth.oidc.scopes`                             | comma-separated list of scopes to be used in OIDC | `nil`  |
 | `config.auth.oidc.audience`                           | OIDC audience (required for Auth0, optional for others) | `nil`  |
 | `config.auth.oidc.useUserInfo`                        | Use UserInfo endpoint for role extraction (for providers that don't include roles in access token) | `false`  |
-| `config.auth.oidc.caFile`                             | Path to a PEM-encoded CA certificate file to trust for OIDC provider TLS verification (additive to system CAs) | `nil`  |
 | `config.database.host`                                | The host name of the database server                                                                                                 | `""` (use postgresql from Bitnami subchart)                             |
 | `config.database.port`                                | The port number the database server is listening on                                                                                  | `5432`                                                                  |
 | `config.database.sslMode`                             | The mode of the database connection                                                                                                  | `disable`                                                               |

--- a/charts/nebraska/templates/deployment.yaml
+++ b/charts/nebraska/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             {{- if .Values.config.app.httpStaticDir }}
             - "-http-static-dir={{ .Values.config.app.httpStaticDir }}"
             {{- end }}
+            {{- with .Values.config.caFile }}
+            - "-ca-file={{ . }}"
+            {{- end }}
 
             {{- /* --- Syncer settings --- */}}
             {{- if .Values.config.syncer.enabled }}
@@ -131,9 +134,7 @@ spec:
               {{- if .Values.config.auth.oidc.useUserInfo }}
             - "-oidc-use-userinfo"
               {{- end }}
-              {{- with .Values.config.auth.oidc.caFile }}
-            - "-oidc-ca-file={{ . }}"
-              {{- end }}
+
             {{- end }}
 
             {{- /* --- Extra Args --- */ -}}

--- a/charts/nebraska/templates/deployment.yaml
+++ b/charts/nebraska/templates/deployment.yaml
@@ -131,6 +131,9 @@ spec:
               {{- if .Values.config.auth.oidc.useUserInfo }}
             - "-oidc-use-userinfo"
               {{- end }}
+              {{- with .Values.config.auth.oidc.caFile }}
+            - "-oidc-ca-file={{ . }}"
+              {{- end }}
             {{- end }}
 
             {{- /* --- Extra Args --- */ -}}

--- a/charts/nebraska/values.yaml
+++ b/charts/nebraska/values.yaml
@@ -42,6 +42,10 @@ config:
         - ReadWriteOnce
       size: 10Gi
 
+  # Path to a PEM-encoded CA certificate file to trust for TLS verification
+  # (additive to system CAs, supports multiple certs in one file)
+  caFile:
+
   auth:
     mode: noop
     oidc:
@@ -57,9 +61,6 @@ config:
       audience:
       # Use OIDC UserInfo endpoint for role extraction (for providers that don't include roles in access token)
       useUserInfo: false
-      # Path to a PEM-encoded CA certificate file to trust for OIDC provider TLS verification
-      # (additive to system CAs, supports multiple certs in one file)
-      caFile:
     github:
       clientID:
       clientSecret:
@@ -201,6 +202,7 @@ extraAnnotations: {}
 # ... for more options see https://github.com/bitnami/charts/tree/master/bitnami/postgresql
 postgresql:
   enabled: true
+
   auth:
     username: postgres
     database: nebraska

--- a/charts/nebraska/values.yaml
+++ b/charts/nebraska/values.yaml
@@ -57,6 +57,9 @@ config:
       audience:
       # Use OIDC UserInfo endpoint for role extraction (for providers that don't include roles in access token)
       useUserInfo: false
+      # Path to a PEM-encoded CA certificate file to trust for OIDC provider TLS verification
+      # (additive to system CAs, supports multiple certs in one file)
+      caFile:
     github:
       clientID:
       clientSecret:

--- a/docs/oidc-migration-guide.md
+++ b/docs/oidc-migration-guide.md
@@ -64,7 +64,21 @@ Migration guide for Nebraska's secure OIDC implementation with Authorization Cod
 --oidc-management-url=https://your-idp.com # Account management URL
 --oidc-logout-url=https://your-idp.com/logout # Fallback logout URL
 --oidc-audience=https://nebraska-api       # Required for Auth0 (use your API identifier)
+--oidc-ca-file=/path/to/ca.pem            # Custom CA cert for OIDC provider TLS (see below)
 ```
+
+### Custom CA Certificates
+
+If your OIDC provider uses a certificate signed by a non-system CA (e.g., internal CA, Let's Encrypt staging), you can provide a custom CA certificate file:
+
+```bash
+--oidc-ca-file=/path/to/ca-bundle.pem
+```
+
+- The file should contain one or more PEM-encoded CA certificates
+- Custom CAs are **added** to the system CA pool (system-trusted CAs remain trusted)
+- Only affects the OIDC HTTP client (discovery, JWKS, UserInfo), not the rest of Nebraska
+- If the file is unreadable or contains no valid PEM certificates, Nebraska fails at startup with a clear error
 
 ### 3. Verification
 
@@ -96,6 +110,7 @@ Visit the updated Nebraska documentation at `https://www.flatcar.org/docs/latest
 | User has no access | Verify user roles match configured roles |
 | Frequent re-authentication | Increase access token expiration time in OIDC provider |
 | JWT decode error (Auth0) | Ensure audience is set and Implicit grant is disabled |
+| x509: certificate signed by unknown authority | Use `--oidc-ca-file` to trust your OIDC provider's CA certificate |
 
 **Debug JWT claims:**
 ```bash

--- a/docs/oidc-migration-guide.md
+++ b/docs/oidc-migration-guide.md
@@ -64,7 +64,7 @@ Migration guide for Nebraska's secure OIDC implementation with Authorization Cod
 --oidc-management-url=https://your-idp.com # Account management URL
 --oidc-logout-url=https://your-idp.com/logout # Fallback logout URL
 --oidc-audience=https://nebraska-api       # Required for Auth0 (use your API identifier)
---oidc-ca-file=/path/to/ca.pem            # Custom CA cert for OIDC provider TLS (see below)
+--ca-file=/path/to/ca.pem                 # Custom CA cert for TLS (see below)
 ```
 
 ### Custom CA Certificates
@@ -72,12 +72,12 @@ Migration guide for Nebraska's secure OIDC implementation with Authorization Cod
 If your OIDC provider uses a certificate signed by a non-system CA (e.g., internal CA, Let's Encrypt staging), you can provide a custom CA certificate file:
 
 ```bash
---oidc-ca-file=/path/to/ca-bundle.pem
+--ca-file=/path/to/ca-bundle.pem
 ```
 
 - The file should contain one or more PEM-encoded CA certificates
-- Custom CAs are **added** to the system CA pool (system-trusted CAs remain trusted)
-- Only affects the OIDC HTTP client (discovery, JWKS, UserInfo), not the rest of Nebraska
+- Custom CAs are **added** to the system trust store (system-trusted CAs remain trusted)
+- Applies to the OIDC HTTP client (discovery, JWKS, UserInfo) and the syncer HTTP client
 - If the file is unreadable or contains no valid PEM certificates, Nebraska fails at startup with a clear error
 
 ### 3. Verification
@@ -110,7 +110,7 @@ Visit the updated Nebraska documentation at `https://www.flatcar.org/docs/latest
 | User has no access | Verify user roles match configured roles |
 | Frequent re-authentication | Increase access token expiration time in OIDC provider |
 | JWT decode error (Auth0) | Ensure audience is set and Implicit grant is disabled |
-| x509: certificate signed by unknown authority | Use `--oidc-ca-file` to trust your OIDC provider's CA certificate |
+| x509: certificate signed by unknown authority | Use `--ca-file` to trust your CA certificate |
 
 **Debug JWT claims:**
 ```bash


### PR DESCRIPTION
Nebraska only trusts system CAs. If your OIDC provider or update server uses a certificate from an internal or non-public CA, Nebraska refuses to connect. The only workaround today is modifying the container's system trust store, which is inconvenient.

This PR adds a `--ca-file` flag that points to a PEM file with one or more CA certificates. These CAs are added to the system trust store — nothing is replaced. The custom trust applies to both the OIDC client and the syncer. When the flag is omitted, behaviour is identical to before.

If the file is missing, unreadable, or contains no valid PEM data, Nebraska fails at startup with a clear error message.

The flag is also exposed in the Helm chart as `config.caFile`, and documented in the OIDC migration guide.