### PR TITLE
frontend: refresh package data after editing

### DIFF
--- a/frontend/src/__tests__/Common/PackagesList.spec.tsx
+++ b/frontend/src/__tests__/Common/PackagesList.spec.tsx
@@ -1,14 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const storeMocks = vi.hoisted(() => ({
+  getCachedApplication: vi.fn(),
+  getApplication: vi.fn(),
+  addChangeListener: vi.fn(),
+  removeChangeListener: vi.fn(),
+  getPackageQueryParams: vi.fn(() => ({ page: 0, perPage: 10 })),
+  getAndUpdatePackages: vi.fn(),
+  updatePackage: vi.fn(),
+}));
+
 vi.mock('../../stores/Stores', () => ({
-  applicationsStore: vi.fn(() => ({
-    getCachedApplication: vi.fn(),
-    getApplication: vi.fn(),
-    addChangeListener: vi.fn(),
-    removeChangeListener: vi.fn(),
-    getPackageQueryParams: vi.fn(),
-    getAndUpdatePackages: vi.fn(),
-  })),
+  applicationsStore: vi.fn(() => storeMocks),
 }));
 
 vi.mock('../../api/API', async () => ({
@@ -20,22 +23,35 @@ vi.mock('../../api/API', async () => ({
 import '../../i18n/config.ts';
 
 import { StyledEngineProvider, ThemeProvider } from '@mui/material/styles';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import List from '../../components/Packages/List.tsx';
 import themes from '../../lib/themes';
 
-const mockGetCachedApplication = vi.fn();
-const mockGetApplication = vi.fn();
-const mockAddChangeListener = vi.fn();
-const mockRemoveChangeListener = vi.fn();
+vi.mock('../../components/Packages/Item.tsx', () => ({
+  default: ({ packageItem, handleUpdatePackage }: any) => (
+    <button onClick={() => handleUpdatePackage(packageItem.id)}>
+      {packageItem.extra_files?.[0]?.name || 'no extra files'}
+    </button>
+  ),
+}));
 
-const mockStore = {
-  getCachedApplication: mockGetCachedApplication,
-  getApplication: mockGetApplication,
-  addChangeListener: mockAddChangeListener,
-  removeChangeListener: mockRemoveChangeListener,
-};
+vi.mock('../../components/Packages/EditDialog.tsx', () => ({
+  default: ({ data, onPackageUpdated }: any) =>
+    data.package?.id ? (
+      <button
+        onClick={() =>
+          onPackageUpdated({
+            id: 'pkg1',
+            application_id: 'app123',
+            extra_files: [{ name: 'signature.txt' }],
+          })
+        }
+      >
+        Save package
+      </button>
+    ) : null,
+}));
 
 describe('List Component', () => {
   const minProps = {
@@ -43,14 +59,17 @@ describe('List Component', () => {
   };
 
   beforeEach(() => {
-    mockGetCachedApplication.mockReset();
-    mockGetApplication.mockReset();
-    mockAddChangeListener.mockReset();
-    mockRemoveChangeListener.mockReset();
+    storeMocks.getCachedApplication.mockReset();
+    storeMocks.getApplication.mockReset();
+    storeMocks.addChangeListener.mockReset();
+    storeMocks.removeChangeListener.mockReset();
+    storeMocks.getPackageQueryParams.mockReturnValue({ page: 0, perPage: 10 });
+    storeMocks.getAndUpdatePackages.mockReset();
+    storeMocks.updatePackage.mockReset();
   });
 
   it('should render the list', () => {
-    mockStore.getCachedApplication.mockReturnValueOnce(null);
+    storeMocks.getCachedApplication.mockReturnValueOnce(null);
 
     render(
       <StyledEngineProvider injectFirst>
@@ -60,5 +79,30 @@ describe('List Component', () => {
       </StyledEngineProvider>
     );
     expect(screen.getByText('Packages')).toBeTruthy();
+  });
+
+  it('updates edited package data locally without sending a second update request', () => {
+    storeMocks.getCachedApplication.mockReturnValue({
+      id: 'app123',
+      channels: [],
+      packages: {
+        totalCount: 1,
+        items: [{ id: 'pkg1', application_id: 'app123', extra_files: [] }],
+      },
+    });
+
+    render(
+      <StyledEngineProvider injectFirst>
+        <ThemeProvider theme={themes['light']}>
+          <List {...minProps} />
+        </ThemeProvider>
+      </StyledEngineProvider>
+    );
+
+    fireEvent.click(screen.getByText('no extra files'));
+    fireEvent.click(screen.getByText('Save package'));
+
+    expect(screen.getByText('signature.txt')).toBeTruthy();
+    expect(storeMocks.updatePackage).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/Common/PackagesList.spec.tsx
+++ b/frontend/src/__tests__/Common/PackagesList.spec.tsx
@@ -40,13 +40,15 @@ vi.mock('../../components/Packages/EditDialog.tsx', () => ({
   default: ({ data, onPackageUpdated }: any) =>
     data.package?.id ? (
       <button
-        onClick={() =>
-          onPackageUpdated({
+        onClick={() => {
+          const updatedPackage = {
             id: 'pkg1',
             application_id: 'app123',
             extra_files: [{ name: 'signature.txt' }],
-          })
-        }
+          };
+          storeMocks.updatePackage(updatedPackage);
+          onPackageUpdated(updatedPackage);
+        }}
       >
         Save package
       </button>
@@ -103,6 +105,6 @@ describe('List Component', () => {
     fireEvent.click(screen.getByText('Save package'));
 
     expect(screen.getByText('signature.txt')).toBeTruthy();
-    expect(storeMocks.updatePackage).not.toHaveBeenCalled();
+    expect(storeMocks.updatePackage).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/Packages/List.tsx
+++ b/frontend/src/components/Packages/List.tsx
@@ -53,7 +53,21 @@ function List(props: ListProps) {
   }
 
   function handlePackageUpdated(updatedPackage: Package) {
-    applicationsStore().updatePackage(updatedPackage);
+    setApplication(currentApplication => {
+      if (!currentApplication?.packages) {
+        return currentApplication;
+      }
+
+      return {
+        ...currentApplication,
+        packages: {
+          ...currentApplication.packages,
+          items: currentApplication.packages.items.map(packageItem =>
+            packageItem.id === updatedPackage.id ? updatedPackage : packageItem
+          ),
+        },
+      };
+    });
   }
 
   function openEditDialog(packageID: string) {


### PR DESCRIPTION
## Description

The package edit dialog already persists changes through the applications store. Its completion callback was sending the same update a second time while leaving the package list dependent on an asynchronous refresh.

Update the package in the list's local application state when editing completes. This makes updated extra files available immediately when the dialog is reopened and avoids the duplicate update request.

Add regression coverage for both the refreshed package data and the absence of a second store update.

Closes #634

## Testing

- `npm test -- --run`
- `npm run tsc`
- `npx eslint src/components/Packages/List.tsx src/__tests__/Common/PackagesList.spec.tsx`
- `npx prettier --config package.json --check src/components/Packages/List.tsx src/__tests__/Common/PackagesList.spec.tsx`