### PR TITLE
metrics: expose rollout progress and update tracking for monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *sublime*
 backend/__postgres_testing_volume/
 **/.distrobox
+.pr-helper/

--- a/backend/pkg/api/internal/dbreads/metrics.go
+++ b/backend/pkg/api/internal/dbreads/metrics.go
@@ -23,6 +23,31 @@ WHERE a.id = e.application_id AND e.event_type_id = et.id AND et.result = 0 AND 
 GROUP BY app_name
 ORDER BY app_name
 `, ignoreFakeInstanceCondition("e.instance_id"))
+
+	groupUpdatesStatsMetricSQL = fmt.Sprintf(`
+SELECT 
+	g.application_id,
+	g.id as group_id,
+	a.name as application_name,
+	g.name as group_name,
+	COALESCE(c.name, 'no channel') as channel_name,
+	COUNT(ia.instance_id) AS total_instances,
+	COALESCE(SUM(CASE WHEN ia.last_update_version = COALESCE(p.version, '') THEN 1 ELSE 0 END), 0) AS updates_to_current_version_granted,
+	COALESCE(SUM(CASE WHEN ia.update_in_progress = false AND ia.last_update_version = COALESCE(p.version, '') THEN 1 ELSE 0 END), 0) AS updates_to_current_version_attempted,
+	COALESCE(SUM(CASE WHEN ia.update_in_progress = false AND ia.last_update_version = COALESCE(p.version, '') AND ia.last_update_version = ia.version THEN 1 ELSE 0 END), 0) AS updates_to_current_version_succeeded,
+	COALESCE(SUM(CASE WHEN ia.update_in_progress = false AND ia.last_update_version = COALESCE(p.version, '') AND ia.last_update_version != ia.version THEN 1 ELSE 0 END), 0) AS updates_to_current_version_failed,
+	COALESCE(SUM(CASE WHEN ia.last_update_granted_ts > (now() AT TIME ZONE 'utc' - g.policy_period_interval::interval) THEN 1 ELSE 0 END), 0) AS updates_granted_in_last_period,
+	COALESCE(SUM(CASE WHEN ia.update_in_progress = true AND (now() AT TIME ZONE 'utc' - ia.last_update_granted_ts) <= g.policy_update_timeout::interval THEN 1 ELSE 0 END), 0) AS updates_in_progress,
+	COALESCE(SUM(CASE WHEN ia.update_in_progress = true AND (now() AT TIME ZONE 'utc' - ia.last_update_granted_ts) > g.policy_update_timeout::interval THEN 1 ELSE 0 END), 0) AS updates_timed_out
+FROM groups g
+JOIN application a ON g.application_id = a.id
+LEFT JOIN instance_application ia ON ia.group_id = g.id AND %s
+LEFT JOIN channel c ON g.channel_id = c.id
+LEFT JOIN package p ON c.package_id = p.id
+WHERE g.policy_updates_enabled = true
+GROUP BY g.id, g.application_id, a.name, g.name, c.name, p.version
+ORDER BY a.name, g.name
+`, ignoreFakeInstanceCondition("ia.instance_id"))
 )
 
 func (q *Queries) GetAppInstancesPerChannelMetrics() ([]types.AppInstancesPerChannelMetric, error) {
@@ -55,6 +80,30 @@ func (q *Queries) GetFailedUpdatesMetrics() ([]types.FailedUpdatesMetric, error)
 	defer rows.Close()
 	for rows.Next() {
 		var metric types.FailedUpdatesMetric
+		err := rows.StructScan(&metric)
+		if err != nil {
+			return nil, err
+		}
+		metrics = append(metrics, metric)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return metrics, nil
+}
+
+// GetGroupUpdatesStatsMetrics returns rollout progress and update tracking metrics for all groups
+// with updates enabled. This exposes data that Nebraska already tracks internally for policy
+// enforcement, making it observable for monitoring and alerting.
+func (q *Queries) GetGroupUpdatesStatsMetrics() ([]types.GroupUpdatesStatsMetric, error) {
+	var metrics []types.GroupUpdatesStatsMetric
+	rows, err := q.db.Queryx(groupUpdatesStatsMetricSQL)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var metric types.GroupUpdatesStatsMetric
 		err := rows.StructScan(&metric)
 		if err != nil {
 			return nil, err

--- a/backend/pkg/api/internal/types/metrics.go
+++ b/backend/pkg/api/internal/types/metrics.go
@@ -11,3 +11,31 @@ type FailedUpdatesMetric struct {
 	ApplicationName string `db:"app_name" json:"app_name"`
 	FailureCount    int    `db:"fail_count" json:"fail_count"`
 }
+
+// GroupUpdatesStatsMetric represents rollout progress and update tracking metrics for a group.
+// This surfaces data Nebraska already tracks internally for rollout policy enforcement,
+// making it observable via Prometheus for monitoring and alerting.
+type GroupUpdatesStatsMetric struct {
+	ApplicationID  string `db:"application_id" json:"application_id"`
+	GroupID        string `db:"group_id" json:"group_id"`
+	ApplicationName string `db:"application_name" json:"application_name"`
+	GroupName      string `db:"group_name" json:"group_name"`
+	ChannelName    string `db:"channel_name" json:"channel_name"`
+	// Update progress stats
+	TotalInstances                   int `db:"total_instances" json:"total_instances"`
+	UpdatesToCurrentVersionGranted   int `db:"updates_to_current_version_granted" json:"updates_to_current_version_granted"`
+	UpdatesToCurrentVersionAttempted int `db:"updates_to_current_version_attempted" json:"updates_to_current_version_attempted"`
+	UpdatesToCurrentVersionSucceeded int `db:"updates_to_current_version_succeeded" json:"updates_to_current_version_succeeded"`
+	UpdatesToCurrentVersionFailed    int `db:"updates_to_current_version_failed" json:"updates_to_current_version_failed"`
+	UpdatesGrantedInLastPeriod       int `db:"updates_granted_in_last_period" json:"updates_granted_in_last_period"`
+	UpdatesInProgress                int `db:"updates_in_progress" json:"updates_in_progress"`
+	UpdatesTimedOut                  int `db:"updates_timed_out" json:"updates_timed_out"`
+}
+
+// InstancesByOEMMetric represents the distribution of instances by OEM/platform.
+// This metric is useful for understanding fleet composition across different
+// hardware vendors and cloud platforms (e.g., aws, azure, gcp, equinixmetal, etc.)
+type InstancesByOEMMetric struct {
+	OEM            string `db:"oem" json:"oem"`
+	InstancesCount int    `db:"instances_count" json:"instances_count"`
+}

--- a/backend/pkg/api/metrics.go
+++ b/backend/pkg/api/metrics.go
@@ -7,4 +7,5 @@ import (
 type (
 	AppInstancesPerChannelMetric = types.AppInstancesPerChannelMetric
 	FailedUpdatesMetric          = types.FailedUpdatesMetric
+	GroupUpdatesStatsMetric      = types.GroupUpdatesStatsMetric
 )

--- a/backend/pkg/api/metrics_test.go
+++ b/backend/pkg/api/metrics_test.go
@@ -82,3 +82,45 @@ func TestGetFailedUpdatesMetrics(t *testing.T) {
 	}
 	require.Equal(t, expectedMetrics, metrics)
 }
+
+func TestGetGroupUpdatesStatsMetrics(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+
+	// Get metrics for all groups with updates enabled
+	metrics, err := a.GetGroupUpdatesStatsMetrics()
+	require.NoError(t, err)
+
+	// Should have metrics for at least one group (sample data includes groups with updates enabled)
+	require.NotEmpty(t, metrics, "should have at least one group with updates enabled")
+
+	// Validate structure of returned metrics
+	for _, metric := range metrics {
+		require.NotEmpty(t, metric.ApplicationID, "application_id should not be empty")
+		require.NotEmpty(t, metric.GroupID, "group_id should not be empty")
+		require.NotEmpty(t, metric.ApplicationName, "application_name should not be empty")
+		require.NotEmpty(t, metric.GroupName, "group_name should not be empty")
+		require.NotEmpty(t, metric.ChannelName, "channel_name should not be empty")
+
+		// Validate that counts are non-negative
+		require.GreaterOrEqual(t, metric.TotalInstances, 0, "total_instances should be non-negative")
+		require.GreaterOrEqual(t, metric.UpdatesToCurrentVersionGranted, 0, "updates_granted should be non-negative")
+		require.GreaterOrEqual(t, metric.UpdatesToCurrentVersionAttempted, 0, "updates_attempted should be non-negative")
+		require.GreaterOrEqual(t, metric.UpdatesToCurrentVersionSucceeded, 0, "updates_succeeded should be non-negative")
+		require.GreaterOrEqual(t, metric.UpdatesToCurrentVersionFailed, 0, "updates_failed should be non-negative")
+		require.GreaterOrEqual(t, metric.UpdatesInProgress, 0, "updates_in_progress should be non-negative")
+		require.GreaterOrEqual(t, metric.UpdatesTimedOut, 0, "updates_timed_out should be non-negative")
+		require.GreaterOrEqual(t, metric.UpdatesGrantedInLastPeriod, 0, "updates_granted_in_period should be non-negative")
+
+		// Logical validations
+		// Attempted should be <= Granted
+		require.LessOrEqual(t, metric.UpdatesToCurrentVersionAttempted, metric.UpdatesToCurrentVersionGranted,
+			"attempted updates should be <= granted updates")
+
+		// Succeeded + Failed should be <= Attempted
+		successPlusFailed := metric.UpdatesToCurrentVersionSucceeded + metric.UpdatesToCurrentVersionFailed
+		require.LessOrEqual(t, successPlusFailed, metric.UpdatesToCurrentVersionAttempted,
+			"succeeded + failed should be <= attempted")
+	}
+}
+

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -40,6 +40,79 @@ var (
 		},
 	)
 
+	// Rollout progress and update tracking metrics
+	groupTotalInstancesMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "nebraska",
+			Name:      "group_total_instances",
+			Help:      "Total number of instances in a group",
+		},
+		[]string{"application", "group", "channel"},
+	)
+
+	groupUpdatesGrantedMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "nebraska",
+			Name:      "group_updates_granted",
+			Help:      "Number of instances granted update to current version",
+		},
+		[]string{"application", "group", "channel"},
+	)
+
+	groupUpdatesAttemptedMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "nebraska",
+			Name:      "group_updates_attempted",
+			Help:      "Number of instances that attempted update to current version",
+		},
+		[]string{"application", "group", "channel"},
+	)
+
+	groupUpdatesSucceededMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "nebraska",
+			Name:      "group_updates_succeeded",
+			Help:      "Number of instances that successfully updated to current version",
+		},
+		[]string{"application", "group", "channel"},
+	)
+
+	groupUpdatesFailedMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "nebraska",
+			Name:      "group_updates_failed",
+			Help:      "Number of instances that failed to update to current version",
+		},
+		[]string{"application", "group", "channel"},
+	)
+
+	groupUpdatesInProgressMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "nebraska",
+			Name:      "group_updates_in_progress",
+			Help:      "Number of instances currently updating (within timeout window)",
+		},
+		[]string{"application", "group", "channel"},
+	)
+
+	groupUpdatesTimedOutMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "nebraska",
+			Name:      "group_updates_timed_out",
+			Help:      "Number of instances where update exceeded timeout",
+		},
+		[]string{"application", "group", "channel"},
+	)
+
+	groupUpdatesGrantedInPeriodMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "nebraska",
+			Name:      "group_updates_granted_in_period",
+			Help:      "Number of updates granted in the current policy period",
+		},
+		[]string{"application", "group", "channel"},
+	)
+
 	openConnections = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "nebraska",
@@ -72,6 +145,14 @@ func registerNebraskaMetrics() error {
 	collectors := []prometheus.Collector{
 		appInstancePerChannelGaugeMetric,
 		failedUpdatesGaugeMetric,
+		groupTotalInstancesMetric,
+		groupUpdatesGrantedMetric,
+		groupUpdatesAttemptedMetric,
+		groupUpdatesSucceededMetric,
+		groupUpdatesFailedMetric,
+		groupUpdatesInProgressMetric,
+		groupUpdatesTimedOutMetric,
+		groupUpdatesGrantedInPeriodMetric,
 		openConnections,
 		inUseConnections,
 		idleConnections,
@@ -146,6 +227,24 @@ func calculateMetrics(api *api.API) error {
 
 	for _, metric := range fuMetrics {
 		failedUpdatesGaugeMetric.WithLabelValues(metric.ApplicationName).Set(float64(metric.FailureCount))
+	}
+
+	// Rollout progress metrics
+	groupStatsMetrics, err := api.GetGroupUpdatesStatsMetrics()
+	if err != nil {
+		return fmt.Errorf("failed to get group updates stats metrics: %w", err)
+	}
+
+	for _, metric := range groupStatsMetrics {
+		labels := []string{metric.ApplicationName, metric.GroupName, metric.ChannelName}
+		groupTotalInstancesMetric.WithLabelValues(labels...).Set(float64(metric.TotalInstances))
+		groupUpdatesGrantedMetric.WithLabelValues(labels...).Set(float64(metric.UpdatesToCurrentVersionGranted))
+		groupUpdatesAttemptedMetric.WithLabelValues(labels...).Set(float64(metric.UpdatesToCurrentVersionAttempted))
+		groupUpdatesSucceededMetric.WithLabelValues(labels...).Set(float64(metric.UpdatesToCurrentVersionSucceeded))
+		groupUpdatesFailedMetric.WithLabelValues(labels...).Set(float64(metric.UpdatesToCurrentVersionFailed))
+		groupUpdatesInProgressMetric.WithLabelValues(labels...).Set(float64(metric.UpdatesInProgress))
+		groupUpdatesTimedOutMetric.WithLabelValues(labels...).Set(float64(metric.UpdatesTimedOut))
+		groupUpdatesGrantedInPeriodMetric.WithLabelValues(labels...).Set(float64(metric.UpdatesGrantedInLastPeriod))
 	}
 
 	// db stats


### PR DESCRIPTION
## Description

Nebraska tracks rollout progress and update stats per group for policy enforcement, but this data is never exposed for monitoring. This makes it difficult to:

- Assess rollout health across groups
- Detect stalled or failing updates early
- Alert on update failures or timeouts
- Track rollout progress in Grafana dashboards

## Fix

Add Prometheus gauges to expose rollout progress and update tracking data from the existing `UpdatesStats` query in the dbreads package.

## Metrics Added

| Metric | Type | Labels | Description |
|--------|------|--------|-------------|
| `nebraska_group_total_instances` | Gauge | application, group, channel | Total instances in a group |
| `nebraska_group_updates_granted` | Gauge | application, group, channel | Updates granted to current version |
| `nebraska_group_updates_attempted` | Gauge | application, group, channel | Updates currently being attempted |
| `nebraska_group_updates_succeeded` | Gauge | application, group, channel | Updates completed successfully |
| `nebraska_group_updates_failed` | Gauge | application, group, channel | Updates that failed |
| `nebraska_group_updates_in_progress` | Gauge | application, group, channel | Updates currently in progress |
| `nebraska_group_updates_timed_out` | Gauge | application, group, channel | Updates that timed out |
| `nebraska_group_updates_granted_in_period` | Gauge | application, group, channel | Updates granted in current policy period |

Only groups with `policy_updates_enabled = true` are tracked.

## Implementation

Instrumented rollout data from existing database query in:

- `GetGroupUpdatesStatsMetrics()` - new DB query exposing UpdatesStats per group
- `backend/pkg/metrics/metrics.go` - 8 new gauge registrations and collection
- `backend/pkg/api/metrics.go` - API export
- `backend/pkg/api/internal/types/metrics.go` - new struct
- `backend/pkg/api/metrics_test.go` - unit test coverage

Fixes #1474
