### PR TITLE
Fix contributing guidelines with Nebraska specifics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@ Welcome! We're so glad you're here and interested in contributing to Flatcar! ðŸ
 
 Whether you're fixing a bug, adding a feature, or improving docs â€” we appreciate you!
 
-For more detailed guidelines (finding issues, community meetings, PR lifecycle, commit message format, and more), check out the [main Flatcar CONTRIBUTING guide](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md) and our [Nebraska specific guide for development](https://www.flatcar.org/docs/latest/updates-releases/nebraska/development/).
+For more detailed guidelines (finding issues, community meetings, PR lifecycle, commit message format, and more), check out the [main Flatcar CONTRIBUTING guide](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md) and our [Nebraska-specific guide for development](https://www.flatcar.org/docs/latest/updates-releases/nebraska/development/).
 
 If you want to file an issue for Nebraska, please use the [Nebraska issue tracker](https://github.com/flatcar/nebraska/issues), and for any other Flatcar repository, please use the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,6 @@ Welcome! We're so glad you're here and interested in contributing to Flatcar! ðŸ
 
 Whether you're fixing a bug, adding a feature, or improving docs â€” we appreciate you!
 
-For more detailed guidelines (finding issues, community meetings, PR lifecycle, commit message format, and more), check out the [main Flatcar CONTRIBUTING guide](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md).
+For more detailed guidelines (finding issues, community meetings, PR lifecycle, commit message format, and more), check out the [main Flatcar CONTRIBUTING guide](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md) and our [Nebraska specific guide for development](https://www.flatcar.org/docs/latest/updates-releases/nebraska/development/).
 
-If you want to file an issue for any Flatcar repository, please use the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues).
-
----
-
-## Repository Specific Guidelines
-
-Any guidelines specific to this repository that are not covered in the main contribution guide will be listed here.
-
-<!-- Add repo-specific guidelines below this line -->
+If you want to file an issue for Nebraska, please use the [Nebraska issue tracker](https://github.com/flatcar/nebraska/issues), and for any other Flatcar repository, please use the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@ Whether you're fixing a bug, adding a feature, or improving docs — we apprecia
 
 For more detailed guidelines (finding issues, community meetings, PR lifecycle, commit message format, and more), check out the [main Flatcar CONTRIBUTING guide](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md) and our [Nebraska-specific guide for development](https://www.flatcar.org/docs/latest/updates-releases/nebraska/development/).
 
-If you want to file an issue for Nebraska, please use the [Nebraska issue tracker](https://github.com/flatcar/nebraska/issues), and for any other Flatcar repository, please use the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues).
+If you want to file an issue for Nebraska, please use the [Nebraska issue tracker](https://github.com/flatcar/nebraska/issues). For any other Flatcar repository, please use the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues).


### PR DESCRIPTION
Updated the CONTRIBUTING.md file to include a link to the Nebraska specific guide for development and clarified issue filing instructions.