### PR TITLE
fix(api): return empty arrays instead of null for empty list responses

### DIFF
--- a/backend/pkg/handler/activity.go
+++ b/backend/pkg/handler/activity.go
@@ -64,7 +64,7 @@ func (h *Handler) PaginateActivity(ctx echo.Context, params codegen.PaginateActi
 		l.Error().Err(err).Str("teamID", teamID).Msgf("getActivity params %v", p)
 		return ctx.NoContent(http.StatusInternalServerError)
 	}
-	return ctx.JSON(http.StatusOK, activityPage{totalCount, len(activityEntries), activityEntries})
+	return ctx.JSON(http.StatusOK, activityPage{totalCount, len(activityEntries), orEmpty(activityEntries)})
 }
 
 type activityPage struct {

--- a/backend/pkg/handler/app.go
+++ b/backend/pkg/handler/app.go
@@ -37,7 +37,7 @@ func (h *Handler) PaginateApps(ctx echo.Context, params codegen.PaginateAppsPara
 		return ctx.NoContent(http.StatusBadRequest)
 	}
 
-	return ctx.JSON(http.StatusOK, applicationPage{totalCount, len(apps), apps})
+	return ctx.JSON(http.StatusOK, applicationPage{totalCount, len(apps), orEmpty(apps)})
 }
 
 func (h *Handler) CreateApp(ctx echo.Context, params codegen.CreateAppParams) error {

--- a/backend/pkg/handler/channels.go
+++ b/backend/pkg/handler/channels.go
@@ -39,7 +39,7 @@ func (h *Handler) PaginateChannels(ctx echo.Context, appIDorProductID string, pa
 		l.Error().Err(err).Str("appID", appID).Msg("getChannels - getting channels")
 		return ctx.NoContent(http.StatusInternalServerError)
 	}
-	return ctx.JSON(http.StatusOK, channelsPage{totalCount, len(channels), channels})
+	return ctx.JSON(http.StatusOK, channelsPage{totalCount, len(channels), orEmpty(channels)})
 }
 
 func (h *Handler) CreateChannel(ctx echo.Context, appIDorProductID string) error {

--- a/backend/pkg/handler/groups.go
+++ b/backend/pkg/handler/groups.go
@@ -41,7 +41,7 @@ func (h *Handler) PaginateGroups(ctx echo.Context, appIDorProductID string, para
 		return ctx.NoContent(http.StatusInternalServerError)
 	}
 
-	return ctx.JSON(http.StatusOK, groupsPage{totalCount, len(groups), groups})
+	return ctx.JSON(http.StatusOK, groupsPage{totalCount, len(groups), orEmpty(groups)})
 }
 
 func (h *Handler) CreateGroup(ctx echo.Context, appIDorProductID string) error {

--- a/backend/pkg/handler/instances.go
+++ b/backend/pkg/handler/instances.go
@@ -45,7 +45,7 @@ func (h *Handler) GetInstanceStatusHistory(ctx echo.Context, appIDorProductID st
 		return ctx.NoContent(http.StatusInternalServerError)
 	}
 
-	return ctx.JSON(http.StatusOK, instanceStatusHistory)
+	return ctx.JSON(http.StatusOK, orEmpty(instanceStatusHistory))
 }
 
 func (h *Handler) UpdateInstance(ctx echo.Context, instanceID string) error {

--- a/backend/pkg/handler/packages.go
+++ b/backend/pkg/handler/packages.go
@@ -39,7 +39,7 @@ func (h *Handler) PaginatePackages(ctx echo.Context, appIDorProductID string, pa
 		return ctx.NoContent(http.StatusInternalServerError)
 	}
 
-	return ctx.JSON(http.StatusOK, packagePage{totalCount, len(pkgs), pkgs})
+	return ctx.JSON(http.StatusOK, packagePage{totalCount, len(pkgs), orEmpty(pkgs)})
 }
 
 func (h *Handler) CreatePackage(ctx echo.Context, appIDorProductID string) error {

--- a/backend/pkg/handler/utils.go
+++ b/backend/pkg/handler/utils.go
@@ -33,3 +33,14 @@ func appNotFoundResponse(ctx echo.Context, appIDProductID string) error {
 		"message": fmt.Sprintf("App not found for :%s", appIDProductID),
 	})
 }
+
+// orEmpty returns s, or an empty slice if s is nil. The paginated list
+// endpoints declare their item field as a required array in api/spec.yaml, but
+// a nil slice marshals to JSON null, which breaks clients generated from the
+// spec when a query returns no rows.
+func orEmpty[T any](s []T) []T {
+	if s == nil {
+		return []T{}
+	}
+	return s
+}

--- a/backend/test/api/empty_list_test.go
+++ b/backend/test/api/empty_list_test.go
@@ -1,0 +1,49 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flatcar/nebraska/backend/pkg/api"
+)
+
+// The paginated list endpoints declare their item field as a required array in
+// api/spec.yaml. A nil slice marshals to JSON null, which violates that
+// contract and breaks clients generated from the spec. These assertions look at
+// the raw JSON because unmarshalling into a Go slice treats null and [] alike.
+func TestEmptyListsAreEmptyArraysNotNull(t *testing.T) {
+	serverURL := os.Getenv("NEBRASKA_TEST_SERVER_URL")
+
+	// A freshly created app has no groups, channels or packages.
+	var app api.Application
+	httpDo(t, serverURL+"/api/apps", http.MethodPost,
+		strings.NewReader(`{"name":"empty-list-serialization-test"}`),
+		http.StatusOK, "json", &app)
+	require.NotEmpty(t, app.ID)
+
+	for _, tc := range []struct {
+		field string
+		path  string
+	}{
+		{"groups", fmt.Sprintf("/api/apps/%s/groups", app.ID)},
+		{"channels", fmt.Sprintf("/api/apps/%s/channels", app.ID)},
+		{"packages", fmt.Sprintf("/api/apps/%s/packages", app.ID)},
+	} {
+		t.Run(tc.field, func(t *testing.T) {
+			var page map[string]json.RawMessage
+			httpDo(t, serverURL+tc.path, http.MethodGet, nil, http.StatusOK, "json", &page)
+
+			raw, ok := page[tc.field]
+			require.True(t, ok, "response is missing the %q field", tc.field)
+			assert.JSONEq(t, "[]", string(raw),
+				"%s must serialize as an empty array, not null", tc.field)
+		})
+	}
+}


### PR DESCRIPTION
The paginated list endpoints declare their item field as a required array in `api/spec.yaml`, but the dbreads layer returns a nil slice when a query matches no rows, and Go marshals a nil slice as JSON `null`. Since `null` is not a valid value for a required array, clients generated from the spec fail to decode an empty result.

Reproduced against current main by creating an app with no children:

```
GET /api/apps/<id>/groups   -> {"totalCount":0,"count":0,"groups":null}
GET /api/apps/<id>/channels -> {"totalCount":0,"count":0,"channels":null}
GET /api/apps/<id>/packages -> {"totalCount":0,"count":0,"packages":null}
```

Two more endpoints have the same problem: `/api/activity` returns `"activities":null` on an empty database, and the instance `status_history` endpoint returns a bare `null` with HTTP 200 against a spec type of `instanceStatusHistories` (`type: array`).

The normalisation is done in the handlers rather than in dbreads, because the handlers own the JSON contract while a nil slice is idiomatic for the internal query helpers. This follows `PaginateChannelFloors`, which already returns an explicit empty slice. `count` is unchanged, since it is still computed from the original slice.

### Related issues

Refs #588 -- that report was unsure about the impact, so the spec-violation detail above is the answer to it. Happy to split out the `status_history` and `/api/activity` changes if you would rather keep this to the list endpoints named in the issue.

### How was this tested?

`go test -p 1 -count=1 ./...` with `NEBRASKA_RUN_SERVER_TESTS=1` against a local PostgreSQL: all 11 packages pass.

Added `TestEmptyListsAreEmptyArraysNotNull`, which asserts on the raw JSON because unmarshalling into a Go slice cannot distinguish `null` from `[]`. Confirmed it fails without the handler changes (`groups must serialize as an empty array, not null`) and passes with them.

Also checked that populated responses are unaffected: an app with 8 groups, 8 channels and 4 packages still returns matching `count` and `totalCount` values.