### PR TITLE
fix(api): propagate errors and rollback on application cloning failure

### DIFF
--- a/backend/pkg/api/admin/applications.go
+++ b/backend/pkg/api/admin/applications.go
@@ -36,44 +36,70 @@ func (s *Service) AddApp(app *types.Application) (*types.Application, error) {
 // channels from an existing application. Channels' packages will be set to null
 // as packages won't be cloned.
 func (s *Service) AddAppCloning(app *types.Application, sourceAppID string) (*types.Application, error) {
+	var sourceApp *types.Application
+	if sourceAppID != "" {
+		var err error
+		sourceApp, err = s.GetApp(sourceAppID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get source app: %w", err)
+		}
+	}
+
 	app, err := s.AddApp(app)
 	if err != nil {
 		return nil, err
 	}
 
-	// NOTE: cloning operation is not transactional and something could go wrong
-
-	if sourceAppID != "" {
-		sourceApp, err := s.GetApp(sourceAppID)
-		if err != nil {
-			l.Error().Err(err).Msg("AddAppCloning - could not get source app")
-			return app, nil
-		}
-
+	if sourceApp != nil {
 		channelsIDsMappings := make(map[string]null.String)
 
 		for _, channel := range sourceApp.Channels {
 			originalChannelID := channel.ID
-			channel.ApplicationID = app.ID
-			channel.PackageID = null.String{}
-			channelCopy, err := s.AddChannel(channel)
+			newChannel := &types.Channel{
+				Name:          channel.Name,
+				Color:         channel.Color,
+				ApplicationID: app.ID,
+				PackageID:     null.String{},
+				Arch:          channel.Arch,
+			}
+			channelCopy, err := s.AddChannel(newChannel)
 			if err != nil {
-				l.Error().Err(err).Msg("AddAppCloning - could not add channel")
-				return app, nil // FIXME - think about what we should return to the caller
+				if delErr := s.DeleteApp(app.ID); delErr != nil {
+					return nil, fmt.Errorf("cannot clone channel %q: %w (rollback failed: %v)", channel.Name, err, delErr)
+				}
+				return nil, fmt.Errorf("cannot clone channel %q: %w", channel.Name, err)
 			}
 			channelsIDsMappings[originalChannelID] = null.StringFrom(channelCopy.ID)
 		}
 
 		for _, group := range sourceApp.Groups {
-			group.ApplicationID = app.ID
+			var channelID null.String
 			if group.ChannelID.String != "" {
-				group.ChannelID = channelsIDsMappings[group.ChannelID.String]
+				channelID = channelsIDsMappings[group.ChannelID.String]
 			}
-			group.PolicyUpdatesEnabled = true
-			group.ID = ""
-			if _, err := s.AddGroup(group); err != nil {
-				l.Error().Err(err).Msg("AddAppCloning - could not add group")
-				return app, nil // FIXME - think about what we should return to the caller
+			track := group.Track
+			if track == group.ID {
+				track = ""
+			}
+			newGroup := &types.Group{
+				Name:                      group.Name,
+				Description:               group.Description,
+				ApplicationID:             app.ID,
+				ChannelID:                 channelID,
+				PolicyUpdatesEnabled:      true,
+				PolicySafeMode:            group.PolicySafeMode,
+				PolicyOfficeHours:         group.PolicyOfficeHours,
+				PolicyTimezone:            group.PolicyTimezone,
+				PolicyPeriodInterval:      group.PolicyPeriodInterval,
+				PolicyMaxUpdatesPerPeriod: group.PolicyMaxUpdatesPerPeriod,
+				PolicyUpdateTimeout:       group.PolicyUpdateTimeout,
+				Track:                     track,
+			}
+			if _, err := s.AddGroup(newGroup); err != nil {
+				if delErr := s.DeleteApp(app.ID); delErr != nil {
+					return nil, fmt.Errorf("cannot clone group %q: %w (rollback failed: %v)", group.Name, err, delErr)
+				}
+				return nil, fmt.Errorf("cannot clone group %q: %w", group.Name, err)
 			}
 		}
 	}

--- a/backend/pkg/api/applications_test.go
+++ b/backend/pkg/api/applications_test.go
@@ -47,7 +47,7 @@ func TestAddAppCloning(t *testing.T) {
 	tApp, _ := as.AddApp(&Application{Name: "test_app", TeamID: tTeam.ID})
 	tPkg, _ := as.AddPackage(&Package{Type: PkgTypeOther, URL: "http://sample.url/pkg", Version: "12.1.0", ApplicationID: tApp.ID})
 	tChannel, _ := as.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID)})
-	_, _ = as.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	_, _ = as.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes", Track: "beta"})
 	_, _ = as.AddGroup(&Group{Name: "group2", ApplicationID: tApp.ID, PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
 
 	clonedApp, err := as.AddAppCloning(&Application{Name: "app1", TeamID: tTeam.ID}, tApp.ID)
@@ -58,10 +58,74 @@ func TestAddAppCloning(t *testing.T) {
 	assert.Equal(t, len(sourceApp.Groups), len(clonedAppX.Groups))
 	assert.Equal(t, len(sourceApp.Channels), len(clonedAppX.Channels))
 
-	// TODO: test specific fields in groups and channels (do not forget channel id in group!)
+	// Verify cloned channel attributes
+	assert.Equal(t, "test_channel", clonedAppX.Channels[0].Name)
+	assert.Equal(t, "blue", clonedAppX.Channels[0].Color)
+	assert.Equal(t, clonedApp.ID, clonedAppX.Channels[0].ApplicationID)
+	assert.False(t, clonedAppX.Channels[0].PackageID.Valid, "Cloned channel should not have package attached")
+
+	// Verify cloned group attributes, custom track, and mapped channel ID
+	var group1, group2 *Group
+	for _, g := range clonedAppX.Groups {
+		if g.Name == "group1" {
+			group1 = g
+		} else if g.Name == "group2" {
+			group2 = g
+		}
+	}
+	assert.NotNil(t, group1)
+	assert.Equal(t, clonedApp.ID, group1.ApplicationID)
+	assert.True(t, group1.ChannelID.Valid)
+	assert.Equal(t, clonedAppX.Channels[0].ID, group1.ChannelID.String)
+	assert.NotEqual(t, tChannel.ID, group1.ChannelID.String)
+	assert.Equal(t, "beta", group1.Track, "Custom track should be preserved")
+
+	assert.NotNil(t, group2)
+	assert.Equal(t, clonedApp.ID, group2.ApplicationID)
+	assert.False(t, group2.ChannelID.Valid, "Group without channel should remain without channel")
+	assert.Equal(t, group2.ID, group2.Track, "Default track should match new group ID")
 
 	_, err = as.AddAppCloning(&Application{Name: "app2", TeamID: tTeam.ID}, "")
 	assert.NoError(t, err, "Using an empty source app id when cloning has the same effect as not cloning.")
+
+	// Test cloning with invalid/non-existent source app id returns error and does not create app
+	_, err = as.AddAppCloning(&Application{Name: "app_invalid_source", TeamID: tTeam.ID}, "00000000-0000-0000-0000-000000000000")
+	assert.Error(t, err)
+
+	apps, listErr := a.GetApps(tTeam.ID, 0, 0)
+	assert.NoError(t, listErr)
+	found := false
+	for _, existing := range apps {
+		if existing.Name == "app_invalid_source" {
+			found = true
+			break
+		}
+	}
+	assert.False(t, found, "Application should not be created when source app is invalid")
+
+	// Test rollback when cloning fails midway: create source app with a broken group
+	brokenSourceApp, err := as.AddApp(&Application{Name: "broken_source_app", TeamID: tTeam.ID})
+	assert.NoError(t, err)
+	_, err = as.AddChannel(&Channel{Name: "broken_channel", Color: "green", ApplicationID: brokenSourceApp.ID})
+	assert.NoError(t, err)
+	// Directly insert a group with invalid timezone and policy_office_hours=true to trigger error during AddGroup cloning
+	_, err = a.db.Exec("insert into groups (id, name, description, application_id, policy_office_hours, policy_timezone, policy_period_interval, policy_max_updates_per_period, policy_update_timeout) values ($1, $2, 'test_desc', $3, true, 'InvalidTimezone', '15 minutes', 2, '60 minutes')",
+		uuid.New().String(), "invalid_tz_group", brokenSourceApp.ID)
+	assert.NoError(t, err)
+
+	_, err = as.AddAppCloning(&Application{Name: "app_should_rollback", TeamID: tTeam.ID}, brokenSourceApp.ID)
+	assert.Error(t, err, "AddAppCloning should fail when group cloning fails")
+
+	apps, listErr = a.GetApps(tTeam.ID, 0, 0)
+	assert.NoError(t, listErr)
+	foundRollback := false
+	for _, existing := range apps {
+		if existing.Name == "app_should_rollback" {
+			foundRollback = true
+			break
+		}
+	}
+	assert.False(t, foundRollback, "Partially cloned application should be deleted/rolled back on failure")
 
 	_, err = as.AddApp(&Application{Name: "productIDApp1", TeamID: tTeam.ID, ProductID: null.StringFrom("io.invalid. Name")})
 	assert.Error(t, err)


### PR DESCRIPTION
### What this PR does

While going through `AddAppCloning`, I noticed that errors during cloning were only being logged, and the function would still return `app, nil`. This meant that if something failed (e.g. invalid source app ID, or channel/group creation failing midway), the API caller would still get a 200 OK with an empty or broken application, leaving dangling data in the database.

Also, the original loop was mutating the source app's channel and group objects in memory.

### What changed

1. **Validate source app upfront**: We now look up `sourceAppID` before creating the new app in the database so we can fail early if it doesn't exist.
2. **Proper error handling & rollback**: If creating a channel or group fails midway, we delete the newly created app (which cascades and cleans up any partial channels/groups) and return the error back to the caller instead of swallowing it.
3. **Avoid in-memory mutations**: We instantiate fresh `Channel` and `Group` structs during the loop instead of mutating the source app's objects.
4. **Preserve custom track names**: If a group has a custom track name set, we keep it on the cloned group, while resetting default UUID tracks so a fresh one is generated.
5. **Tests**: Added unit test cases in `applications_test.go` to test invalid source app IDs, midway failure rollback, and verifying cloned channel/group fields.

Signed-off-by: Prayag <rajprayag014@gmail.com>