### PR TITLE
Fix Header.tsx for dark theme

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -225,7 +225,7 @@ export default function Header() {
     (config.header_style === 'dark' ||
       (config.header_style === undefined && config.appBarColor === 'dark')) ? (
     <StyledStyledEngineProvider injectFirst>
-      (<ThemeProvider theme={themes.dark}>{appBar}</ThemeProvider>)
+      <ThemeProvider theme={themes.dark}>{appBar}</ThemeProvider>
     </StyledStyledEngineProvider>
   ) : (
     appBar


### PR DESCRIPTION
Remove excess brackets in header for dark theme

## How to use

1) start Nebraska dev env locally
2) enable dark theme (add `-client-header-style=dark` command-line parameter)
3) make sure you don't see the following excess brackets (before and after the header on the main page):

<img width="240" height="130" alt="image" src="https://github.com/user-attachments/assets/723a2702-1015-4e45-a42a-1edf1f29ce12" />

## Testing done

**Not tested - needs re-check by someone with dev environment configured!**

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
