### PR TITLE
omaha: reject registration when machine ID is empty

### DIFF
--- a/backend/pkg/omaha/omaha.go
+++ b/backend/pkg/omaha/omaha.go
@@ -139,6 +139,12 @@ func (h *Handler) buildOmahaResponse(omahaReq *omahaSpec.Request, ip string) (*o
 			respApp.AddUpdateCheck(omahaSpec.UpdateInternalError)
 			return omahaResp, nil
 		}
+		if reqApp.MachineID == "" {
+			l.Warn().Str("app", reqApp.ID).Msgf("buildOmahaResponse - request has no machine ID, refusing to register instance")
+			respApp.Status = h.getStatusMessage(api.ErrRegisterInstanceFailed)
+			respApp.AddUpdateCheck(omahaSpec.UpdateInternalError)
+			continue
+		}
 
 		for _, event := range reqApp.Events {
 			if err := h.processEvent(reqApp.MachineID, appID, group, event); err != nil {


### PR DESCRIPTION

Postgres error logs showed repeated failed inserts such as:

    INSERT INTO "instance" ("id", "ip", "alias") VALUES ('', 'y.y.y.y', '') ...

This happens because `reqApp.MachineID` from an incoming Omaha request is
used directly to build the `Instance` struct with no validation. If a
client sends a request with an empty or missing machine ID, that empty
string flows straight into `RegisterInstance`, which then tries to insert
it into the `instance` table. The `id` column already has a
`check (id <> '')` constraint, so Postgres correctly rejects the insert —
but the failure was only logged at Debug level and silently swallowed, so
it kept recurring on every request from an affected client with no one
noticing.

This was especially sneaky on ping-only requests (no `updatecheck`): the
error from `RegisterInstance` was discarded and the response still
reported an `ok` ping status back to the client, so there was no feedback
loop telling anyone something was wrong.

This PR adds a check in `buildOmahaResponse` (`backend/pkg/omaha/omaha.go`)
that rejects the app entry early when `reqApp.MachineID` is empty, before
any instance registration or event processing happens. The response now
correctly reports `error-instanceRegistrationFailed` instead of silently
succeeding (or silently failing, in the ping case).

Fixes #550

This is my first contribution here, so I'd really appreciate any feedback
on the approach — happy to adjust if there's a preferred pattern for this
kind of validation in the codebase!

## How to use

Reviewers can validate by sending an Omaha request with an `<app>` element
that has no `machineid` attribute against a local nebraska instance, and
confirming the response now reports `error-instanceRegistrationFailed`
instead of a silent `ok`. The relevant code path is in
`backend/pkg/omaha/omaha.go`, `buildOmahaResponse`.

## Testing done