### PR TITLE
Fix status history 500 and instance details request loop

### DIFF
--- a/backend/pkg/api/instances.go
+++ b/backend/pkg/api/instances.go
@@ -254,16 +254,22 @@ func (api *API) updateInstanceData(instance *Instance, data map[string]interface
 
 	// This insert is used with values returned from the update query that's executed together,
 	// so we do one transaction in the DB only.
-	// Note: When last_update_version is NULL this fails.
-	//       There always has to be a "updateInstanceStatusUpdatedGranted" done first.
+	// Prefer last_update_version when an update was granted; otherwise fall back to the
+	// instance's current version (e.g. OnHold before any grant — see issue #900).
 	insertQuery, _, err := goqu.Insert("instance_status_history").
 		Cols("status", "version", "instance_id", "application_id", "group_id").
 		With("inst_app", goqu.Update("instance_application").
 			Set(insertData).
 			Where(goqu.C("instance_id").Eq(instance.ID), goqu.C("application_id").Eq(appID)).
-			Returning("instance_id", "application_id", "last_update_version", "group_id")).
+			Returning("instance_id", "application_id", "last_update_version", "group_id", "version")).
 		FromQuery(goqu.From(goqu.L("inst_app")).
-			Select(goqu.V(newStatus).As("status"), goqu.C("last_update_version").As("version"), goqu.C("instance_id"), goqu.C("application_id"), goqu.C("group_id"))).
+			Select(
+				goqu.V(newStatus).As("status"),
+				goqu.L("COALESCE(last_update_version, version)").As("version"),
+				goqu.C("instance_id"),
+				goqu.C("application_id"),
+				goqu.C("group_id"),
+			)).
 		ToSQL()
 
 	if err != nil {

--- a/backend/pkg/api/instances_test.go
+++ b/backend/pkg/api/instances_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 )
 
@@ -300,6 +301,62 @@ func TestGetInstanceStatusHistory(t *testing.T) {
 	assert.Equal(t, history[2].Version, "1.0.1")
 	assert.Equal(t, history[3].Status, InstanceStatusUpdateGranted)
 	assert.Equal(t, history[3].Version, "1.0.1")
+}
+
+// TestGetInstanceStatusHistory_OnHoldWithoutGrantedUpdate reproduces
+// https://github.com/flatcar/nebraska/issues/900 — a newly connected instance
+// put OnHold by policy has NULL last_update_version; status history must still
+// be readable and should fall back to the instance's current version.
+func TestGetInstanceStatusHistory_OnHoldWithoutGrantedUpdate(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+
+	tTeam, _ := a.AddTeam(&Team{Name: "test_team"})
+	tApp, _ := a.AddApp(&Application{Name: "test_app", TeamID: tTeam.ID})
+	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
+	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
+	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+
+	tInstance, err := a.RegisterInstance(Instance{ID: uuid.New().String(), IP: "10.0.0.1"}, NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
+	assert.NoError(t, err)
+
+	err = a.updateInstanceStatus(tInstance.ID, tApp.ID, InstanceStatusOnHold)
+	assert.NoError(t, err)
+
+	history, err := a.GetInstanceStatusHistory(tInstance.ID, tApp.ID, tGroup.ID, 100)
+	assert.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, InstanceStatusOnHold, history[0].Status)
+	assert.Equal(t, "1.0.0", history[0].Version)
+}
+
+// TestGetInstanceStatusHistory_NullVersionRow ensures existing history rows with
+// NULL version (pre-fix data) can still be scanned without a 500.
+func TestGetInstanceStatusHistory_NullVersionRow(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+
+	tTeam, _ := a.AddTeam(&Team{Name: "test_team"})
+	tApp, _ := a.AddApp(&Application{Name: "test_app", TeamID: tTeam.ID})
+	tPkg, _ := a.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
+	tChannel, _ := a.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
+	tGroup, _ := a.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+
+	tInstance, err := a.RegisterInstance(Instance{ID: uuid.New().String(), IP: "10.0.0.1"}, NewInstanceApplication(tApp.ID, tGroup.ID, "1.0.0"))
+	assert.NoError(t, err)
+
+	_, err = a.db.Exec(
+		`INSERT INTO instance_status_history (status, version, instance_id, application_id, group_id)
+		 VALUES ($1, NULL, $2, $3, $4)`,
+		InstanceStatusOnHold, tInstance.ID, tApp.ID, tGroup.ID,
+	)
+	assert.NoError(t, err)
+
+	history, err := a.GetInstanceStatusHistory(tInstance.ID, tApp.ID, tGroup.ID, 100)
+	assert.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, InstanceStatusOnHold, history[0].Status)
+	assert.Equal(t, "", history[0].Version)
 }
 
 func TestUpdateInstanceStats(t *testing.T) {

--- a/backend/pkg/api/internal/dbreads/instances.go
+++ b/backend/pkg/api/internal/dbreads/instances.go
@@ -309,7 +309,17 @@ func (q *Queries) instanceStatusHistoryQuery(instanceID, appID, groupID string, 
 	if limit == 0 {
 		limit = 20
 	}
-	return goqu.From("instance_status_history").Where(goqu.C("instance_id").Eq(instanceID)).
+	return goqu.From("instance_status_history").
+		Select(
+			"id",
+			"status",
+			goqu.L("COALESCE(version, '')").As("version"),
+			"created_ts",
+			"instance_id",
+			"application_id",
+			"group_id",
+		).
+		Where(goqu.C("instance_id").Eq(instanceID)).
 		Where(goqu.C("application_id").Eq(appID)).
 		Where(goqu.C("group_id").Eq(groupID)).
 		Order(goqu.C("created_ts").Desc()).

--- a/frontend/src/components/Instances/Details.tsx
+++ b/frontend/src/components/Instances/Details.tsx
@@ -311,6 +311,9 @@ function DetailsView(props: DetailsViewProps) {
   const hasAlias = !!instance.alias;
 
   React.useEffect(() => {
+    if (!application?.id || !group?.id || !instance?.id) {
+      return;
+    }
     API.getInstanceStatusHistory(application.id, group.id, instance.id)
       .then(statusHistory => {
         setEventHistory(statusHistory || []);
@@ -318,8 +321,7 @@ function DetailsView(props: DetailsViewProps) {
       .catch(() => {
         setEventHistory([]);
       });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [instance]);
+  }, [application?.id, group?.id, instance?.id]);
 
   function updateInstance() {
     setShowEdit(true);

--- a/frontend/src/components/layouts/InstanceLayout/InstanceLayout.tsx
+++ b/frontend/src/components/layouts/InstanceLayout/InstanceLayout.tsx
@@ -36,7 +36,7 @@ export default function InstanceLayout() {
 
   const [group, setGroup] = React.useState(getGroupFromApplication(application || null));
 
-  const onChange = React.useCallback(() => {
+  const fetchInstance = React.useCallback(() => {
     if (!appID || !groupID || !instanceID) {
       return;
     }
@@ -48,13 +48,19 @@ export default function InstanceLayout() {
       );
       setInstance(instance);
     });
+  }, [appID, groupID, instanceID]);
+
+  const onChange = React.useCallback(() => {
     const apps = applicationsStore().getCachedApplications() || [];
     const app = apps.find(({ id }) => id === appID) || null;
-    if (app !== application) {
-      setApplication(app);
-      setGroup(getGroupFromApplication(app));
-    }
-  }, [appID, application, getGroupFromApplication, groupID, instanceID]);
+    setApplication(prev => (prev === app ? prev : app));
+    setGroup(getGroupFromApplication(app));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appID, getGroupFromApplication]);
+
+  React.useEffect(() => {
+    fetchInstance();
+  }, [fetchInstance]);
 
   React.useEffect(() => {
     if (!appID) {
@@ -102,14 +108,14 @@ export default function InstanceLayout() {
           },
         ]}
       />
-      {!instance ? (
+      {!instance || !application || !group ? (
         <Loader />
       ) : (
         <Details
-          application={application!}
-          group={group!}
+          application={application}
+          group={group}
           instance={instance}
-          onInstanceUpdated={() => onChange()}
+          onInstanceUpdated={fetchInstance}
         />
       )}
     </React.Fragment>


### PR DESCRIPTION
# Fix status history 500 and instance details request loop

Handle NULL version in status history (fixes #900). Stop the instance details page from refetching in a loop. (fixes #1438 )

## How to use

Open an On Hold instance details page. Status history should load, and Network should show one instance + one `status_history` request.

## Testing done

- Reproduced 500 on NULL version history; fixed endpoint returns 200.
- Confirmed request loop stops after page load.
- Ran related unit tests.
