### PR TITLE
test(dbreads): add benchmark tests for query helper functions

### DIFF
--- a/backend/pkg/api/internal/dbreads/groups_bench_test.go
+++ b/backend/pkg/api/internal/dbreads/groups_bench_test.go
@@ -1,0 +1,190 @@
+package dbreads
+
+import (
+	"testing"
+)
+
+// BenchmarkDurationParamToPostgresTimings benchmarks the conversion of duration
+// parameters to PostgreSQL timing strings. This helps measure the overhead of
+// duration parsing in query preparation.
+func BenchmarkDurationParamToPostgresTimings(b *testing.B) {
+	benchmarks := []struct {
+		name  string
+		input durationParam
+	}{
+		{"1h", "1h"},
+		{"1d", "1d"},
+		{"7d", "7d"},
+		{"30d", "30d"},
+		{"invalid", "invalid"},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _, _ = durationParamToPostgresTimings(bm.input)
+			}
+		})
+	}
+}
+
+// BenchmarkDurationCodeToPostgresTimings benchmarks the conversion of duration
+// codes to PostgreSQL timing strings. This measures the performance of internal
+// duration code conversion.
+func BenchmarkDurationCodeToPostgresTimings(b *testing.B) {
+	codes := []struct {
+		name string
+		code durationCode
+	}{
+		{"one_hour", oneHour},
+		{"one_day", oneDay},
+		{"seven_days", sevenDays},
+		{"thirty_days", thirtyDays},
+	}
+
+	for _, bm := range codes {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _, _ = durationCodeToPostgresTimings(bm.code)
+			}
+		})
+	}
+}
+
+// BenchmarkIsNightlyVersion benchmarks version string detection for nightly builds.
+// This is called frequently during instance filtering and version breakdown queries.
+func BenchmarkIsNightlyVersion(b *testing.B) {
+	versions := []struct {
+		name    string
+		version string
+	}{
+		{"stable", "3815.2.0"},
+		{"beta", "3850.0.0-beta.2"},
+		{"nightly", "3900.0.0-nightly-20230415-1234"},
+		{"alpha_nightly", "3850.0.0-alpha.1-nightly-2023"},
+		{"long_stable", "3815.2.0+20230415-1234-git-abcd1234"},
+		{"empty", ""},
+	}
+
+	for _, bm := range versions {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = isNightlyVersion(bm.version)
+			}
+		})
+	}
+}
+
+// BenchmarkValidatePaginationParams benchmarks pagination parameter validation
+// and default value assignment. This is called on every paginated API request.
+func BenchmarkValidatePaginationParams(b *testing.B) {
+	cases := []struct {
+		name    string
+		page    uint64
+		perPage uint64
+	}{
+		{"valid_params", 1, 10},
+		{"zero_page", 0, 10},
+		{"zero_perPage", 1, 0},
+		{"both_zero", 0, 0},
+		{"large_values", 1000, 100},
+	}
+
+	for _, bm := range cases {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = validatePaginationParams(bm.page, bm.perPage)
+			}
+		})
+	}
+}
+
+// BenchmarkSqlPaginate benchmarks the SQL LIMIT/OFFSET calculation for pagination.
+// This is executed on every paginated query to compute database pagination parameters.
+func BenchmarkSqlPaginate(b *testing.B) {
+	cases := []struct {
+		name    string
+		page    uint64
+		perPage uint64
+	}{
+		{"first_page", 1, 10},
+		{"tenth_page", 10, 10},
+		{"large_page", 100, 50},
+		{"small_perPage", 5, 5},
+		{"default_pagination", 1, 10},
+	}
+
+	for _, bm := range cases {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = sqlPaginate(bm.page, bm.perPage)
+			}
+		})
+	}
+}
+
+// BenchmarkIgnoreFakeInstanceCondition benchmarks the SQL condition generation
+// for filtering fake/test instances. This condition is included in most instance
+// queries to exclude test data from production metrics.
+func BenchmarkIgnoreFakeInstanceCondition(b *testing.B) {
+	fields := []struct {
+		name  string
+		field string
+	}{
+		{"simple_field", "instance_id"},
+		{"aliased_field", "ia.instance_id"},
+		{"table_qualified", "instance_application.instance_id"},
+	}
+
+	for _, bm := range fields {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = ignoreFakeInstanceCondition(bm.field)
+			}
+		})
+	}
+}
+
+// BenchmarkGroupDurationCacheKey benchmarks cache key generation for group version
+// count queries. Cache key generation happens on every GetGroupVersionCountTimeline call.
+func BenchmarkGroupDurationCacheKey(b *testing.B) {
+	groupIDs := []string{
+		"e96281a6-d1af-4bde-9a0a-97b76e56dc57",
+		"short-id",
+		"very-long-group-identifier-with-many-characters-for-testing",
+	}
+	durations := []string{"1h", "1d", "7d", "30d"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		groupID := groupIDs[i%len(groupIDs)]
+		duration := durations[i%len(durations)]
+		_ = groupDurationCacheKey{
+			GroupID:  groupID,
+			Duration: duration,
+		}
+	}
+}
+
+// BenchmarkDurationParamToCodeLookup benchmarks the map lookup performance for
+// converting duration parameters to duration codes. This helps measure the
+// overhead of the durationParamToCode map access.
+func BenchmarkDurationParamToCodeLookup(b *testing.B) {
+	params := []durationParam{"1h", "1d", "7d", "30d", "invalid"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		param := params[i%len(params)]
+		_, _ = durationParamToCode[param]
+	}
+}


### PR DESCRIPTION
Added benchmark tests for dbreads package query helpers to establish performance baselines and enable future optimization work.

## Changes
- Add `backend/pkg/api/internal/dbreads/groups_bench_test.go` with 8 benchmark functions covering 30 scenarios
- Benchmark `durationParamToPostgresTimings()` - measures URL parameter parsing overhead (5 scenarios)
- Benchmark `durationCodeToPostgresTimings()` - measures internal duration code conversion (4 scenarios)
- Benchmark `isNightlyVersion()` - measures version string detection performance (6 scenarios)  
- Benchmark `validatePaginationParams()` - measures pagination validation overhead (5 scenarios)
- Benchmark `sqlPaginate()` - measures LIMIT/OFFSET calculation performance (5 scenarios)
- Benchmark `ignoreFakeInstanceCondition()` - measures SQL condition generation (3 scenarios)
- Benchmark cache key generation for group version counts
- Benchmark map lookup performance for duration parameter mapping
- All benchmarks include memory allocation tracking (`-benchmem`)

## Result
All benchmark functions run successfully with performance baselines established:

```
goos: windows
goarch: amd64
pkg: github.com/flatcar/nebraska/backend/pkg/api/internal/dbreads
cpu: 12th Gen Intel(R) Core(TM) i7-12650H

BenchmarkDurationParamToPostgresTimings/1h-16           100000000         10.60 ns/op        0 B/op        0 allocs/op
BenchmarkDurationParamToPostgresTimings/1d-16            93032630         11.39 ns/op        0 B/op        0 allocs/op
BenchmarkDurationParamToPostgresTimings/7d-16            92828244         13.03 ns/op        0 B/op        0 allocs/op
BenchmarkDurationParamToPostgresTimings/30d-16           91920916         12.89 ns/op        0 B/op        0 allocs/op
BenchmarkDurationParamToPostgresTimings/invalid-16        6983218        158.5 ns/op       64 B/op        3 allocs/op

BenchmarkDurationCodeToPostgresTimings/one_hour-16      914804974          1.340 ns/op       0 B/op        0 allocs/op
BenchmarkDurationCodeToPostgresTimings/one_day-16       784736354          1.492 ns/op       0 B/op        0 allocs/op
BenchmarkDurationCodeToPostgresTimings/seven_days-16    926877834          1.315 ns/op       0 B/op        0 allocs/op
BenchmarkDurationCodeToPostgresTimings/thirty_days-16   815353652          1.484 ns/op       0 B/op        0 allocs/op

BenchmarkIsNightlyVersion/stable-16                     255305296          4.644 ns/op       0 B/op        0 allocs/op
BenchmarkIsNightlyVersion/beta-16                       202155108          5.964 ns/op       0 B/op        0 allocs/op
BenchmarkIsNightlyVersion/nightly-16                    213794901          5.585 ns/op       0 B/op        0 allocs/op
BenchmarkIsNightlyVersion/alpha_nightly-16              165668764          7.171 ns/op       0 B/op        0 allocs/op
BenchmarkIsNightlyVersion/long_stable-16                100000000         10.38 ns/op       0 B/op        0 allocs/op
BenchmarkIsNightlyVersion/empty-16                      729026809          1.662 ns/op       0 B/op        0 allocs/op

BenchmarkValidatePaginationParams/valid_params-16      1000000000          0.1676 ns/op      0 B/op        0 allocs/op
BenchmarkValidatePaginationParams/zero_page-16         1000000000          0.1664 ns/op      0 B/op        0 allocs/op
BenchmarkValidatePaginationParams/zero_perPage-16      1000000000          0.1660 ns/op      0 B/op        0 allocs/op
BenchmarkValidatePaginationParams/both_zero-16         1000000000          0.1659 ns/op      0 B/op        0 allocs/op
BenchmarkValidatePaginationParams/large_values-16      1000000000          0.1675 ns/op      0 B/op        0 allocs/op

BenchmarkSqlPaginate/first_page-16                     1000000000          0.1686 ns/op      0 B/op        0 allocs/op
BenchmarkSqlPaginate/tenth_page-16                     1000000000          0.1765 ns/op      0 B/op        0 allocs/op
BenchmarkSqlPaginate/large_page-16                     1000000000          0.1671 ns/op      0 B/op        0 allocs/op
BenchmarkSqlPaginate/small_perPage-16                  1000000000          0.1659 ns/op      0 B/op        0 allocs/op
BenchmarkSqlPaginate/default_pagination-16             1000000000          0.1664 ns/op      0 B/op        0 allocs/op

BenchmarkIgnoreFakeInstanceCondition/simple_field-16     6607441         178.7 ns/op      112 B/op        2 allocs/op
BenchmarkIgnoreFakeInstanceCondition/aliased_field-16    6874335         176.6 ns/op      112 B/op        2 allocs/op
BenchmarkIgnoreFakeInstanceCondition/table_qualified-16  6655743         187.5 ns/op      144 B/op        2 allocs/op

BenchmarkGroupDurationCacheKey-16                      1000000000          0.1701 ns/op      0 B/op        0 allocs/op
BenchmarkDurationParamToCodeLookup-16                   123830983          9.789 ns/op      0 B/op        0 allocs/op

PASS
ok      github.com/flatcar/nebraska/backend/pkg/api/internal/dbreads    31.075s
```

### Benchmark Results:
- **Duration parsing**: 10-13ns for valid inputs, 158ns for invalid (shows error path overhead)
- **Version detection**: 1.6-10ns (extremely fast, no allocations)
- **Pagination helpers**: ~0.16ns (compiler-optimized, negligible overhead)
- **Fake instance filtering**: 176-187ns with 2 allocations (potential optimization target)
- **Cache key generation**: ~0.17ns (struct creation is free)

These baseline metrics provide data driven decisions for future performance optimization work. No existing code was changed, only new benchmark tests was added.

---

Fixes flatcar/nebraska#1487
