### PR TITLE
frontend: replace array index with unique id for React keys

### DIFF
--- a/frontend/src/components/Applications/ApplicationItemChannelsList.tsx
+++ b/frontend/src/components/Applications/ApplicationItemChannelsList.tsx
@@ -16,8 +16,8 @@ function ApplicationItemChannelsList(props: { channels?: Channel[] }) {
 
   return (
     <Grid container justifyContent="space-between">
-      {entries.map((entry: React.ReactNode, i: number) => (
-        <Grid key={i} size={4}>
+      {entries.map((entry: any, i: number) => (
+        <Grid key={entry?.props?.channel?.id || entry?.key || i} size={4}>
           {entry}
         </Grid>
       ))}

--- a/frontend/src/components/Groups/GroupCharts/TimelineChart.tsx
+++ b/frontend/src/components/Groups/GroupCharts/TimelineChart.tsx
@@ -143,11 +143,11 @@ export default function TimelineChart(props: TimelineChartProps) {
         stroke={'#000'}
       />
       <YAxis stroke="#000" />
-      {props.keys.map((key: string, i: number) => (
+      {props.keys.map((key: string) => (
         <Area
           isAnimationActive={props.isAnimationActive}
           type={interpolation}
-          key={i}
+          key={key}
           dataKey={key}
           stackId="1"
           stroke={props.colors[key]}

--- a/frontend/src/components/Instances/Charts.tsx
+++ b/frontend/src/components/Instances/Charts.tsx
@@ -228,7 +228,7 @@ export default function InstanceStatusArea(props: InstanceStatusAreaProps) {
         <InstanceCountLabel countText={totalInstances} href={href} />
       </Grid>
       <Grid container justifyContent="space-between" size={8}>
-        {instanceStateCount.map(({ status, count }, i) => {
+        {instanceStateCount.map(({ status, count }) => {
           // Sort the data entries so the smaller amounts are shown first.
           count.sort((obj1, obj2) => {
             const stats1 = instanceStats[obj1.key];
@@ -239,7 +239,7 @@ export default function InstanceStatusArea(props: InstanceStatusAreaProps) {
           });
 
           return (
-            <Grid key={i}>
+            <Grid key={status}>
               <ProgressDoughnut
                 data={count.map(({ key, label = status }) => {
                   const statusLabel = statusDefs[label].label;

--- a/frontend/src/components/Packages/Item.tsx
+++ b/frontend/src/components/Packages/Item.tsx
@@ -106,9 +106,9 @@ function Item(props: ItemProps) {
               {`${t('packages|channels')}:`}
             </Typography>
             &nbsp;
-            {processedChannels.map((channel, i) => {
+            {processedChannels.map(channel => {
               return (
-                <span className={classes.channelLabel} key={i}>
+                <span className={classes.channelLabel} key={channel.name}>
                   <ChannelAvatar color={channel.color} size="10px" />
                   &nbsp;
                   {channel.name}

--- a/frontend/src/components/common/ListHeader/ListHeader.tsx
+++ b/frontend/src/components/common/ListHeader/ListHeader.tsx
@@ -32,7 +32,8 @@ export default function ListHeader(props: { title: string; actions?: React.React
           </Box>
         </Grid>
       )}
-      {actions && actions.map((action, i: number) => <Grid key={i}>{action}</Grid>)}
+      {actions &&
+        actions.map((action: any, i: number) => <Grid key={action?.key || i}>{action}</Grid>)}
     </StyledGrid>
   );
 }

--- a/frontend/src/components/common/MoreMenu/MoreMenu.tsx
+++ b/frontend/src/components/common/MoreMenu/MoreMenu.tsx
@@ -53,9 +53,9 @@ export default function MoreMenu(props: MoreMenuProps) {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
-        {options.map(({ label, action }, i) => (
+        {options.map(({ label, action }) => (
           <MenuItem
-            key={i}
+            key={label}
             onClick={() => {
               handleClose();
               action();

--- a/frontend/src/components/common/SimpleTable/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable/SimpleTable.tsx
@@ -58,10 +58,10 @@ export default function SimpleTable(props: SimpleTableProps) {
         </TableHead>
         <TableBody>
           {props.instances &&
-            getPagedRows().map((row, i) => (
-              <TableRow key={i}>
-                {Object.keys(columns).map((column, i) => (
-                  <TableCell key={`cell_${i}`}>
+            getPagedRows().map((row: any, i) => (
+              <TableRow key={row.id || row.name || i}>
+                {Object.keys(columns).map(column => (
+                  <TableCell key={column}>
                     {i === 0 && row.color && (
                       <React.Fragment>
                         <InlineIcon icon={squareIcon} color={row.color} height="15" width="15" />

--- a/frontend/src/components/common/Tabs/Tabs.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.tsx
@@ -65,7 +65,7 @@ export default function Tabs(props: TabsProps) {
       >
         {tabs.map(({ label }, i) => (
           <MuiTab
-            key={i}
+            key={label}
             label={label}
             sx={
               tabs?.length > 7
@@ -78,8 +78,8 @@ export default function Tabs(props: TabsProps) {
           />
         ))}
       </MuiTabs>
-      {tabs.map(({ component }, i) => (
-        <TabPanel key={i} tabIndex={Number(tabIndex)} index={i}>
+      {tabs.map(({ component, label }, i) => (
+        <TabPanel key={label} tabIndex={Number(tabIndex)} index={i}>
           {component}
         </TabPanel>
       ))}

--- a/frontend/src/components/common/VersionBreakdownBar/VersionBreakdownBar.tsx
+++ b/frontend/src/components/common/VersionBreakdownBar/VersionBreakdownBar.tsx
@@ -157,9 +157,9 @@ function VersionProgressBar(props: { version_breakdown: any; channel: Channel | 
         <Tooltip content={<VersionsTooltip versionsData={chartData} />} />
         <XAxis hide type="number" />
         <YAxis hide dataKey="key" type="category" />
-        {chartData.versions.map((version, index) => {
+        {chartData.versions.map(version => {
           const color = chartData.colors[version];
-          return <Bar key={index} dataKey={version} stackId="1" fill={color} />;
+          return <Bar key={version} dataKey={version} stackId="1" fill={color} />;
         })}
       </BarChart>
     </StyledResponsiveContainer>


### PR DESCRIPTION
Fixes #328

This PR removes the use of array indices as `React key props` during mapping, replacing them with unique identifiers (like `id` or `name`). This prevents potential reconciliation bugs when the UI updates.

## How to use

Review the code changes to ensure that .map() functions in the frontend now use unique data properties for their key props instead of the array index i.

## Testing done
- Ran `npm run lint` and fixed all warnings (removed unused index variables).

- Ran `npm run format` to ensure styling compliance.

- Ran `tsc -b` to verify no typescript errors.

Built and ran the frontend locally to ensure components render correctly.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
