### PR TITLE
refactor(api): extract domain types to internal/types

### DIFF
--- a/backend/pkg/api/actions.go
+++ b/backend/pkg/api/actions.go
@@ -1,26 +1,12 @@
 package api
 
 import (
-	"time"
-
 	"github.com/doug-martin/goqu/v9"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
-// FlatcarAction represents an Omaha action with some Flatcar specific fields.
-type FlatcarAction struct {
-	ID                    string    `db:"id" json:"id"`
-	Event                 string    `db:"event" json:"event"`
-	ChromeOSVersion       string    `db:"chromeos_version" json:"chromeos_version"`
-	Sha256                string    `db:"sha256" json:"sha256"`
-	NeedsAdmin            bool      `db:"needs_admin" json:"needs_admin"`
-	IsDelta               bool      `db:"is_delta" json:"is_delta"`
-	DisablePayloadBackoff bool      `db:"disable_payload_backoff" json:"disable_payload_backoff"`
-	MetadataSignatureRsa  string    `db:"metadata_signature_rsa" json:"metadata_signature_rsa"`
-	MetadataSize          string    `db:"metadata_size" json:"metadata_size"`
-	Deadline              string    `db:"deadline" json:"deadline"`
-	CreatedTs             time.Time `db:"created_ts" json:"created_ts"`
-	PackageID             string    `db:"package_id" json:"-"`
-}
+type FlatcarAction = types.FlatcarAction
 
 // AddFlatcarAction registers the provided Omaha Flatcar action.
 func (api *API) AddFlatcarAction(action *FlatcarAction) (*FlatcarAction, error) {

--- a/backend/pkg/api/activity.go
+++ b/backend/pkg/api/activity.go
@@ -4,7 +4,8 @@ import (
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
-	"gopkg.in/guregu/null.v4"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
 const (
@@ -23,35 +24,10 @@ const (
 	activityError
 )
 
-// Activity represents a Nebraska activity entry.
-type Activity struct {
-	ID              string      `db:"id" json:"id"`
-	AppID           null.String `db:"application_id" json:"app_id"`
-	GroupID         null.String `db:"group_id" json:"group_id"`
-	CreatedTs       time.Time   `db:"created_ts" json:"created_ts"`
-	Class           int         `db:"class" json:"class"`
-	Severity        int         `db:"severity" json:"severity"`
-	Version         string      `db:"version" json:"version"`
-	ApplicationName string      `db:"application_name" json:"application_name"`
-	GroupName       null.String `db:"group_name" json:"group_name"`
-	ChannelName     null.String `db:"channel_name" json:"channel_name"`
-	InstanceID      null.String `db:"instance_id" json:"instance_id"`
-}
-
-// ActivityQueryParams represents a helper structure used to pass a set of
-// parameters when querying activity entries.
-type ActivityQueryParams struct {
-	AppID      string    `db:"application_id"`
-	GroupID    string    `db:"group_id"`
-	ChannelID  string    `db:"channel_id"`
-	InstanceID string    `db:"instance_id"`
-	Version    string    `db:"version"`
-	Severity   int       `db:"severity"`
-	Start      time.Time `db:"start"`
-	End        time.Time `db:"end"`
-	Page       uint64    `json:"page"`
-	PerPage    uint64    `json:"perpage"`
-}
+type (
+	Activity            = types.Activity
+	ActivityQueryParams = types.ActivityQueryParams
+)
 
 // Gets the activity count using some ActivityQueryParams filters
 // Page and PerPage are ignored.

--- a/backend/pkg/api/api.go
+++ b/backend/pkg/api/api.go
@@ -51,9 +51,6 @@ var (
 	// ErrInvalidSemver indicates that the provided semver version is not valid.
 	ErrInvalidSemver = errors.New("nebraska: invalid semver")
 
-	// ErrInvalidArch indicates that the provided architecture is not valid/supported
-	ErrInvalidArch = errors.New("nebraska: invalid/unsupported arch")
-
 	// ErrArchMismatch indicates that arches of two objects didn't
 	// match (for example, for a package and channel)
 	ErrArchMismatch = errors.New("nebraska: mismatched arches")

--- a/backend/pkg/api/applications.go
+++ b/backend/pkg/api/applications.go
@@ -6,11 +6,12 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/jmoiron/sqlx"
 	"gopkg.in/guregu/null.v4"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
 type appsCache map[string]string
@@ -32,21 +33,7 @@ const (
 	flatcarAppID = "e96281a6-d1af-4bde-9a0a-97b76e56dc57"
 )
 
-// Application represents a Nebraska application instance.
-type Application struct {
-	ID          string      `db:"id" json:"id"`
-	ProductID   null.String `db:"product_id" json:"product_id"`
-	Name        string      `db:"name" json:"name"`
-	Description string      `db:"description" json:"description"`
-	CreatedTs   time.Time   `db:"created_ts" json:"created_ts"`
-	TeamID      string      `db:"team_id" json:"-"`
-	Groups      []*Group    `db:"groups" json:"groups"`
-	Channels    []*Channel  `db:"channels" json:"channels"`
-
-	Instances struct {
-		Count int `db:"count" json:"count"`
-	} `db:"instances" json:"instances,omitempty"`
-}
+type Application = types.Application
 
 // AddApp registers the provided application.
 func (api *API) AddApp(app *Application) (*Application, error) {

--- a/backend/pkg/api/arch.go
+++ b/backend/pkg/api/arch.go
@@ -1,92 +1,18 @@
 package api
 
-import (
-	"fmt"
-)
+import "github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 
-type Arch uint
+type Arch = types.Arch
 
 const (
-	ArchAll Arch = iota
-	ArchAMD64
-	ArchAArch64
-	ArchX86
+	ArchAll     = types.ArchAll
+	ArchAMD64   = types.ArchAMD64
+	ArchAArch64 = types.ArchAArch64
+	ArchX86     = types.ArchX86
 )
 
-var allSupportedArches = map[Arch]struct{}{
-	ArchAll:     {},
-	ArchAMD64:   {},
-	ArchAArch64: {},
-	ArchX86:     {},
-}
+var ErrInvalidArch = types.ErrInvalidArch
 
-func sprintfBogusArch(raw uint) string {
-	return fmt.Sprintf("Arch(%d)", raw)
-}
-
-func emptyBogusArch(_ uint) string {
-	return ""
-}
-
-const (
-	ourArchIdx = iota
-	omahaArchIdx
-	coreosArchIdx
-)
-
-var archStringData = [][3]string{
-	// our string, omaha string, coreos string
-	{"all", "", ""},
-	{"amd64", "x64", "amd64-usr"},
-	{"aarch64", "arm", "arm64-usr"},
-	{"x86", "x86", ""},
-}
-
-func (a Arch) toString(kindIdx int, bogus func(uint) string) string {
-	archIdx := int(a)
-	if archIdx < len(archStringData) {
-		return archStringData[archIdx][kindIdx]
-	}
-	return bogus(uint(a))
-}
-
-func (a Arch) String() string {
-	return a.toString(ourArchIdx, sprintfBogusArch)
-}
-
-func (a Arch) OmahaString() string {
-	return a.toString(omahaArchIdx, emptyBogusArch)
-}
-
-func (a Arch) CoreosString() string {
-	return a.toString(coreosArchIdx, emptyBogusArch)
-}
-
-func (a Arch) IsValid() bool {
-	_, ok := allSupportedArches[a]
-	return ok
-}
-
-func pkgArchFromIdxString(s string, idx int) (Arch, error) {
-	if s == "" {
-		return 0, ErrInvalidArch
-	}
-	for i := 0; i < len(archStringData); i++ {
-		if s == archStringData[i][idx] {
-			return Arch(i), nil
-		}
-	}
-	return ArchAll, ErrInvalidArch
-}
-
-func ArchFromString(s string) (Arch, error) {
-	return pkgArchFromIdxString(s, ourArchIdx)
-}
-
-func ArchFromOmahaString(s string) (Arch, error) {
-	return pkgArchFromIdxString(s, omahaArchIdx)
-}
-
-func ArchFromCoreosString(s string) (Arch, error) {
-	return pkgArchFromIdxString(s, coreosArchIdx)
-}
+func ArchFromString(s string) (Arch, error)       { return types.ArchFromString(s) }
+func ArchFromOmahaString(s string) (Arch, error)  { return types.ArchFromOmahaString(s) }
+func ArchFromCoreosString(s string) (Arch, error) { return types.ArchFromCoreosString(s) }

--- a/backend/pkg/api/channels.go
+++ b/backend/pkg/api/channels.go
@@ -3,10 +3,10 @@ package api
 import (
 	"database/sql"
 	"errors"
-	"time"
 
 	"github.com/doug-martin/goqu/v9"
-	"gopkg.in/guregu/null.v4"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
 var (
@@ -19,17 +19,7 @@ var (
 	ErrBlacklistedChannel = errors.New("nebraska: blacklisted channel")
 )
 
-// Channel represents a Nebraska application's channel.
-type Channel struct {
-	ID            string      `db:"id" json:"id"`
-	Name          string      `db:"name" json:"name"`
-	Color         string      `db:"color" json:"color"`
-	CreatedTs     time.Time   `db:"created_ts" json:"created_ts"`
-	ApplicationID string      `db:"application_id" json:"application_id"`
-	PackageID     null.String `db:"package_id" json:"package_id"`
-	Package       *Package    `db:"package" json:"package"`
-	Arch          Arch        `db:"arch" json:"arch"`
-}
+type Channel = types.Channel
 
 // AddChannel registers the provided channel.
 func (api *API) AddChannel(channel *Channel) (*Channel, error) {

--- a/backend/pkg/api/groups.go
+++ b/backend/pkg/api/groups.go
@@ -11,7 +11,8 @@ import (
 	"github.com/doug-martin/goqu/v9"
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/guregu/null.v4"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
 type (
@@ -76,81 +77,16 @@ type groupVersionCountCache struct {
 	storedAt time.Time
 }
 
-type GroupDescriptor struct {
-	AppID string
-	Track string
-	Arch  Arch
-}
-
-// Group represents a Nebraska application's group.
-type Group struct {
-	ID                        string      `db:"id" json:"id"`
-	Name                      string      `db:"name" json:"name"`
-	Description               string      `db:"description" json:"description"`
-	CreatedTs                 time.Time   `db:"created_ts" json:"created_ts"`
-	RolloutInProgress         bool        `db:"rollout_in_progress" json:"rollout_in_progress"`
-	ApplicationID             string      `db:"application_id" json:"application_id"`
-	ChannelID                 null.String `db:"channel_id" json:"channel_id"`
-	PolicyUpdatesEnabled      bool        `db:"policy_updates_enabled" json:"policy_updates_enabled"`
-	PolicySafeMode            bool        `db:"policy_safe_mode" json:"policy_safe_mode"`
-	PolicyOfficeHours         bool        `db:"policy_office_hours" json:"policy_office_hours"`
-	PolicyTimezone            null.String `db:"policy_timezone" json:"policy_timezone"`
-	PolicyPeriodInterval      string      `db:"policy_period_interval" json:"policy_period_interval"`
-	PolicyMaxUpdatesPerPeriod int         `db:"policy_max_updates_per_period" json:"policy_max_updates_per_period"`
-	PolicyUpdateTimeout       string      `db:"policy_update_timeout" json:"policy_update_timeout"`
-	Channel                   *Channel    `db:"channel" json:"channel,omitempty"`
-	Track                     string      `db:"track" json:"track"`
-}
-
-// VersionBreakdownEntry represents the distribution of the versions currently
-// installed in the instances belonging to a given group.
-type VersionBreakdownEntry struct {
-	Version    string  `db:"version" json:"version"`
-	Instances  int     `db:"instances" json:"instances"`
-	Percentage float64 `db:"percentage" json:"percentage"`
-}
-
-type VersionCountTimelineEntry struct {
-	Time    time.Time `db:"ts" json:"time"`
-	Version string    `db:"version" json:"version"`
-	Total   uint64    `db:"total" json:"total"`
-}
-
-type StatusVersionCountTimelineEntry struct {
-	Time    time.Time `db:"ts" json:"time"`
-	Status  int       `db:"status" json:"status"`
-	Version string    `db:"version" json:"version"`
-	Total   uint64    `db:"total" json:"total"`
-}
-
-type VersionCountMap = map[string]uint64
-
-// InstancesStatusStats represents a set of statistics about the status of the
-// instances that belong to a given group.
-type InstancesStatusStats struct {
-	Total         int      `db:"total" json:"total"`
-	Undefined     null.Int `db:"undefined" json:"undefined"`
-	UpdateGranted null.Int `db:"update_granted" json:"update_granted"`
-	Error         null.Int `db:"error" json:"error"`
-	Complete      null.Int `db:"complete" json:"complete"`
-	Installed     null.Int `db:"installed" json:"installed"`
-	Downloaded    null.Int `db:"downloaded" json:"downloaded"`
-	Downloading   null.Int `db:"downloading" json:"downloading"`
-	OnHold        null.Int `db:"onhold" json:"onhold"`
-}
-
-// UpdatesStats represents a set of statistics about the status of the updates
-// that may be taking place in the instaces belonging to a given group.
-type UpdatesStats struct {
-	TotalInstances                   int `db:"total_instances"`
-	UpdatesToCurrentVersionGranted   int `db:"updates_to_current_version_granted"`
-	UpdatesToCurrentVersionAttempted int `db:"updates_to_current_version_attempted"`
-	UpdatesToCurrentVersionSucceeded int `db:"updates_to_current_version_succeeded"`
-	UpdatesToCurrentVersionFailed    int `db:"updates_to_current_version_failed"`
-	UpdatesGrantedInLastPeriod       int `db:"updates_granted_in_last_period"`
-	UpdatesInProgress                int `db:"updates_in_progress"`
-	UpdatesTimedOut                  int `db:"updates_timed_out"`
-}
+type (
+	GroupDescriptor                 = types.GroupDescriptor
+	Group                           = types.Group
+	VersionBreakdownEntry           = types.VersionBreakdownEntry
+	VersionCountTimelineEntry       = types.VersionCountTimelineEntry
+	StatusVersionCountTimelineEntry = types.StatusVersionCountTimelineEntry
+	VersionCountMap                 = types.VersionCountMap
+	InstancesStatusStats            = types.InstancesStatusStats
+	UpdatesStats                    = types.UpdatesStats
+)
 
 // AddGroup registers the provided group.
 func (api *API) AddGroup(group *Group) (*Group, error) {

--- a/backend/pkg/api/instances.go
+++ b/backend/pkg/api/instances.go
@@ -11,40 +11,19 @@ import (
 	"github.com/doug-martin/goqu/v9/exp"
 	"github.com/google/uuid"
 	"gopkg.in/guregu/null.v4"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
 const (
-	// InstanceStatusUndefined indicates that the instance hasn't sent yet an
-	// event to Nebraska so it doesn't know in which state it is.
-	InstanceStatusUndefined int = 1 + iota
-
-	// InstanceStatusUpdateGranted indicates that the instance has been granted
-	// an update (it should be reporting soon through events how is it going).
-	InstanceStatusUpdateGranted
-
-	// InstanceStatusError indicates that the instance reported an error while
-	// processing the update.
-	InstanceStatusError
-
-	// InstanceStatusComplete indicates that the instance completed the update
-	// process successfully.
-	InstanceStatusComplete
-
-	// InstanceStatusInstalled indicates that the instance has installed the
-	// downloaded packages, but it hasn't applied it or restarted yet.
-	InstanceStatusInstalled
-
-	// InstanceStatusDownloaded indicates that the instance downloaded
-	// successfully the update package.
-	InstanceStatusDownloaded
-
-	// InstanceStatusDownloading indicates that the instance started
-	// downloading the update package.
-	InstanceStatusDownloading
-
-	// InstanceStatusOnHold indicates that the instance hasn't been granted an
-	// update because one of the rollout policy limits has been reached.
-	InstanceStatusOnHold
+	InstanceStatusUndefined     = types.InstanceStatusUndefined
+	InstanceStatusUpdateGranted = types.InstanceStatusUpdateGranted
+	InstanceStatusError         = types.InstanceStatusError
+	InstanceStatusComplete      = types.InstanceStatusComplete
+	InstanceStatusInstalled     = types.InstanceStatusInstalled
+	InstanceStatusDownloaded    = types.InstanceStatusDownloaded
+	InstanceStatusDownloading   = types.InstanceStatusDownloading
+	InstanceStatusOnHold        = types.InstanceStatusOnHold
 )
 
 const (
@@ -52,77 +31,18 @@ const (
 	defaultStatsInterval time.Duration    = 24 * time.Hour
 )
 
-// Instance represents an instance running one or more applications for which
-// Nebraska can provide updates.
-type Instance struct {
-	ID           string              `db:"id" json:"id"`
-	IP           string              `db:"ip" json:"ip"`
-	OEM          string              `db:"oem" json:"oem,omitempty"`
-	AlephVersion string              `db:"aleph_version" json:"aleph_version,omitempty"`
-	CreatedTs    time.Time           `db:"created_ts" json:"created_ts"`
-	Application  InstanceApplication `db:"application" json:"application,omitempty"`
-	Alias        string              `db:"alias" json:"alias,omitempty"`
-}
-type InstancesWithTotal struct {
-	TotalInstances uint64      `json:"total"`
-	Instances      []*Instance `json:"instances"`
-}
-
-// InstanceApplication represents some details about an application running on
-// a given instance: current version of the app, last time the instance checked
-// for updates for this app, etc.
-type InstanceApplication struct {
-	InstanceID          string      `db:"instance_id" json:"instance_id,omitempty"`
-	ApplicationID       string      `db:"application_id" json:"application_id"`
-	GroupID             null.String `db:"group_id" json:"group_id"`
-	Version             string      `db:"version" json:"version"`
-	CreatedTs           time.Time   `db:"created_ts" json:"created_ts"`
-	Status              null.Int    `db:"status" json:"status"`
-	LastCheckForUpdates time.Time   `db:"last_check_for_updates" json:"last_check_for_updates"`
-	LastUpdateGrantedTs null.Time   `db:"last_update_granted_ts" json:"last_update_granted_ts"`
-	LastUpdateVersion   null.String `db:"last_update_version" json:"last_update_version"`
-	UpdateInProgress    bool        `db:"update_in_progress" json:"update_in_progress"`
-}
+type (
+	Instance                   = types.Instance
+	InstancesWithTotal         = types.InstancesWithTotal
+	InstanceApplication        = types.InstanceApplication
+	InstanceStatusHistoryEntry = types.InstanceStatusHistoryEntry
+	InstancesQueryParams       = types.InstancesQueryParams
+	InstanceStats              = types.InstanceStats
+)
 
 // NewInstanceApplication creates an InstanceApplication with the fields used for registration.
 func NewInstanceApplication(appID, groupID, version string) InstanceApplication {
 	return InstanceApplication{ApplicationID: appID, GroupID: null.StringFrom(groupID), Version: version}
-}
-
-// InstanceStatusHistoryEntry represents an entry in the instance status
-// history.
-type InstanceStatusHistoryEntry struct {
-	ID            int         `db:"id" json:"-"`
-	Status        int         `db:"status" json:"status"`
-	Version       string      `db:"version" json:"version"`
-	CreatedTs     time.Time   `db:"created_ts" json:"created_ts"`
-	InstanceID    string      `db:"instance_id" json:"-"`
-	ApplicationID string      `db:"application_id" json:"-"`
-	GroupID       string      `db:"group_id" json:"-"`
-	ErrorCode     null.String `db:"error_code" json:"error_code"`
-}
-
-// InstancesQueryParams represents a helper structure used to pass a set of
-// parameters when querying instances.
-type InstancesQueryParams struct {
-	ApplicationID string `json:"application_id"`
-	GroupID       string `json:"group_id"`
-	Status        int    `json:"status"`
-	Version       string `json:"version"`
-	Page          uint64 `json:"page"`
-	PerPage       uint64 `json:"perpage"`
-	SortFilter    string `json:"sort_filter"`
-	SortOrder     string `json:"sort_order"`
-	SearchFilter  string `json:"search_filter"`
-	SearchValue   string `json:"search_value"`
-}
-
-type InstanceStats struct {
-	Timestamp   time.Time `db:"timestamp" json:"timestamp"`
-	ChannelName string    `db:"channel_name" json:"channel_name"`
-	Arch        string    `db:"arch" json:"arch"`
-	Version     string    `db:"version" json:"version"`
-	Instances   int       `db:"instances" json:"instances"`
 }
 
 type instanceFilterItem int

--- a/backend/pkg/api/internal/types/action.go
+++ b/backend/pkg/api/internal/types/action.go
@@ -1,0 +1,19 @@
+package types
+
+import "time"
+
+// FlatcarAction represents an Omaha action with some Flatcar specific fields.
+type FlatcarAction struct {
+	ID                    string    `db:"id" json:"id"`
+	Event                 string    `db:"event" json:"event"`
+	ChromeOSVersion       string    `db:"chromeos_version" json:"chromeos_version"`
+	Sha256                string    `db:"sha256" json:"sha256"`
+	NeedsAdmin            bool      `db:"needs_admin" json:"needs_admin"`
+	IsDelta               bool      `db:"is_delta" json:"is_delta"`
+	DisablePayloadBackoff bool      `db:"disable_payload_backoff" json:"disable_payload_backoff"`
+	MetadataSignatureRsa  string    `db:"metadata_signature_rsa" json:"metadata_signature_rsa"`
+	MetadataSize          string    `db:"metadata_size" json:"metadata_size"`
+	Deadline              string    `db:"deadline" json:"deadline"`
+	CreatedTs             time.Time `db:"created_ts" json:"created_ts"`
+	PackageID             string    `db:"package_id" json:"-"`
+}

--- a/backend/pkg/api/internal/types/activity.go
+++ b/backend/pkg/api/internal/types/activity.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"time"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+// Activity represents a Nebraska activity entry.
+type Activity struct {
+	ID              string      `db:"id" json:"id"`
+	AppID           null.String `db:"application_id" json:"app_id"`
+	GroupID         null.String `db:"group_id" json:"group_id"`
+	CreatedTs       time.Time   `db:"created_ts" json:"created_ts"`
+	Class           int         `db:"class" json:"class"`
+	Severity        int         `db:"severity" json:"severity"`
+	Version         string      `db:"version" json:"version"`
+	ApplicationName string      `db:"application_name" json:"application_name"`
+	GroupName       null.String `db:"group_name" json:"group_name"`
+	ChannelName     null.String `db:"channel_name" json:"channel_name"`
+	InstanceID      null.String `db:"instance_id" json:"instance_id"`
+}
+
+// ActivityQueryParams represents a helper structure used to pass a set of
+// parameters when querying activity entries.
+type ActivityQueryParams struct {
+	AppID      string    `db:"application_id"`
+	GroupID    string    `db:"group_id"`
+	ChannelID  string    `db:"channel_id"`
+	InstanceID string    `db:"instance_id"`
+	Version    string    `db:"version"`
+	Severity   int       `db:"severity"`
+	Start      time.Time `db:"start"`
+	End        time.Time `db:"end"`
+	Page       uint64    `json:"page"`
+	PerPage    uint64    `json:"perpage"`
+}

--- a/backend/pkg/api/internal/types/application.go
+++ b/backend/pkg/api/internal/types/application.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	"time"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+// Application represents a Nebraska application instance.
+type Application struct {
+	ID          string      `db:"id" json:"id"`
+	ProductID   null.String `db:"product_id" json:"product_id"`
+	Name        string      `db:"name" json:"name"`
+	Description string      `db:"description" json:"description"`
+	CreatedTs   time.Time   `db:"created_ts" json:"created_ts"`
+	TeamID      string      `db:"team_id" json:"-"`
+	Groups      []*Group    `db:"groups" json:"groups"`
+	Channels    []*Channel  `db:"channels" json:"channels"`
+
+	Instances struct {
+		Count int `db:"count" json:"count"`
+	} `db:"instances" json:"instances,omitempty"`
+}

--- a/backend/pkg/api/internal/types/arch.go
+++ b/backend/pkg/api/internal/types/arch.go
@@ -1,0 +1,96 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidArch indicates that the provided architecture is not valid/supported
+var ErrInvalidArch = errors.New("nebraska: invalid/unsupported arch")
+
+type Arch uint
+
+const (
+	ArchAll Arch = iota
+	ArchAMD64
+	ArchAArch64
+	ArchX86
+)
+
+var allSupportedArches = map[Arch]struct{}{
+	ArchAll:     {},
+	ArchAMD64:   {},
+	ArchAArch64: {},
+	ArchX86:     {},
+}
+
+func sprintfBogusArch(raw uint) string {
+	return fmt.Sprintf("Arch(%d)", raw)
+}
+
+func emptyBogusArch(_ uint) string {
+	return ""
+}
+
+const (
+	ourArchIdx = iota
+	omahaArchIdx
+	coreosArchIdx
+)
+
+var archStringData = [][3]string{
+	// our string, omaha string, coreos string
+	{"all", "", ""},
+	{"amd64", "x64", "amd64-usr"},
+	{"aarch64", "arm", "arm64-usr"},
+	{"x86", "x86", ""},
+}
+
+func (a Arch) toString(kindIdx int, bogus func(uint) string) string {
+	archIdx := int(a)
+	if archIdx < len(archStringData) {
+		return archStringData[archIdx][kindIdx]
+	}
+	return bogus(uint(a))
+}
+
+func (a Arch) String() string {
+	return a.toString(ourArchIdx, sprintfBogusArch)
+}
+
+func (a Arch) OmahaString() string {
+	return a.toString(omahaArchIdx, emptyBogusArch)
+}
+
+func (a Arch) CoreosString() string {
+	return a.toString(coreosArchIdx, emptyBogusArch)
+}
+
+func (a Arch) IsValid() bool {
+	_, ok := allSupportedArches[a]
+	return ok
+}
+
+func pkgArchFromIdxString(s string, idx int) (Arch, error) {
+	if s == "" {
+		return 0, ErrInvalidArch
+	}
+	for i := 0; i < len(archStringData); i++ {
+		if s == archStringData[i][idx] {
+			return Arch(i), nil
+		}
+	}
+	return ArchAll, ErrInvalidArch
+}
+
+func ArchFromString(s string) (Arch, error) {
+	return pkgArchFromIdxString(s, ourArchIdx)
+}
+
+func ArchFromOmahaString(s string) (Arch, error) {
+	return pkgArchFromIdxString(s, omahaArchIdx)
+}
+
+func ArchFromCoreosString(s string) (Arch, error) {
+	return pkgArchFromIdxString(s, coreosArchIdx)
+}

--- a/backend/pkg/api/internal/types/channel.go
+++ b/backend/pkg/api/internal/types/channel.go
@@ -1,0 +1,19 @@
+package types
+
+import (
+	"time"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+// Channel represents a Nebraska application's channel.
+type Channel struct {
+	ID            string      `db:"id" json:"id"`
+	Name          string      `db:"name" json:"name"`
+	Color         string      `db:"color" json:"color"`
+	CreatedTs     time.Time   `db:"created_ts" json:"created_ts"`
+	ApplicationID string      `db:"application_id" json:"application_id"`
+	PackageID     null.String `db:"package_id" json:"package_id"`
+	Package       *Package    `db:"package" json:"package"`
+	Arch          Arch        `db:"arch" json:"arch"`
+}

--- a/backend/pkg/api/internal/types/channel_floor.go
+++ b/backend/pkg/api/internal/types/channel_floor.go
@@ -1,0 +1,9 @@
+package types
+
+import "gopkg.in/guregu/null.v4"
+
+// ChannelFloorInfo contains a channel and its floor reason for a specific package
+type ChannelFloorInfo struct {
+	Channel     *Channel    `json:"channel"`
+	FloorReason null.String `json:"floor_reason"`
+}

--- a/backend/pkg/api/internal/types/group.go
+++ b/backend/pkg/api/internal/types/group.go
@@ -1,0 +1,83 @@
+package types
+
+import (
+	"time"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+type GroupDescriptor struct {
+	AppID string
+	Track string
+	Arch  Arch
+}
+
+// Group represents a Nebraska application's group.
+type Group struct {
+	ID                        string      `db:"id" json:"id"`
+	Name                      string      `db:"name" json:"name"`
+	Description               string      `db:"description" json:"description"`
+	CreatedTs                 time.Time   `db:"created_ts" json:"created_ts"`
+	RolloutInProgress         bool        `db:"rollout_in_progress" json:"rollout_in_progress"`
+	ApplicationID             string      `db:"application_id" json:"application_id"`
+	ChannelID                 null.String `db:"channel_id" json:"channel_id"`
+	PolicyUpdatesEnabled      bool        `db:"policy_updates_enabled" json:"policy_updates_enabled"`
+	PolicySafeMode            bool        `db:"policy_safe_mode" json:"policy_safe_mode"`
+	PolicyOfficeHours         bool        `db:"policy_office_hours" json:"policy_office_hours"`
+	PolicyTimezone            null.String `db:"policy_timezone" json:"policy_timezone"`
+	PolicyPeriodInterval      string      `db:"policy_period_interval" json:"policy_period_interval"`
+	PolicyMaxUpdatesPerPeriod int         `db:"policy_max_updates_per_period" json:"policy_max_updates_per_period"`
+	PolicyUpdateTimeout       string      `db:"policy_update_timeout" json:"policy_update_timeout"`
+	Channel                   *Channel    `db:"channel" json:"channel,omitempty"`
+	Track                     string      `db:"track" json:"track"`
+}
+
+// VersionBreakdownEntry represents the distribution of the versions currently
+// installed in the instances belonging to a given group.
+type VersionBreakdownEntry struct {
+	Version    string  `db:"version" json:"version"`
+	Instances  int     `db:"instances" json:"instances"`
+	Percentage float64 `db:"percentage" json:"percentage"`
+}
+
+type VersionCountTimelineEntry struct {
+	Time    time.Time `db:"ts" json:"time"`
+	Version string    `db:"version" json:"version"`
+	Total   uint64    `db:"total" json:"total"`
+}
+
+type StatusVersionCountTimelineEntry struct {
+	Time    time.Time `db:"ts" json:"time"`
+	Status  int       `db:"status" json:"status"`
+	Version string    `db:"version" json:"version"`
+	Total   uint64    `db:"total" json:"total"`
+}
+
+type VersionCountMap = map[string]uint64
+
+// InstancesStatusStats represents a set of statistics about the status of the
+// instances that belong to a given group.
+type InstancesStatusStats struct {
+	Total         int      `db:"total" json:"total"`
+	Undefined     null.Int `db:"undefined" json:"undefined"`
+	UpdateGranted null.Int `db:"update_granted" json:"update_granted"`
+	Error         null.Int `db:"error" json:"error"`
+	Complete      null.Int `db:"complete" json:"complete"`
+	Installed     null.Int `db:"installed" json:"installed"`
+	Downloaded    null.Int `db:"downloaded" json:"downloaded"`
+	Downloading   null.Int `db:"downloading" json:"downloading"`
+	OnHold        null.Int `db:"onhold" json:"onhold"`
+}
+
+// UpdatesStats represents a set of statistics about the status of the updates
+// that may be taking place in the instances belonging to a given group.
+type UpdatesStats struct {
+	TotalInstances                   int `db:"total_instances"`
+	UpdatesToCurrentVersionGranted   int `db:"updates_to_current_version_granted"`
+	UpdatesToCurrentVersionAttempted int `db:"updates_to_current_version_attempted"`
+	UpdatesToCurrentVersionSucceeded int `db:"updates_to_current_version_succeeded"`
+	UpdatesToCurrentVersionFailed    int `db:"updates_to_current_version_failed"`
+	UpdatesGrantedInLastPeriod       int `db:"updates_granted_in_last_period"`
+	UpdatesInProgress                int `db:"updates_in_progress"`
+	UpdatesTimedOut                  int `db:"updates_timed_out"`
+}

--- a/backend/pkg/api/internal/types/instance.go
+++ b/backend/pkg/api/internal/types/instance.go
@@ -1,0 +1,110 @@
+package types
+
+import (
+	"time"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+const (
+	// InstanceStatusUndefined indicates that the instance hasn't sent yet an
+	// event to Nebraska so it doesn't know in which state it is.
+	InstanceStatusUndefined int = 1 + iota
+
+	// InstanceStatusUpdateGranted indicates that the instance has been granted
+	// an update (it should be reporting soon through events how is it going).
+	InstanceStatusUpdateGranted
+
+	// InstanceStatusError indicates that the instance reported an error while
+	// processing the update.
+	InstanceStatusError
+
+	// InstanceStatusComplete indicates that the instance completed the update
+	// process successfully.
+	InstanceStatusComplete
+
+	// InstanceStatusInstalled indicates that the instance has installed the
+	// downloaded packages, but it hasn't applied it or restarted yet.
+	InstanceStatusInstalled
+
+	// InstanceStatusDownloaded indicates that the instance downloaded
+	// successfully the update package.
+	InstanceStatusDownloaded
+
+	// InstanceStatusDownloading indicates that the instance started
+	// downloading the update package.
+	InstanceStatusDownloading
+
+	// InstanceStatusOnHold indicates that the instance hasn't been granted an
+	// update because one of the rollout policy limits has been reached.
+	InstanceStatusOnHold
+)
+
+// Instance represents an instance running one or more applications for which
+// Nebraska can provide updates.
+type Instance struct {
+	ID           string              `db:"id" json:"id"`
+	IP           string              `db:"ip" json:"ip"`
+	OEM          string              `db:"oem" json:"oem,omitempty"`
+	AlephVersion string              `db:"aleph_version" json:"aleph_version,omitempty"`
+	CreatedTs    time.Time           `db:"created_ts" json:"created_ts"`
+	Application  InstanceApplication `db:"application" json:"application,omitempty"`
+	Alias        string              `db:"alias" json:"alias,omitempty"`
+}
+
+type InstancesWithTotal struct {
+	TotalInstances uint64      `json:"total"`
+	Instances      []*Instance `json:"instances"`
+}
+
+// InstanceApplication represents some details about an application running on
+// a given instance: current version of the app, last time the instance checked
+// for updates for this app, etc.
+type InstanceApplication struct {
+	InstanceID          string      `db:"instance_id" json:"instance_id,omitempty"`
+	ApplicationID       string      `db:"application_id" json:"application_id"`
+	GroupID             null.String `db:"group_id" json:"group_id"`
+	Version             string      `db:"version" json:"version"`
+	CreatedTs           time.Time   `db:"created_ts" json:"created_ts"`
+	Status              null.Int    `db:"status" json:"status"`
+	LastCheckForUpdates time.Time   `db:"last_check_for_updates" json:"last_check_for_updates"`
+	LastUpdateGrantedTs null.Time   `db:"last_update_granted_ts" json:"last_update_granted_ts"`
+	LastUpdateVersion   null.String `db:"last_update_version" json:"last_update_version"`
+	UpdateInProgress    bool        `db:"update_in_progress" json:"update_in_progress"`
+}
+
+// InstanceStatusHistoryEntry represents an entry in the instance status
+// history.
+type InstanceStatusHistoryEntry struct {
+	ID            int         `db:"id" json:"-"`
+	Status        int         `db:"status" json:"status"`
+	Version       string      `db:"version" json:"version"`
+	CreatedTs     time.Time   `db:"created_ts" json:"created_ts"`
+	InstanceID    string      `db:"instance_id" json:"-"`
+	ApplicationID string      `db:"application_id" json:"-"`
+	GroupID       string      `db:"group_id" json:"-"`
+	ErrorCode     null.String `db:"error_code" json:"error_code"`
+}
+
+// InstancesQueryParams represents a helper structure used to pass a set of
+// parameters when querying instances.
+type InstancesQueryParams struct {
+	ApplicationID string `json:"application_id"`
+	GroupID       string `json:"group_id"`
+	Status        int    `json:"status"`
+	Version       string `json:"version"`
+	Page          uint64 `json:"page"`
+	PerPage       uint64 `json:"perpage"`
+	SortFilter    string `json:"sort_filter"`
+	SortOrder     string `json:"sort_order"`
+	SearchFilter  string `json:"search_filter"`
+	SearchValue   string `json:"search_value"`
+}
+
+type InstanceStats struct {
+	Timestamp   time.Time `db:"timestamp" json:"timestamp"`
+	ChannelName string    `db:"channel_name" json:"channel_name"`
+	Arch        string    `db:"arch" json:"arch"`
+	Version     string    `db:"version" json:"version"`
+	Instances   int       `db:"instances" json:"instances"`
+}

--- a/backend/pkg/api/internal/types/metrics.go
+++ b/backend/pkg/api/internal/types/metrics.go
@@ -1,0 +1,13 @@
+package types
+
+type AppInstancesPerChannelMetric struct {
+	ApplicationName string `db:"app_name" json:"app_name"`
+	Version         string `db:"version" json:"version"`
+	ChannelName     string `db:"channel_name" json:"channel_name"`
+	InstancesCount  int    `db:"instances_count" json:"instances_count"`
+}
+
+type FailedUpdatesMetric struct {
+	ApplicationName string `db:"app_name" json:"app_name"`
+	FailureCount    int    `db:"fail_count" json:"fail_count"`
+}

--- a/backend/pkg/api/internal/types/package.go
+++ b/backend/pkg/api/internal/types/package.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"time"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+type File struct {
+	ID        int64       `db:"id" json:"id"`
+	PackageID string      `db:"package_id" json:"package_id"`
+	Name      null.String `db:"name" json:"name"`
+	Size      null.String `db:"size" json:"size"`
+	Hash      null.String `db:"hash" json:"hash"`
+	Hash256   null.String `db:"hash256" json:"hash256"`
+	CreatedTs time.Time   `db:"created_ts" json:"created_ts"`
+}
+
+func (f File) Equals(otherFile File) bool {
+	return f.Name.String == otherFile.Name.String && f.Size.String == otherFile.Size.String && f.Hash.String == otherFile.Hash.String && f.Hash256.String == otherFile.Hash256.String
+}
+
+// Package represents a Nebraska application's package.
+type Package struct {
+	ID                string         `db:"id" json:"id"`
+	Type              int            `db:"type" json:"type"`
+	Version           string         `db:"version" json:"version"`
+	URL               string         `db:"url" json:"url"`
+	Filename          null.String    `db:"filename" json:"filename"`
+	Description       null.String    `db:"description" json:"description"`
+	Size              null.String    `db:"size" json:"size"`
+	Hash              null.String    `db:"hash" json:"hash"`
+	CreatedTs         time.Time      `db:"created_ts" json:"created_ts"`
+	ChannelsBlacklist StringArray    `db:"channels_blacklist" json:"channels_blacklist"`
+	ApplicationID     string         `db:"application_id" json:"application_id"`
+	FlatcarAction     *FlatcarAction `db:"flatcar_action" json:"flatcar_action"`
+	Arch              Arch           `db:"arch" json:"arch"`
+	ExtraFiles        []File         `db:"extra_files" json:"extra_files"`
+
+	// Floor metadata (populated when querying floor packages)
+	IsFloor     bool        `db:"is_floor" json:"is_floor,omitempty"`
+	FloorReason null.String `db:"floor_reason" json:"floor_reason"`
+}
+
+// ChannelPackageFloor represents a floor package for a specific channel
+type ChannelPackageFloor struct {
+	ChannelID   string      `db:"channel_id" json:"channel_id"`
+	PackageID   string      `db:"package_id" json:"package_id"`
+	FloorReason null.String `db:"floor_reason" json:"floor_reason"`
+	CreatedTs   time.Time   `db:"created_ts" json:"created_ts"`
+}

--- a/backend/pkg/api/internal/types/string_array.go
+++ b/backend/pkg/api/internal/types/string_array.go
@@ -1,6 +1,6 @@
 // This file was taken from the pq project and is licensed under the terms of the MIT license: https://github.com/lib/pq
 // Copyright (c) 2011-2013, 'pq' Contributors Portions Copyright (C) 2011 Blake Mizerany
-package api
+package types
 
 import (
 	"bytes"

--- a/backend/pkg/api/internal/types/team.go
+++ b/backend/pkg/api/internal/types/team.go
@@ -1,0 +1,10 @@
+package types
+
+import "time"
+
+// Team represents a Nebraska team.
+type Team struct {
+	ID        string    `db:"id"`
+	Name      string    `db:"name"`
+	CreatedTs time.Time `db:"created_ts"`
+}

--- a/backend/pkg/api/internal/types/user.go
+++ b/backend/pkg/api/internal/types/user.go
@@ -1,0 +1,12 @@
+package types
+
+import "time"
+
+// User represents a Nebraska user.
+type User struct {
+	ID        string    `db:"id" json:"id"`             // UUID v4 unique, created automatically
+	Username  string    `db:"username" json:"username"` // unique username
+	Secret    string    `db:"secret" json:"secret"`     // md5 hash from (username:realm:password)
+	CreatedTs time.Time `db:"created_ts" json:"-"`      // Created automatically
+	TeamID    string    `db:"team_id" json:"team_id"`   // User can be in single team
+}

--- a/backend/pkg/api/metrics.go
+++ b/backend/pkg/api/metrics.go
@@ -3,6 +3,8 @@ package api
 import (
 	"database/sql"
 	"fmt"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
 var (
@@ -23,12 +25,10 @@ ORDER BY app_name
 `, ignoreFakeInstanceCondition("e.instance_id"))
 )
 
-type AppInstancesPerChannelMetric struct {
-	ApplicationName string `db:"app_name" json:"app_name"`
-	Version         string `db:"version" json:"version"`
-	ChannelName     string `db:"channel_name" json:"channel_name"`
-	InstancesCount  int    `db:"instances_count" json:"instances_count"`
-}
+type (
+	AppInstancesPerChannelMetric = types.AppInstancesPerChannelMetric
+	FailedUpdatesMetric          = types.FailedUpdatesMetric
+)
 
 func (api *API) GetAppInstancesPerChannelMetrics() ([]AppInstancesPerChannelMetric, error) {
 	var metrics []AppInstancesPerChannelMetric
@@ -49,11 +49,6 @@ func (api *API) GetAppInstancesPerChannelMetrics() ([]AppInstancesPerChannelMetr
 		return nil, err
 	}
 	return metrics, nil
-}
-
-type FailedUpdatesMetric struct {
-	ApplicationName string `db:"app_name" json:"app_name"`
-	FailureCount    int    `db:"fail_count" json:"fail_count"`
 }
 
 func (api *API) GetFailedUpdatesMetrics() ([]FailedUpdatesMetric, error) {

--- a/backend/pkg/api/packages.go
+++ b/backend/pkg/api/packages.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"gopkg.in/guregu/null.v4"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
 const (
@@ -27,6 +28,13 @@ const (
 	PkgTypeOther
 )
 
+type (
+	File                = types.File
+	Package             = types.Package
+	ChannelPackageFloor = types.ChannelPackageFloor
+	StringArray         = types.StringArray
+)
+
 var (
 	// ErrBlacklistingChannel error indicates that the channel the package is
 	// trying to blacklist is already pointing to the package.
@@ -40,50 +48,6 @@ var (
 	// because it is marked as a floor version for the channel.
 	ErrBlacklistingFloor = errors.New("nebraska: cannot blacklist package marked as floor version for this channel")
 )
-
-type File struct {
-	ID        int64       `db:"id" json:"id"`
-	PackageID string      `db:"package_id" json:"package_id"`
-	Name      null.String `db:"name" json:"name"`
-	Size      null.String `db:"size" json:"size"`
-	Hash      null.String `db:"hash" json:"hash"`
-	Hash256   null.String `db:"hash256" json:"hash256"`
-	CreatedTs time.Time   `db:"created_ts" json:"created_ts"`
-}
-
-func (f File) Equals(otherFile File) bool {
-	return f.Name.String == otherFile.Name.String && f.Size.String == otherFile.Size.String && f.Hash.String == otherFile.Hash.String && f.Hash256.String == otherFile.Hash256.String
-}
-
-// Package represents a Nebraska application's package.
-type Package struct {
-	ID                string         `db:"id" json:"id"`
-	Type              int            `db:"type" json:"type"`
-	Version           string         `db:"version" json:"version"`
-	URL               string         `db:"url" json:"url"`
-	Filename          null.String    `db:"filename" json:"filename"`
-	Description       null.String    `db:"description" json:"description"`
-	Size              null.String    `db:"size" json:"size"`
-	Hash              null.String    `db:"hash" json:"hash"`
-	CreatedTs         time.Time      `db:"created_ts" json:"created_ts"`
-	ChannelsBlacklist StringArray    `db:"channels_blacklist" json:"channels_blacklist"`
-	ApplicationID     string         `db:"application_id" json:"application_id"`
-	FlatcarAction     *FlatcarAction `db:"flatcar_action" json:"flatcar_action"`
-	Arch              Arch           `db:"arch" json:"arch"`
-	ExtraFiles        []File         `db:"extra_files" json:"extra_files"`
-
-	// Floor metadata (populated when querying floor packages)
-	IsFloor     bool        `db:"is_floor" json:"is_floor,omitempty"`
-	FloorReason null.String `db:"floor_reason" json:"floor_reason"`
-}
-
-// ChannelPackageFloor represents a floor package for a specific channel
-type ChannelPackageFloor struct {
-	ChannelID   string      `db:"channel_id" json:"channel_id"`
-	PackageID   string      `db:"package_id" json:"package_id"`
-	FloorReason null.String `db:"floor_reason" json:"floor_reason"`
-	CreatedTs   time.Time   `db:"created_ts" json:"created_ts"`
-}
 
 // checkMatchingArch returns an error if the arch does not match the channels
 func (api *API) checkMatchingArch(channelIDs StringArray, arch Arch) error {

--- a/backend/pkg/api/packages_floors.go
+++ b/backend/pkg/api/packages_floors.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/doug-martin/goqu/v9"
 	"gopkg.in/guregu/null.v4"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
 var (
@@ -324,11 +326,7 @@ func (api *API) GetChannelFloorPackagesPaginated(channelID string, page, perPage
 	return api.getPackagesFromQuery(query)
 }
 
-// ChannelFloorInfo contains a channel and its floor reason for a specific package
-type ChannelFloorInfo struct {
-	Channel     *Channel    `json:"channel"`
-	FloorReason null.String `json:"floor_reason"`
-}
+type ChannelFloorInfo = types.ChannelFloorInfo
 
 // GetPackageFloorChannels returns all channels where a package is marked as a floor
 func (api *API) GetPackageFloorChannels(packageID string) ([]ChannelFloorInfo, error) {

--- a/backend/pkg/api/teams.go
+++ b/backend/pkg/api/teams.go
@@ -1,17 +1,12 @@
 package api
 
 import (
-	"time"
-
 	"github.com/doug-martin/goqu/v9"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
-// Team represents a Nebraska team.
-type Team struct {
-	ID        string    `db:"id"`
-	Name      string    `db:"name"`
-	CreatedTs time.Time `db:"created_ts"`
-}
+type Team = types.Team
 
 func (api *API) GetTeams() ([]*Team, error) {
 	var teams []*Team

--- a/backend/pkg/api/users.go
+++ b/backend/pkg/api/users.go
@@ -5,9 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/doug-martin/goqu/v9"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
 const (
@@ -21,16 +22,9 @@ var (
 	ErrUpdatingPassword = errors.New("nebraska: error updating password")
 )
 
-// User represents a Nebraska user.
-type User struct {
-	ID        string    `db:"id" json:"id"`             // UUID v4 unique, created automatically
-	Username  string    `db:"username" json:"username"` // unique username
-	Secret    string    `db:"secret" json:"secret"`     // md5 hash from (username:realm:password)
-	CreatedTs time.Time `db:"created_ts" json:"-"`      // Created automatically
-	TeamID    string    `db:"team_id" json:"team_id"`   // User can be in single team
-}
+type User = types.User
 
-// AddTeam registers a team.
+// AddUser registers a user.
 func (api *API) AddUser(user *User) (*User, error) {
 	query, _, err := goqu.Insert("users").
 		Cols("username", "team_id", "secret").


### PR DESCRIPTION
# refactor(api): extract domain types to `pkg/api/internal/types`

Groundwork for the sub-package split described in [RFC #1375](https://github.com/flatcar/nebraska/issues/1375) (Rollout PR 3: extract `pkg/api/dbreads/`). See also the design doc in [#1405](https://github.com/flatcar/nebraska/pull/1405).

Move pkg/api data types and their methods into a new internal package pkg/api/internal/types. pkg/api keeps re-exports (type X = types.X, const/var re-exports) so callers stay unchanged. The re-exports let us minimize the size of the change and avoid updating any tests in this commit. ~~Eventually, after splitting into the 3 packages (dbreads, admin, runtime), we will drop the re-exports in the api package and callers can reference the types package directly.~~

Prerequisite for extracting the read layer into pkg/api/internal/dbreads, which is itself a step towards later splitting the admin and runtime writer packages. dbreads cannot import pkg/api without an import cycle, so shared types have to live in a neutral internal package first.

This commit is purely refactoring and shouldn't change any behavior.

### After the follow-up dbreads-extraction PR

```mermaid
flowchart TD
    handler[pkg/handler]
    omaha[pkg/omaha]
    syncer[pkg/syncer]
    api[pkg/api<br/>writers + shims]
    dbreads[pkg/api/internal/dbreads<br/>read queries]
    types[pkg/api/internal/types<br/>domain types]

    handler --> api
    omaha --> api
    syncer --> api
    api --> dbreads
    api --> types
    dbreads --> types
```

## How to use

- This PR is intended to be purely refactoring. To validate, we should ensure that there's no behavior change at all.

## Testing done

```
$ cd backend
$ make code-checks
go build ./...
./tools/check_pkg_test.sh
NEBRASKA_SKIP_TESTS=1 go test ./... >/dev/null
./tools/golangci-lint run --fix
0 issues.
go mod tidy

$ make check-backend-with-container
# ... spins up postgres via docker-compose.test.yaml, runs full backend suite
# with NEBRASKA_RUN_SERVER_TESTS=1, then tears down.
ok  github.com/flatcar/nebraska/backend/pkg/api                44.746s
ok  github.com/flatcar/nebraska/backend/pkg/auth               0.006s
ok  github.com/flatcar/nebraska/backend/pkg/middleware         0.010s
ok  github.com/flatcar/nebraska/backend/pkg/omaha              6.745s
ok  github.com/flatcar/nebraska/backend/pkg/random             0.005s
ok  github.com/flatcar/nebraska/backend/pkg/sessions           0.007s
ok  github.com/flatcar/nebraska/backend/pkg/sessions/memcache  0.017s
ok  github.com/flatcar/nebraska/backend/pkg/sessions/memcache/gob  0.007s
ok  github.com/flatcar/nebraska/backend/pkg/syncer             8.253s
ok  github.com/flatcar/nebraska/backend/test/api               33.606s
ok  github.com/flatcar/nebraska/backend/test/auth/oidc         6.755s
```
Additionally, a manual end-to-end scenario suite was run against the local container.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
