### PR TITLE
fix(metrics): drop gauge series that are no longer reported

### DIFF
--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -128,6 +128,20 @@ func RegisterAndInstrument(api *api.API) error {
 	return nil
 }
 
+func setAppInstancesPerChannel(metrics []api.AppInstancesPerChannelMetric) {
+	appInstancePerChannelGaugeMetric.Reset()
+	for _, metric := range metrics {
+		appInstancePerChannelGaugeMetric.WithLabelValues(metric.ApplicationName, metric.Version, metric.ChannelName).Set(float64(metric.InstancesCount))
+	}
+}
+
+func setFailedUpdates(metrics []api.FailedUpdatesMetric) {
+	failedUpdatesGaugeMetric.Reset()
+	for _, metric := range metrics {
+		failedUpdatesGaugeMetric.WithLabelValues(metric.ApplicationName).Set(float64(metric.FailureCount))
+	}
+}
+
 // calculateMetrics calculates the application metrics and updates the respective metric.
 func calculateMetrics(api *api.API) error {
 	aipcMetrics, err := api.GetAppInstancesPerChannelMetrics()
@@ -135,18 +149,14 @@ func calculateMetrics(api *api.API) error {
 		return fmt.Errorf("failed to get app instances per channel metrics: %w", err)
 	}
 
-	for _, metric := range aipcMetrics {
-		appInstancePerChannelGaugeMetric.WithLabelValues(metric.ApplicationName, metric.Version, metric.ChannelName).Set(float64(metric.InstancesCount))
-	}
+	setAppInstancesPerChannel(aipcMetrics)
 
 	fuMetrics, err := api.GetFailedUpdatesMetrics()
 	if err != nil {
 		return fmt.Errorf("failed to get failed update metrics: %w", err)
 	}
 
-	for _, metric := range fuMetrics {
-		failedUpdatesGaugeMetric.WithLabelValues(metric.ApplicationName).Set(float64(metric.FailureCount))
-	}
+	setFailedUpdates(fuMetrics)
 
 	// db stats
 	dbStats := api.DbStats()

--- a/backend/pkg/metrics/metrics_test.go
+++ b/backend/pkg/metrics/metrics_test.go
@@ -1,0 +1,79 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flatcar/nebraska/backend/pkg/api"
+)
+
+func seriesCount(t *testing.T, c prometheus.Collector) int {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 1024)
+	c.Collect(ch)
+	close(ch)
+	count := 0
+	for range ch {
+		count++
+	}
+	return count
+}
+
+func TestSetAppInstancesPerChannelDropsStaleSeries(t *testing.T) {
+	t.Cleanup(appInstancePerChannelGaugeMetric.Reset)
+	appInstancePerChannelGaugeMetric.Reset()
+
+	setAppInstancesPerChannel([]api.AppInstancesPerChannelMetric{
+		{ApplicationName: "app", Version: "1.0.0", ChannelName: "stable", InstancesCount: 7},
+		{ApplicationName: "app", Version: "2.0.0", ChannelName: "stable", InstancesCount: 3},
+	})
+	require.Equal(t, 2, seriesCount(t, appInstancePerChannelGaugeMetric))
+
+	setAppInstancesPerChannel([]api.AppInstancesPerChannelMetric{
+		{ApplicationName: "app", Version: "2.0.0", ChannelName: "stable", InstancesCount: 10},
+	})
+
+	assert.Equal(t, 1, seriesCount(t, appInstancePerChannelGaugeMetric),
+		"a version that is no longer reported must not keep its last value")
+}
+
+func TestSetFailedUpdatesDropsStaleSeries(t *testing.T) {
+	t.Cleanup(failedUpdatesGaugeMetric.Reset)
+	failedUpdatesGaugeMetric.Reset()
+
+	setFailedUpdates([]api.FailedUpdatesMetric{
+		{ApplicationName: "app-a", FailureCount: 4},
+		{ApplicationName: "app-b", FailureCount: 1},
+	})
+	require.Equal(t, 2, seriesCount(t, failedUpdatesGaugeMetric))
+
+	setFailedUpdates([]api.FailedUpdatesMetric{
+		{ApplicationName: "app-a", FailureCount: 4},
+	})
+
+	assert.Equal(t, 1, seriesCount(t, failedUpdatesGaugeMetric),
+		"an application that stopped reporting failures must not keep its series")
+}
+
+func TestSetMetricsEmptyResultClearsEverything(t *testing.T) {
+	t.Cleanup(appInstancePerChannelGaugeMetric.Reset)
+	t.Cleanup(failedUpdatesGaugeMetric.Reset)
+	appInstancePerChannelGaugeMetric.Reset()
+	failedUpdatesGaugeMetric.Reset()
+
+	setAppInstancesPerChannel([]api.AppInstancesPerChannelMetric{
+		{ApplicationName: "app", Version: "1.0.0", ChannelName: "stable", InstancesCount: 7},
+	})
+	setFailedUpdates([]api.FailedUpdatesMetric{{ApplicationName: "app", FailureCount: 2}})
+	require.Equal(t, 1, seriesCount(t, appInstancePerChannelGaugeMetric))
+	require.Equal(t, 1, seriesCount(t, failedUpdatesGaugeMetric))
+
+	setAppInstancesPerChannel(nil)
+	setFailedUpdates(nil)
+
+	assert.Zero(t, seriesCount(t, appInstancePerChannelGaugeMetric))
+	assert.Zero(t, seriesCount(t, failedUpdatesGaugeMetric))
+}


### PR DESCRIPTION
# fix(metrics): drop gauge series that are no longer reported

calculateMetrics populates appInstancePerChannelGaugeMetric and
failedUpdatesGaugeMetric with Set() on each row the query returns, but a
GaugeVec keeps every series it has ever been given until the process exits.
A label combination that stops appearing in the query result therefore keeps
reporting its last value indefinitely.

Reset both vectors before repopulating. The reset happens after the query
returns, so a failed read leaves the previous values in place rather than
briefly reporting nothing.

## How to use

This only affects the Prometheus `/metrics` output no API, schema or UI change.

To see the bug on `main`:

1. Run Nebraska against a database with instances on at least two versions,
   with a short refresh interval so you aren't waiting 15s per cycle:

   NEBRASKA_METRICS_UPDATE_INTERVAL=2s NEBRASKA_DB_URL=... ./nebraska -auth-mode noop

2. Note a version and its count:

   curl -s localhost:8000/metrics | grep application_instances_per_channel

3. Remove every instance on that version:

   psql -c "DELETE FROM instance_application WHERE version='<version>';"

4. Wait a few refresh intervals and re-read `/metrics`. On `main` the series is
   still there with its old value. On this branch it is gone, and the remaining
   series are unchanged.

## Testing done

go build ./...                        # ok
go vet ./...                          # ok
gofmt -l backend/pkg/metrics/         # no output
go test -count=1 ./pkg/metrics/...    # ok, 3 tests, 0.009s

Confirmed the tests fail without the fix, by removing the two Reset() calls:

    --- FAIL: TestSetAppInstancesPerChannelDropsStaleSeries
            expected: 1
            actual  : 2
            a version that is no longer reported must not keep its last value
    --- FAIL: TestSetFailedUpdatesDropsStaleSeries
    --- FAIL: TestSetMetricsEmptyResultClearsEverything

Manual reproduction against a 50,000-instance PostgreSQL 17 database: after
deleting all 5,000 instances on one version, /metrics still reported
1666/1667/1667 for that version across three channels, unchanged after several
refresh intervals. With the fix the series is removed and the other 11 remain
correct.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
