### PR TITLE
fix(api): base version breakdown percentage on filtered instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bugfixes
 
 - Fixed package blacklist changes not appearing in UI immediately after save
+- Fixed group version breakdown percentages not adding up to 100% for groups containing instances with bracketed IDs
 
 ## [3.0.0] - 28/11/2025
 

--- a/backend/pkg/api/groups_test.go
+++ b/backend/pkg/api/groups_test.go
@@ -191,7 +191,45 @@ func TestGetGroupsFiltered(t *testing.T) {
 			vb := versionBreakdown[0]
 			assert.Equal(t, "1.0.0", vb.Version)
 			assert.Equal(t, 1, vb.Instances)
+			// The only instance that counts is the real one, so it accounts
+			// for the whole group and not just for a share of it.
+			assert.Equal(t, 100.0, vb.Percentage)
 		}
+	}
+}
+
+func TestVersionBreakdownPercentages(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	as := adminSvc(a)
+
+	tTeam, _ := as.AddTeam(&Team{Name: "test_team"})
+	tApp, _ := as.AddApp(&Application{Name: "test_app", TeamID: tTeam.ID})
+	tPkg, _ := as.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
+	tChannel, _ := as.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
+	tGroup, _ := as.AddGroup(&Group{Name: "test_group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+
+	for _, version := range []string{"1.0.0", "1.0.0", "1.0.0", "2.0.0"} {
+		_, _ = a.RegisterInstance(Instance{ID: uuid.New().String(), IP: "10.0.0.1"}, NewInstanceApplication(tApp.ID, tGroup.ID, version))
+	}
+	_, _ = a.RegisterInstance(Instance{ID: "{" + uuid.New().String() + "}", IP: "10.0.0.2"}, NewInstanceApplication(tApp.ID, tGroup.ID, "3.0.0"))
+
+	versionBreakdown, err := a.GetGroupVersionBreakdown(tGroup.ID)
+	assert.NoError(t, err)
+
+	total := 0.0
+	for _, entry := range versionBreakdown {
+		total += entry.Percentage
+	}
+	assert.InDelta(t, 100.0, total, 0.01)
+
+	if assert.Len(t, versionBreakdown, 2) {
+		assert.Equal(t, "2.0.0", versionBreakdown[0].Version)
+		assert.Equal(t, 1, versionBreakdown[0].Instances)
+		assert.InDelta(t, 25.0, versionBreakdown[0].Percentage, 0.01)
+		assert.Equal(t, "1.0.0", versionBreakdown[1].Version)
+		assert.Equal(t, 3, versionBreakdown[1].Instances)
+		assert.InDelta(t, 75.0, versionBreakdown[1].Percentage, 0.01)
 	}
 }
 

--- a/backend/pkg/api/internal/dbreads/groups.go
+++ b/backend/pkg/api/internal/dbreads/groups.go
@@ -306,15 +306,13 @@ func (q *Queries) GetGroupVersionBreakdown(groupID string) ([]*types.VersionBrea
 		return nil, err
 	}
 
+	// The percentage denominator is derived from the same grouped rows as the
+	// numerator, so both sides always cover the same set of instances.
 	query := fmt.Sprintf(`
-	SELECT version, count(*) as instances, (count(*) * 100.0 / total) as percentage
-	FROM instance_application, (
-		SELECT count(*) as total
-		FROM instance_application
-		WHERE group_id=$1 AND last_check_for_updates > now() at time zone 'utc' - interval '%[1]s'
-		) totals
+	SELECT version, count(*) as instances, (count(*) * 100.0 / sum(count(*)) over ()) as percentage
+	FROM instance_application
 	WHERE group_id=$1 AND last_check_for_updates > now() at time zone 'utc' - interval '%[1]s' AND %[2]s
-	GROUP BY version, total
+	GROUP BY version
 	ORDER BY %[3]s DESC
 	`, validityInterval, ignoreFakeInstanceCondition("instance_id"), semverExpr)
 	rows, err := q.db.Queryx(query, groupID)


### PR DESCRIPTION
Fixes #1451

## Why

`GetGroupVersionBreakdown` filters out instances with bracketed IDs, but the `total` it divided by came from a subquery without that filter, so the numerator and the denominator were counting different sets of rows. Every percentage came out lower than it should be, and a group's percentages only added up to 100% if it had no bracketed instances. The `instances` counts in the same response were always correct, only `percentage` was off.

The visible effect is in the group card. The tooltip shows these percentages directly, and since `VersionBreakdownBar` folds anything under 10% into "Other", a version that is really above 10% could get pushed into "Other" and disappear from the card. The bar width itself looked fine, because the chart has no axis domain set and scales to whatever the values add up to, which is probably why this went unnoticed for so long.

## What changed

Instead of repeating the same condition inside the subquery, the denominator now comes from the grouped rows through `sum(count(*)) over ()`. Both sides read the same rows by construction, so they cannot drift apart again if someone changes the filter later, and `instance_application` is scanned once instead of twice.

```sql
SELECT version, count(*) as instances, (count(*) * 100.0 / sum(count(*)) over ()) as percentage
FROM instance_application
WHERE group_id=$1 AND last_check_for_updates > ... AND <bracketed id filter>
GROUP BY version
```

## Testing

`TestGetGroupsFiltered` already sets up one real and two bracketed instances, so it only needed the percentage assertion. It reported 33.33% before this change instead of 100%.

I also added `TestVersionBreakdownPercentages`, which uses two versions plus a bracketed instance and checks both the split and the total. Without the fix it reports 20 / 60 adding up to 80, with the fix 25 / 75 adding up to 100.

Full backend suite passes against PostgreSQL 17.

## Numbers

One group, 200k instances, six versions, 2% of them bracketed:

| | percentages add up to | execution time (median of 5) |
| --- | --- | --- |
| before | 98.0000% | 142.8 ms |
| after | 100.0000% | 55.8 ms |

`instances` per version was identical in both runs.

## Note

I kept this to the one query. The other callers of `ignoreFakeInstanceCondition` all apply it in a single `WHERE`, so this was the only place where the numerator and denominator could disagree.
