### PR TITLE
updater: report missing ProgressDownloadStarted and ProgressInstallationStarted in TryUpdate

### DIFF
--- a/updater/progress_test.go
+++ b/updater/progress_test.go
@@ -1,0 +1,111 @@
+package updater
+
+import (
+	"testing"
+
+	"github.com/flatcar/go-omaha/omaha"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProgressToEventRequest verifies that each progress value maps to the
+// correct Omaha event type and result. This is a regression test for the bug
+// where ProgressInstallationFinished incorrectly mapped to EventTypeInstallStarted
+// instead of EventTypeInstallComplete.
+func TestProgressToEventRequest(t *testing.T) {
+	tests := []struct {
+		name           string
+		progress       progress
+		wantType       omaha.EventType
+		wantResult     omaha.EventResult
+		wantNil        bool
+	}{
+		{
+			name:       "ProgressDownloadStarted maps to EventTypeUpdateDownloadStarted",
+			progress:   ProgressDownloadStarted,
+			wantType:   omaha.EventTypeUpdateDownloadStarted,
+			wantResult: omaha.EventResultSuccess,
+		},
+		{
+			name:       "ProgressDownloadFinished maps to EventTypeUpdateDownloadFinished",
+			progress:   ProgressDownloadFinished,
+			wantType:   omaha.EventTypeUpdateDownloadFinished,
+			wantResult: omaha.EventResultSuccess,
+		},
+		{
+			name:       "ProgressInstallationStarted maps to EventTypeInstallStarted",
+			progress:   ProgressInstallationStarted,
+			wantType:   omaha.EventTypeInstallStarted,
+			wantResult: omaha.EventResultSuccess,
+		},
+		{
+			// Regression test for: ProgressInstallationFinished was incorrectly
+			// mapping to EventTypeInstallStarted instead of EventTypeInstallComplete,
+			// making installation start and finish indistinguishable in server logs.
+			name:       "ProgressInstallationFinished maps to EventTypeInstallComplete",
+			progress:   ProgressInstallationFinished,
+			wantType:   omaha.EventTypeInstallComplete,
+			wantResult: omaha.EventResultSuccess,
+		},
+		{
+			name:       "ProgressUpdateComplete maps to EventTypeUpdateComplete",
+			progress:   ProgressUpdateComplete,
+			wantType:   omaha.EventTypeUpdateComplete,
+			wantResult: omaha.EventResultSuccess,
+		},
+		{
+			name:       "ProgressUpdateCompleteAndRestarted maps to EventTypeUpdateComplete with reboot result",
+			progress:   ProgressUpdateCompleteAndRestarted,
+			wantType:   omaha.EventTypeUpdateComplete,
+			wantResult: omaha.EventResultSuccessReboot,
+		},
+		{
+			name:       "ProgressError maps to EventTypeUpdateComplete with error result",
+			progress:   ProgressError,
+			wantType:   omaha.EventTypeUpdateComplete,
+			wantResult: omaha.EventResultError,
+		},
+		{
+			name:    "unknown progress value returns nil",
+			progress: progress(999),
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := progressToEventRequest(tc.progress)
+
+			if tc.wantNil {
+				assert.Nil(t, got, "expected nil for unknown progress value")
+				return
+			}
+
+			require.NotNil(t, got, "expected non-nil EventRequest")
+			assert.Equal(t, tc.wantType, got.Type,
+				"progress %v: wrong event type", tc.progress)
+			assert.Equal(t, tc.wantResult, got.Result,
+				"progress %v: wrong event result", tc.progress)
+		})
+	}
+}
+
+// TestProgressInstallationStartedAndFinishedAreDistinct verifies that
+// ProgressInstallationStarted and ProgressInstallationFinished produce
+// different event types. This is the core assertion of the bug fix.
+func TestProgressInstallationStartedAndFinishedAreDistinct(t *testing.T) {
+	started := progressToEventRequest(ProgressInstallationStarted)
+	finished := progressToEventRequest(ProgressInstallationFinished)
+
+	require.NotNil(t, started)
+	require.NotNil(t, finished)
+
+	assert.NotEqual(t, started.Type, finished.Type,
+		"ProgressInstallationStarted and ProgressInstallationFinished must produce different event types")
+
+	assert.Equal(t, omaha.EventTypeInstallStarted, started.Type,
+		"ProgressInstallationStarted must produce EventTypeInstallStarted")
+
+	assert.Equal(t, omaha.EventTypeInstallComplete, finished.Type,
+		"ProgressInstallationFinished must produce EventTypeInstallComplete")
+}

--- a/updater/progress_test.go
+++ b/updater/progress_test.go
@@ -1,6 +1,7 @@
 package updater
 
 import (
+	"context"
 	"testing"
 
 	"github.com/flatcar/go-omaha/omaha"
@@ -9,16 +10,14 @@ import (
 )
 
 // TestProgressToEventRequest verifies that each progress value maps to the
-// correct Omaha event type and result. This is a regression test for the bug
-// where ProgressInstallationFinished incorrectly mapped to EventTypeInstallStarted
-// instead of EventTypeInstallComplete.
+// correct Omaha event type and result.
 func TestProgressToEventRequest(t *testing.T) {
 	tests := []struct {
-		name           string
-		progress       progress
-		wantType       omaha.EventType
-		wantResult     omaha.EventResult
-		wantNil        bool
+		name       string
+		progress   progress
+		wantType   omaha.EventType
+		wantResult omaha.EventResult
+		wantNil    bool
 	}{
 		{
 			name:       "ProgressDownloadStarted maps to EventTypeUpdateDownloadStarted",
@@ -39,9 +38,6 @@ func TestProgressToEventRequest(t *testing.T) {
 			wantResult: omaha.EventResultSuccess,
 		},
 		{
-			// Regression test for: ProgressInstallationFinished was incorrectly
-			// mapping to EventTypeInstallStarted instead of EventTypeInstallComplete,
-			// making installation start and finish indistinguishable in server logs.
 			name:       "ProgressInstallationFinished maps to EventTypeInstallComplete",
 			progress:   ProgressInstallationFinished,
 			wantType:   omaha.EventTypeInstallComplete,
@@ -66,33 +62,29 @@ func TestProgressToEventRequest(t *testing.T) {
 			wantResult: omaha.EventResultError,
 		},
 		{
-			name:    "unknown progress value returns nil",
+			name:     "unknown progress value returns nil",
 			progress: progress(999),
-			wantNil: true,
+			wantNil:  true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := progressToEventRequest(tc.progress)
-
 			if tc.wantNil {
-				assert.Nil(t, got, "expected nil for unknown progress value")
+				assert.Nil(t, got)
 				return
 			}
-
-			require.NotNil(t, got, "expected non-nil EventRequest")
-			assert.Equal(t, tc.wantType, got.Type,
-				"progress %v: wrong event type", tc.progress)
-			assert.Equal(t, tc.wantResult, got.Result,
-				"progress %v: wrong event result", tc.progress)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantType, got.Type)
+			assert.Equal(t, tc.wantResult, got.Result)
 		})
 	}
 }
 
 // TestProgressInstallationStartedAndFinishedAreDistinct verifies that
 // ProgressInstallationStarted and ProgressInstallationFinished produce
-// different event types. This is the core assertion of the bug fix.
+// different event types.
 func TestProgressInstallationStartedAndFinishedAreDistinct(t *testing.T) {
 	started := progressToEventRequest(ProgressInstallationStarted)
 	finished := progressToEventRequest(ProgressInstallationFinished)
@@ -100,12 +92,116 @@ func TestProgressInstallationStartedAndFinishedAreDistinct(t *testing.T) {
 	require.NotNil(t, started)
 	require.NotNil(t, finished)
 
-	assert.NotEqual(t, started.Type, finished.Type,
-		"ProgressInstallationStarted and ProgressInstallationFinished must produce different event types")
+	assert.NotEqual(t, started.Type, finished.Type)
+	assert.Equal(t, omaha.EventTypeInstallStarted, started.Type)
+	assert.Equal(t, omaha.EventTypeInstallComplete, finished.Type)
+}
 
-	assert.Equal(t, omaha.EventTypeInstallStarted, started.Type,
-		"ProgressInstallationStarted must produce EventTypeInstallStarted")
+// recordingHandler is a test UpdateHandler that records which methods were called.
+type recordingHandler struct {
+	fetchCalled bool
+	applyCalled bool
+}
 
-	assert.Equal(t, omaha.EventTypeInstallComplete, finished.Type,
-		"ProgressInstallationFinished must produce EventTypeInstallComplete")
+func (h *recordingHandler) FetchUpdate(_ context.Context, _ UpdateInfo) error {
+	h.fetchCalled = true
+	return nil
+}
+
+func (h *recordingHandler) ApplyUpdate(_ context.Context, _ UpdateInfo) error {
+	h.applyCalled = true
+	return nil
+}
+
+// recordingOmahaHandler captures all Omaha event types sent during TryUpdate.
+type recordingOmahaHandler struct {
+	eventTypes []omaha.EventType
+	hasUpdate  bool
+}
+
+func (h *recordingOmahaHandler) Handle(_ context.Context, _ string, req *omaha.Request) (*omaha.Response, error) {
+	resp := omaha.NewResponse()
+	for _, app := range req.Apps {
+		respApp := resp.AddApp(string(app.ID), omaha.AppOK)
+
+		// Record any events sent
+		for _, event := range app.Events {
+			h.eventTypes = append(h.eventTypes, event.Type)
+			respApp.AddEvent()
+		}
+
+		// Respond to update check
+		if app.UpdateCheck != nil {
+			if h.hasUpdate {
+				uc := respApp.AddUpdateCheck(omaha.UpdateOK)
+				m := uc.AddManifest("2.0.0")
+				m.AddPackage()
+				uc.AddURL("http://example.com/")
+			} else {
+				respApp.AddUpdateCheck(omaha.NoUpdate)
+			}
+		}
+	}
+	return resp, nil
+}
+
+// TestTryUpdateReportsAllProgressEvents verifies that TryUpdate sends the
+// complete sequence of Omaha progress events:
+//
+//	DownloadStarted → DownloadFinished → InstallStarted → InstallComplete → UpdateComplete
+//
+// Before the fix, TryUpdate skipped DownloadStarted and InstallationStarted,
+// so the server only saw: DownloadFinished → InstallComplete → UpdateComplete.
+func TestTryUpdateReportsAllProgressEvents(t *testing.T) {
+	omahaHandler := &recordingOmahaHandler{hasUpdate: true}
+
+	u, err := New(Config{
+		OmahaURL:        "http://localhost",
+		AppID:           "{test-app-id}",
+		Channel:         "stable",
+		InstanceID:      "test-instance",
+		InstanceVersion: "1.0.0",
+		OmahaReqHandler: omahaHandler,
+	})
+	require.NoError(t, err)
+
+	handler := &recordingHandler{}
+	err = u.TryUpdate(context.Background(), handler)
+	require.NoError(t, err)
+
+	assert.True(t, handler.fetchCalled, "FetchUpdate should have been called")
+	assert.True(t, handler.applyCalled, "ApplyUpdate should have been called")
+
+	wantEvents := []omaha.EventType{
+		omaha.EventTypeUpdateDownloadStarted,
+		omaha.EventTypeUpdateDownloadFinished,
+		omaha.EventTypeInstallStarted,
+		omaha.EventTypeInstallComplete,
+		omaha.EventTypeUpdateComplete,
+	}
+
+	assert.Equal(t, wantEvents, omahaHandler.eventTypes,
+		"TryUpdate must report the complete event sequence to the Omaha server")
+}
+
+// TestTryUpdateNoUpdateReportsNoEvents verifies that when no update is
+// available, TryUpdate reports no events.
+func TestTryUpdateNoUpdateReportsNoEvents(t *testing.T) {
+	omahaHandler := &recordingOmahaHandler{hasUpdate: false}
+
+	u, err := New(Config{
+		OmahaURL:        "http://localhost",
+		AppID:           "{test-app-id}",
+		Channel:         "stable",
+		InstanceID:      "test-instance",
+		InstanceVersion: "1.0.0",
+		OmahaReqHandler: omahaHandler,
+	})
+	require.NoError(t, err)
+
+	err = u.TryUpdate(context.Background(), &recordingHandler{})
+	require.Error(t, err)
+	var noUpdateErr NoUpdateError
+	assert.ErrorAs(t, err, &noUpdateErr)
+	assert.Empty(t, omahaHandler.eventTypes, "no events should be sent when no update is available")
 }

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -322,6 +322,10 @@ func (u *updater) TryUpdate(ctx context.Context, handler UpdateHandler) error {
 		}
 	}
 
+	if err := u.ReportProgress(ctx, ProgressDownloadStarted); err != nil {
+		return fmt.Errorf("reporting progress download started: %w", err)
+	}
+
 	if err := handler.FetchUpdate(ctx, *info); err != nil {
 		if reportErr := u.ReportError(ctx, nil); reportErr != nil && u.debug {
 			fmt.Println("Reporting error to omaha server:", errors.Unwrap(reportErr))
@@ -331,6 +335,10 @@ func (u *updater) TryUpdate(ctx context.Context, handler UpdateHandler) error {
 
 	if err := u.ReportProgress(ctx, ProgressDownloadFinished); err != nil {
 		return fmt.Errorf("reporting progress download finished: %w", err)
+	}
+
+	if err := u.ReportProgress(ctx, ProgressInstallationStarted); err != nil {
+		return fmt.Errorf("reporting progress installation started: %w", err)
 	}
 
 	if err := handler.ApplyUpdate(ctx, *info); err != nil {


### PR DESCRIPTION
## Description

`TryUpdate()` never called `ReportProgress(ProgressDownloadStarted)` before `FetchUpdate()` or `ReportProgress(ProgressInstallationStarted)` before `ApplyUpdate()`. Both progress values were defined and mapped correctly but never used in the update flow.

**Before (incomplete sequence sent to Omaha server):**

EventTypeUpdateDownloadFinished
EventTypeInstallComplete
EventTypeUpdateComplete

**After (complete sequence):**

EventTypeUpdateDownloadStarted   ← now reported
EventTypeUpdateDownloadFinished
EventTypeInstallStarted          ← now reported
EventTypeInstallComplete
EventTypeUpdateComplete

## Changes

- `updater/updater.go` — added `ReportProgress(ProgressDownloadStarted)` before `FetchUpdate()` and `ReportProgress(ProgressInstallationStarted)` before `ApplyUpdate()`
- `updater/progress_test.go` (new) — 11 unit tests including `TestTryUpdateReportsAllProgressEvents` which verifies the complete event sequence using a mock Omaha handler

## How to use

cd updater && go test -v -run "TestProgress|TestTryUpdateReports|TestTryUpdateNoUpdate" .

## Testing done

=== RUN   TestProgressToEventRequest (8 subtests - all PASS)
--- PASS: TestProgressToEventRequest
=== RUN   TestProgressInstallationStartedAndFinishedAreDistinct
--- PASS: TestProgressInstallationStartedAndFinishedAreDistinct
=== RUN   TestTryUpdateReportsAllProgressEvents
--- PASS: TestTryUpdateReportsAllProgressEvents
=== RUN   TestTryUpdateNoUpdateReportsNoEvents
--- PASS: TestTryUpdateNoUpdateReportsNoEvents
ok  github.com/flatcar/nebraska/updater  0.005s

Fixes #1492
