### PR TITLE
Fix duplicate-key violations in HA deployments by coordinating syncer leadership across replicas

### DIFF
--- a/backend/pkg/api/sync_leadership.go
+++ b/backend/pkg/api/sync_leadership.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 The Nebraska Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"database/sql"
+)
+
+// syncLeadershipLockID is a fixed, arbitrary Postgres advisory lock id used
+// to coordinate the syncer's periodic sync tick across replicas. There is
+// only ever one syncer per Nebraska deployment (it is not per-tenant), so a
+// single fixed id is sufficient - unlike per-TMS locks, no derivation from
+// configuration is needed here.
+const syncLeadershipLockID = 5548415426157
+
+// SyncLeadership represents held leadership for one sync tick, backed by a
+// session-scoped Postgres advisory lock on a dedicated connection. Close
+// releases the lock and the connection. If the process holding it crashes,
+// Postgres detects the dead connection and releases the lock automatically.
+type SyncLeadership struct {
+	conn *sql.Conn
+}
+
+// Close releases the advisory lock and the underlying connection.
+func (l *SyncLeadership) Close() error {
+	defer func() { _ = l.conn.Close() }()
+
+	_, err := l.conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", syncLeadershipLockID)
+
+	return err
+}
+
+// AcquireSyncLeadership attempts to acquire the sync leadership advisory
+// lock, so only one replica runs the periodic sync at a time.
+//
+// Previously every replica ran its own independent syncer with no
+// coordination: in HA deployments (e.g. via the Helm chart's
+// replicaCount), each replica's syncer ticked and wrote to the same shared
+// tables concurrently, causing duplicate-key violations and panics under
+// load. See https://github.com/flatcar/nebraska/issues/388.
+//
+// Returns acquired=false and a nil leadership if another replica currently
+// holds the lock; the caller should skip that tick rather than block.
+func (api *API) AcquireSyncLeadership(ctx context.Context) (*SyncLeadership, bool, error) {
+	conn, err := api.db.Conn(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", syncLeadershipLockID).Scan(&acquired); err != nil {
+		_ = conn.Close()
+
+		return nil, false, err
+	}
+
+	if !acquired {
+		_ = conn.Close()
+
+		return nil, false, nil
+	}
+
+	return &SyncLeadership{conn: conn}, true, nil
+}

--- a/backend/pkg/api/sync_leadership_test.go
+++ b/backend/pkg/api/sync_leadership_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 The Nebraska Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAcquireSyncLeadership_ConcurrentReplicas verifies that when two
+// "replicas" (independent API instances sharing the same underlying
+// database) race to acquire sync leadership concurrently, exactly one
+// wins. This is the scenario behind #388: previously every replica ran
+// its own independent syncer with no coordination, causing concurrent
+// writes and duplicate-key violations under HA deployments.
+func TestAcquireSyncLeadership_ConcurrentReplicas(t *testing.T) {
+	replicaA := newForTest(t)
+	defer replicaA.Close()
+	replicaB := newForTest(t)
+	defer replicaB.Close()
+
+	var wg sync.WaitGroup
+	results := make([]bool, 2)
+	leaderships := make([]*SyncLeadership, 2)
+	errs := make([]error, 2)
+
+	acquire := func(i int, a *API) {
+		defer wg.Done()
+		l, acquired, err := a.AcquireSyncLeadership(context.Background())
+		results[i] = acquired
+		errs[i] = err
+		if acquired {
+			leaderships[i] = l
+		}
+	}
+
+	wg.Add(2)
+	go acquire(0, replicaA)
+	go acquire(1, replicaB)
+	wg.Wait()
+
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+	require.NotEqual(t, results[0], results[1], "exactly one replica should acquire sync leadership, got: A=%v B=%v", results[0], results[1])
+
+	for _, l := range leaderships {
+		if l != nil {
+			require.NoError(t, l.Close())
+		}
+	}
+
+	// after release, a third attempt should succeed again
+	l3, acquired3, err := replicaA.AcquireSyncLeadership(context.Background())
+	require.NoError(t, err)
+	require.True(t, acquired3, "sync leadership should be acquirable again after release")
+	require.NoError(t, l3.Close())
+}

--- a/backend/pkg/syncer/syncer.go
+++ b/backend/pkg/syncer/syncer.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/base64"
@@ -163,19 +164,43 @@ func (s *Syncer) Start() {
 	l.Debug().Msg("syncer ready!")
 	s.ticker = time.NewTicker(s.checkFrequency)
 
-	_ = s.checkForUpdates()
+	s.runSyncTick()
 
 L:
 	for {
 		select {
 		case <-s.ticker.C:
-			_ = s.checkForUpdates()
+			s.runSyncTick()
 		case <-s.stopCh:
 			break L
 		}
 	}
 
 	s.api.Close()
+}
+
+// runSyncTick acquires sync leadership for this tick so only one replica
+// performs the sync at a time; other replicas skip the tick rather than
+// racing to write the same data concurrently. See #388.
+func (s *Syncer) runSyncTick() {
+	leadership, acquired, err := s.api.AcquireSyncLeadership(context.Background())
+	if err != nil {
+		l.Error().Err(err).Msg("failed to acquire sync leadership")
+
+		return
+	}
+	if !acquired {
+		l.Debug().Msg("sync leadership not acquired, skipping tick")
+
+		return
+	}
+	defer func() {
+		if err := leadership.Close(); err != nil {
+			l.Warn().Err(err).Msg("failed to release sync leadership")
+		}
+	}()
+
+	_ = s.checkForUpdates()
 }
 
 // Stop stops the polling for updates.


### PR DESCRIPTION
Fixes #388: every replica previously ran its own independent syncer with no coordination between them. `cmd/nebraska/main.go` starts `syncer.Start()` unconditionally on every process, and the ticker loop calls `checkForUpdates()` on the same interval on each replica independently. In HA deployments (e.g. via the Helm chart's `replicaCount > 1`), this caused every replica to write to the same shared tables concurrently, producing the duplicate-key violations and nil-pointer panics reported in the issue.

Adds a Postgres advisory-lock-based leadership check so only one replica performs the sync per tick; others skip it:

-> `api.AcquireSyncLeadership` - session-scoped `pg_try_advisory_lock` on a dedicated connection. If the leader crashes, Postgres detects the dead connection and releases the lock automatically, so the next tick's winner picks it up cleanly, no manual lease/TTL needed
-> `Syncer.Start()` now calls `runSyncTick()`, which acquires leadership before `checkForUpdates()` and releases it after

There is only one syncer per Nebraska deployment (not per-tenant), so a single fixed lock id is sufficient here.

## How to use

Deploy with `replicaCount > 1` (or run two local instances against the same DB) and confirm only one replica's logs show sync activity per tick; the other should log "sync leadership not acquired, skipping tick".

## Testing done

`TestAcquireSyncLeadership_ConcurrentReplicas` verifies real `pg_try_advisory_lock` contention between two API instances sharing a database - exactly one acquires leadership, and a third attempt succeeds again after release. Passes consistently across repeated runs.
make check-backend-with-container

Full suite green, including:

ok github.com/flatcar/nebraska/backend/pkg/api 13.209s
ok github.com/flatcar/nebraska/backend/pkg/syncer 3.252s


`golangci-lint run` - 0 issues.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.