### PR TITLE
fix(api): return refreshed instance on partial registration update

### DIFF
--- a/backend/pkg/api/instances.go
+++ b/backend/pkg/api/instances.go
@@ -122,7 +122,7 @@ func (api *API) RegisterInstance(inst Instance, instApp InstanceApplication) (*I
 			return nil, err
 		}
 
-		return instance, nil
+		return api.GetInstance(inst.ID, appID)
 	}
 
 	// If this is an instance we haven't seen yet, then we write into instance + instance_application

--- a/backend/pkg/api/instances_test.go
+++ b/backend/pkg/api/instances_test.go
@@ -73,6 +73,28 @@ func TestRegisterInstance(t *testing.T) {
 	assert.Equal(t, null.StringFrom(tGroup3.ID), instance.Application.GroupID)
 	assert.Equal(t, "gcp", instance.OEM, "OEM should be updated when provided")
 	assert.Equal(t, "3.0.0", instance.AlephVersion, "AlephVersion should be updated when provided")
+
+	instance, err = a.RegisterInstance(Instance{ID: instanceID, IP: "10.0.0.4"}, NewInstanceApplication(tApp.ID, tGroup3.ID, "1.0.3"))
+	assert.NoError(t, err, "Registering an already registered instance updating only instance IP.")
+	assert.Equal(t, "10.0.0.4", instance.IP)
+	assert.Equal(t, "1.0.3", instance.Application.Version)
+	assert.Equal(t, null.StringFrom(tGroup3.ID), instance.Application.GroupID)
+	assert.Equal(t, "gcp", instance.OEM)
+	assert.Equal(t, "3.0.0", instance.AlephVersion)
+
+	instance, err = a.RegisterInstance(Instance{ID: instanceID, IP: "10.0.0.4"}, NewInstanceApplication(tApp.ID, tGroup3.ID, "1.0.4"))
+	assert.NoError(t, err, "Registering an already registered instance updating only application version.")
+	assert.Equal(t, "10.0.0.4", instance.IP)
+	assert.Equal(t, "1.0.4", instance.Application.Version)
+	assert.Equal(t, null.StringFrom(tGroup3.ID), instance.Application.GroupID)
+	assert.Equal(t, "gcp", instance.OEM)
+	assert.Equal(t, "3.0.0", instance.AlephVersion)
+
+	instance, err = a.RegisterInstance(Instance{ID: instanceID, Alias: "partiallyupdatedalias", IP: "10.0.0.4"}, NewInstanceApplication(tApp.ID, tGroup3.ID, "1.0.4"))
+	assert.NoError(t, err, "Registering an already registered instance updating only alias.")
+	assert.Equal(t, "partiallyupdatedalias", instance.Alias)
+	assert.Equal(t, "10.0.0.4", instance.IP)
+	assert.Equal(t, "1.0.4", instance.Application.Version)
 }
 
 func TestGetInstance(t *testing.T) {


### PR DESCRIPTION
## Description

When `RegisterInstance` performs a partial update where only one table is modified (`updateInstance != updateInstanceApplication`), it previously returned the stale in-memory `instance` object fetched prior to executing the database upsert query.

This causes callers to receive outdated instance metadata (e.g. old IP, alias, OEM, version, or timestamp) immediately following a partial update.

### Changes
- In `backend/pkg/api/instances.go`, replace `return instance, nil` with `return api.GetInstance(inst.ID, appID)` in the partial update branch, matching the behavior of the full update path.
- In `backend/pkg/api/instances_test.go`, add regression test cases verifying that updating only instance fields (IP, alias) or only instance_application fields (version) returns an updated `*Instance` struct reflecting the new values.

### Testing
- Code formatting and linting verified with `golangci-lint` and `go fmt`.