### PR TITLE
fix(metrics): reset gauge vectors before repopulating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bugfixes
 
 - Fixed package blacklist changes not appearing in UI immediately after save
+- Fixed `nebraska_application_instances_per_channel` and `nebraska_failed_updates` Prometheus metrics keeping stale label values (e.g. after an application rename) instead of dropping them
 
 ## [3.0.0] - 28/11/2025
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -150,6 +150,7 @@ require (
 	github.com/kkHAIKE/contextcheck v1.1.6 // indirect
 	github.com/kulti/thelper v0.7.1 // indirect
 	github.com/kunwardeep/paralleltest v1.0.15 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/lasiar/canonicalheader v1.1.2 // indirect
 	github.com/ldez/exptostd v0.4.5 // indirect

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -135,6 +135,11 @@ func calculateMetrics(api *api.API) error {
 		return fmt.Errorf("failed to get app instances per channel metrics: %w", err)
 	}
 
+	// Drop every label combination before repopulating, otherwise a
+	// combination that stops being returned by the query (application
+	// renamed, channel changed, instances gone) keeps reporting its last
+	// known value forever instead of disappearing.
+	appInstancePerChannelGaugeMetric.Reset()
 	for _, metric := range aipcMetrics {
 		appInstancePerChannelGaugeMetric.WithLabelValues(metric.ApplicationName, metric.Version, metric.ChannelName).Set(float64(metric.InstancesCount))
 	}
@@ -144,6 +149,7 @@ func calculateMetrics(api *api.API) error {
 		return fmt.Errorf("failed to get failed update metrics: %w", err)
 	}
 
+	failedUpdatesGaugeMetric.Reset()
 	for _, metric := range fuMetrics {
 		failedUpdatesGaugeMetric.WithLabelValues(metric.ApplicationName).Set(float64(metric.FailureCount))
 	}

--- a/backend/pkg/metrics/metrics_test.go
+++ b/backend/pkg/metrics/metrics_test.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flatcar/nebraska/backend/pkg/api"
+	"github.com/flatcar/nebraska/backend/pkg/api/admin"
+)
+
+const sampleApplicationID = "b6458005-8f40-4627-b33b-be70a718c48e"
+
+// A renamed application still owns the same instances, so the next tick
+// should report the same counts under the new name and stop reporting them
+// under the old one. Nothing about the label combinations themselves is
+// invalid, they just no longer match what the query returns.
+func TestCalculateMetricsDropsStaleLabelSeries(t *testing.T) {
+	a, err := api.NewForTest(api.OptionInitDB)
+	require.NoError(t, err)
+	defer a.Close()
+
+	require.NoError(t, calculateMetrics(a))
+
+	before := `
+# HELP nebraska_application_instances_per_channel Number of applications from specific channel running on instances
+# TYPE nebraska_application_instances_per_channel gauge
+nebraska_application_instances_per_channel{application="Sample application",channel="Failing",version="1.0.1"} 1
+nebraska_application_instances_per_channel{application="Sample application",channel="Master",version="1.0.1"} 1
+nebraska_application_instances_per_channel{application="Sample application",channel="Master",version="1.0.2"} 1
+nebraska_application_instances_per_channel{application="Sample application",channel="Master",version="1.0.3"} 1
+nebraska_application_instances_per_channel{application="Sample application",channel="Master",version="1.0.4"} 1
+nebraska_application_instances_per_channel{application="Sample application",channel="Stable",version="1.0.1"} 1
+nebraska_application_instances_per_channel{application="Sample application",channel="Stable",version="1.0.2"} 2
+nebraska_application_instances_per_channel{application="Sample application",channel="Stable",version="1.0.3"} 4
+`
+	require.NoError(t, testutil.CollectAndCompare(appInstancePerChannelGaugeMetric, strings.NewReader(before)))
+
+	adminSvc := admin.NewService(a.Reads())
+	app, err := a.Reads().GetApp(sampleApplicationID)
+	require.NoError(t, err)
+	app.Name = "Sample application renamed"
+	require.NoError(t, adminSvc.UpdateApp(app))
+
+	require.NoError(t, calculateMetrics(a))
+
+	// Same 8 lines, only the application name changed. If the old name is
+	// still present too, CollectAndCompare fails because the exposed set no
+	// longer matches exactly this one.
+	after := strings.ReplaceAll(before, "Sample application", "Sample application renamed")
+	require.NoError(t, testutil.CollectAndCompare(appInstancePerChannelGaugeMetric, strings.NewReader(after)),
+		"the old application name must not still be exposed after a rename")
+}


### PR DESCRIPTION
Fixes #1467

## Why

`calculateMetrics` set both Prometheus gauges (`application_instances_per_channel` and `failed_updates`) by calling `.WithLabelValues(...).Set(...)` for every row the current query returned. `GaugeVec.Set()` only updates the series for the labels it's given, it never removes a series that was there before but isn't in this round's rows. So once a label combination stops showing up, its gauge just keeps reporting whatever it last measured. I checked this by renaming a demo application without touching its instances: `/metrics` kept the old name's series at its old values right next to the new name at the same values, so anyone summing the metric across `application` labels got double the real number, and it stayed doubled for as long as the process kept running.

## What changed

`GaugeVec.Reset()` clears every label combination currently held by the vector. I added one call for each gauge, right before its repopulation loop and after the query has already succeeded, so a query error still leaves the last good values in place instead of wiping them.

```go
appInstancePerChannelGaugeMetric.Reset()
for _, metric := range aipcMetrics {
	appInstancePerChannelGaugeMetric.WithLabelValues(...).Set(...)
}
```

Same for `failedUpdatesGaugeMetric`.

## Testing

Added `TestCalculateMetricsDropsStaleLabelSeries` in `backend/pkg/metrics/metrics_test.go`. It runs `calculateMetrics` against the sample data, renames the sample application through the same `admin.Service.UpdateApp` call the API handler uses, runs `calculateMetrics` again, and checks the exposed gauge with `testutil.CollectAndCompare`. Without the fix the old name's 8 lines are still there alongside the new name's 8 lines, the test fails on that diff. With the fix only the new name's 8 lines are left.

I also built this branch and ran it against a real database to see it on an actual `/metrics` endpoint, same demo application and rename as in the issue. Before the fix:

```
nebraska_application_instances_per_channel{application="Screenshot Demo",channel="demo-stable",version="4152.2.3"} 9
nebraska_application_instances_per_channel{application="Screenshot Demo",channel="demo-stable",version="4230.2.1"} 6
```

renamed the app, waited one tick, still on the old build:

```
nebraska_application_instances_per_channel{application="Screenshot Demo",channel="demo-stable",version="4152.2.3"} 9
nebraska_application_instances_per_channel{application="Screenshot Demo",channel="demo-stable",version="4230.2.1"} 6
nebraska_application_instances_per_channel{application="Screenshot Demo v2",channel="demo-stable",version="4152.2.3"} 9
nebraska_application_instances_per_channel{application="Screenshot Demo v2",channel="demo-stable",version="4230.2.1"} 6
```

same steps on this branch:

```
nebraska_application_instances_per_channel{application="Screenshot Demo v2",channel="demo-stable",version="4152.2.3"} 9
nebraska_application_instances_per_channel{application="Screenshot Demo v2",channel="demo-stable",version="4230.2.1"} 6
```

Full backend suite passes.

## Note on scope

I only touched `calculateMetrics` in `backend/pkg/metrics/metrics.go`. Nothing about the queries or the metric definitions changed, this is only about how the results get applied to the gauges.
