### PR TITLE
fix(README): update issue tracker link for Nebraska

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10926/badge)](https://www.bestpractices.dev/projects/10926)
 
 
-> **Note:** To file an issue for any Flatcar repository, please use the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues).
+> **Note:** To file an issue for Nebraska, [go-omaha](https://github.com/flatcar/go-omaha), or [nebraska-update-agent](https://github.com/flatcar/nebraska-update-agent), please use the [Nebraska issue tracker](https://github.com/flatcar/nebraska/issues).
 </div>
 
 # Nebraska  <img align="right" width=384 src="docs/nebraska-logo.svg">

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,3 +4,4 @@ tools/golangci-lint
 tools/swag
 tools/oapi-codegen
 .env
+/nebraska


### PR DESCRIPTION
This PR cleans up two small issues:

1. Removes the accidentally committed backend/nebraska binary. It was committed in db6593e77 ("feat: Implement multi-step updates with floor packages"). The Makefile builds the binary to bin/nebraska (already gitignored via bin). /nebraska is added to backend/.gitignore as a safeguard against it happening again.
 
2. Fixes the issue tracker link in README.md.
