### PR TITLE
feat(ci): add pre-built binaries to GitHub releases

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,48 @@
+name: Release Binaries
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]*.[0-9]*.[0-9]*'
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and Publish Binaries
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+    - name: Set up Node
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 24
+        cache: npm
+        cache-dependency-path: frontend/package-lock.json
+    - name: Build frontend
+      run: |
+        cd frontend
+        npm ci
+        npm run build
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: backend/go.mod
+        cache-dependency-path: backend/go.sum
+    - name: Package static assets
+      run: |
+        rm -rf static
+        mkdir -p static
+        cp -r frontend/dist/. static/
+        tar -czf nebraska-static-assets.tar.gz static
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+      with:
+        distribution: goreleaser
+        version: v2.17.1
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *sublime*
 backend/__postgres_testing_volume/
 **/.distrobox
+/dist/
+/static/
+/nebraska-static-assets.tar.gz

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+version: 2
+
+project_name: nebraska
+
+builds:
+  - id: nebraska
+    dir: backend
+    main: ./cmd/nebraska
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+        -X github.com/flatcar/nebraska/backend/pkg/version.Version={{.Version}}
+
+archives:
+  - id: nebraska
+    formats: [binary]
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+
+checksum:
+  name_template: SHA256SUMS
+  algorithm: sha256
+
+release:
+  draft: true
+  extra_files:
+    - glob: ./nebraska-static-assets.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 ### Added
 
+- **Pre-built release binaries:** GitHub releases now include pre-built `nebraska` binaries for Linux, macOS and Windows (amd64/arm64), the static frontend assets as a `nebraska-static-assets.tar.gz`, and a `SHA256SUMS` checksum file. This allows running Nebraska without Docker or a local Go/Node.js toolchain. ([#1139](https://github.com/flatcar/nebraska/issues/1139))
 - **Custom CA Certificate for TLS:** Added `--ca-file` flag to trust additional CA certificates for TLS verification (e.g., internal CA, Let's Encrypt staging). Applies to the OIDC provider client and the syncer. Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.caFile` in the Helm chart.
 - **OEM Attribute Capture:** Instances now store OEM and Aleph version information from Omaha update requests. ([#1286](https://github.com/flatcar/nebraska/pull/1286))
 - **Multi-Step Updates with Floor Packages:** Added support for mandatory intermediate update versions (floor packages) that clients must install before reaching the target version. This enables safe migration paths for breaking changes by ensuring clients update through specific versions in order. Floor packages can be configured per channel with optional reasons and are architecture-specific. ([#1195](https://github.com/flatcar/nebraska/pull/1195))


### PR DESCRIPTION
Closes #1139

## What this does

Adds a GoReleaser-based release workflow that publishes pre-built Nebraska binaries as GitHub release assets, so Nebraska can be run without Docker or a local Go/Node.js toolchain.

On every `x.y.z` version tag push, the new `release-binaries.yml` workflow:

1. Builds the frontend (`npm ci && npm run build`)
2. Packages the static assets into `nebraska-static-assets.tar.gz` (extracts to a `static/` dir, matching the usage below)
3. Runs GoReleaser to cross-compile the backend for:
   - Linux (amd64, arm64)
   - macOS (amd64, arm64)
   - Windows (amd64, arm64)
4. Publishes a **draft** GitHub release (reviewed by maintainers before publishing) with:
   - `nebraska-linux-amd64`, `nebraska-linux-arm64`, `nebraska-darwin-amd64`, `nebraska-darwin-arm64`, `nebraska-windows-amd64.exe`, `nebraska-windows-arm64.exe`
   - `nebraska-static-assets.tar.gz`
   - `SHA256SUMS` checksum file

## Usage

```sh
wget <release-url>/nebraska-linux-amd64
wget <release-url>/nebraska-static-assets.tar.gz
tar -xzf nebraska-static-assets.tar.gz
./nebraska-linux-amd64 -http-static-dir=./static
```

## Notes

- Uses the existing GitHub Actions pinning convention (SHA + version comment).
- The release is created as a draft so maintainers can review and edit notes before publishing — this also addresses the open question in the issue.
- The `-http-static-dir` flag already exists (`backend/pkg/config/config.go:117`), defaulting to `../frontend/dist`.
- Verified locally with `goreleaser release --snapshot`: all 6 targets build and are named correctly, and `SHA256SUMS` is generated.