### PR TITLE
frontend: ignore stale instance responses after route changes

### DIFF
--- a/frontend/src/__tests__/Common/InstanceLayout.spec.tsx
+++ b/frontend/src/__tests__/Common/InstanceLayout.spec.tsx
@@ -20,7 +20,7 @@ vi.mock('../../api/API', () => ({
 
 vi.mock('../../stores/Stores', () => ({
   applicationsStore: () => ({
-    getCachedApplication: () => application,
+    getCachedApplication: () => ({ ...application }),
     getCachedApplications: () => [application],
     addChangeListener: testState.addChangeListener,
     removeChangeListener: testState.removeChangeListener,
@@ -174,5 +174,14 @@ describe('InstanceLayout', () => {
     await act(async () => instanceB.resolve(makeInstance('instance-b')));
 
     expect(screen.getByTestId('group-details').textContent).toBe('group-2');
+  });
+
+  it('does not refetch the application after its cached value changes', async () => {
+    testState.getInstance.mockResolvedValue(makeInstance('instance-a'));
+
+    renderInstanceRoute();
+    await act(async () => undefined);
+
+    expect(testState.getApplication).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/__tests__/Common/InstanceLayout.spec.tsx
+++ b/frontend/src/__tests__/Common/InstanceLayout.spec.tsx
@@ -1,0 +1,149 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Application, Instance } from '../../api/apiDataTypes';
+
+const testState = vi.hoisted(() => ({
+  getInstance: vi.fn(),
+  addChangeListener: vi.fn(),
+  removeChangeListener: vi.fn(),
+  getApplication: vi.fn(),
+  listener: undefined as (() => void) | undefined,
+}));
+
+vi.mock('../../api/API', () => ({
+  default: {
+    getInstance: testState.getInstance,
+  },
+}));
+
+vi.mock('../../stores/Stores', () => ({
+  applicationsStore: () => ({
+    getCachedApplication: () => application,
+    getCachedApplications: () => [application],
+    addChangeListener: testState.addChangeListener,
+    removeChangeListener: testState.removeChangeListener,
+    getApplication: testState.getApplication,
+  }),
+}));
+
+vi.mock('../../components/common/SectionHeader', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../components/common/Loader', () => ({
+  default: () => <div data-testid="loader" />,
+}));
+
+vi.mock('../../components/Instances/Details', () => ({
+  default: ({ instance }: { instance: Instance }) => (
+    <div data-testid="instance-details">{instance.id}</div>
+  ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import InstanceLayout from '../../components/layouts/InstanceLayout/InstanceLayout';
+
+const application = {
+  id: 'app-1',
+  name: 'Application',
+  groups: [{ id: 'group-1', name: 'Group' }],
+} as Application;
+
+function makeInstance(id: string): Instance {
+  return {
+    id,
+    alias: id,
+    application: {
+      status: null,
+      version: '1.0.0',
+    },
+  } as Instance;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function renderInstanceRoute() {
+  function NavigateToInstanceB() {
+    const navigate = useNavigate();
+    return (
+      <button onClick={() => navigate('/apps/app-1/groups/group-1/instances/instance-b')}>
+        Show instance B
+      </button>
+    );
+  }
+
+  return render(
+    <MemoryRouter initialEntries={['/apps/app-1/groups/group-1/instances/instance-a']}>
+      <NavigateToInstanceB />
+      <Routes>
+        <Route
+          path="/apps/:appID/groups/:groupID/instances/:instanceID"
+          element={<InstanceLayout />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('InstanceLayout', () => {
+  beforeEach(() => {
+    testState.getInstance.mockReset();
+    testState.listener = undefined;
+    testState.addChangeListener.mockReset();
+    testState.removeChangeListener.mockReset();
+    testState.getApplication.mockReset();
+    testState.addChangeListener.mockImplementation(listener => {
+      testState.listener = listener;
+    });
+    testState.getApplication.mockImplementation(() => {
+      testState.listener?.();
+    });
+  });
+
+  it('does not keep showing the previous instance while a new route loads', async () => {
+    const instanceA = deferred<Instance>();
+    const instanceB = deferred<Instance>();
+    testState.getInstance
+      .mockReturnValueOnce(instanceA.promise)
+      .mockReturnValueOnce(instanceB.promise);
+
+    renderInstanceRoute();
+
+    await act(async () => instanceA.resolve(makeInstance('instance-a')));
+    expect(screen.getByTestId('instance-details').textContent).toBe('instance-a');
+
+    fireEvent.click(screen.getByText('Show instance B'));
+
+    expect(screen.queryByTestId('instance-details')).toBeNull();
+    expect(screen.getByTestId('loader')).toBeTruthy();
+  });
+
+  it('ignores a response from the previous instance route that arrives late', async () => {
+    const instanceA = deferred<Instance>();
+    const instanceB = deferred<Instance>();
+    testState.getInstance
+      .mockReturnValueOnce(instanceA.promise)
+      .mockReturnValueOnce(instanceB.promise);
+
+    renderInstanceRoute();
+
+    fireEvent.click(screen.getByText('Show instance B'));
+
+    await act(async () => instanceB.resolve(makeInstance('instance-b')));
+    expect(screen.getByTestId('instance-details').textContent).toBe('instance-b');
+
+    await act(async () => instanceA.resolve(makeInstance('instance-a')));
+    expect(screen.getByTestId('instance-details').textContent).toBe('instance-b');
+  });
+});

--- a/frontend/src/__tests__/Common/InstanceLayout.spec.tsx
+++ b/frontend/src/__tests__/Common/InstanceLayout.spec.tsx
@@ -10,6 +10,7 @@ const testState = vi.hoisted(() => ({
   removeChangeListener: vi.fn(),
   getApplication: vi.fn(),
   listener: undefined as (() => void) | undefined,
+  listeners: [] as (() => void)[],
 }));
 
 vi.mock('../../api/API', () => ({
@@ -111,14 +112,19 @@ describe('InstanceLayout', () => {
   beforeEach(() => {
     testState.getInstance.mockReset();
     testState.listener = undefined;
+    testState.listeners = [];
     testState.addChangeListener.mockReset();
     testState.removeChangeListener.mockReset();
     testState.getApplication.mockReset();
     testState.addChangeListener.mockImplementation(listener => {
       testState.listener = listener;
+      testState.listeners.push(listener);
+    });
+    testState.removeChangeListener.mockImplementation(listener => {
+      testState.listeners = testState.listeners.filter(candidate => candidate !== listener);
     });
     testState.getApplication.mockImplementation(() => {
-      testState.listener?.();
+      testState.listeners.forEach(listener => listener());
     });
   });
 
@@ -183,5 +189,25 @@ describe('InstanceLayout', () => {
     await act(async () => undefined);
 
     expect(testState.getApplication).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a stale store listener after the route changes', async () => {
+    const instanceA = deferred<Instance>();
+    const instanceB = deferred<Instance>();
+    const staleInstance = deferred<Instance>();
+    testState.getInstance
+      .mockReturnValueOnce(instanceA.promise)
+      .mockReturnValueOnce(instanceB.promise)
+      .mockReturnValueOnce(staleInstance.promise);
+
+    renderInstanceRoute();
+    const staleListener = testState.listener!;
+
+    fireEvent.click(screen.getByText('Show instance B'));
+    staleListener();
+    await act(async () => instanceB.resolve(makeInstance('instance-b')));
+
+    expect(testState.getInstance).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('instance-details').textContent).toBe('instance-b');
   });
 });

--- a/frontend/src/__tests__/Common/InstanceLayout.spec.tsx
+++ b/frontend/src/__tests__/Common/InstanceLayout.spec.tsx
@@ -37,8 +37,11 @@ vi.mock('../../components/common/Loader', () => ({
 }));
 
 vi.mock('../../components/Instances/Details', () => ({
-  default: ({ instance }: { instance: Instance }) => (
-    <div data-testid="instance-details">{instance.id}</div>
+  default: ({ group, instance }: { group: { id: string }; instance: Instance }) => (
+    <>
+      <div data-testid="instance-details">{instance.id}</div>
+      <div data-testid="group-details">{group.id}</div>
+    </>
   ),
 }));
 
@@ -51,7 +54,10 @@ import InstanceLayout from '../../components/layouts/InstanceLayout/InstanceLayo
 const application = {
   id: 'app-1',
   name: 'Application',
-  groups: [{ id: 'group-1', name: 'Group' }],
+  groups: [
+    { id: 'group-1', name: 'Group 1' },
+    { id: 'group-2', name: 'Group 2' },
+  ],
 } as Application;
 
 function makeInstance(id: string): Instance {
@@ -77,9 +83,14 @@ function renderInstanceRoute() {
   function NavigateToInstanceB() {
     const navigate = useNavigate();
     return (
-      <button onClick={() => navigate('/apps/app-1/groups/group-1/instances/instance-b')}>
-        Show instance B
-      </button>
+      <>
+        <button onClick={() => navigate('/apps/app-1/groups/group-1/instances/instance-b')}>
+          Show instance B
+        </button>
+        <button onClick={() => navigate('/apps/app-1/groups/group-2/instances/instance-b')}>
+          Show instance B in group 2
+        </button>
+      </>
     );
   }
 
@@ -145,5 +156,23 @@ describe('InstanceLayout', () => {
 
     await act(async () => instanceA.resolve(makeInstance('instance-a')));
     expect(screen.getByTestId('instance-details').textContent).toBe('instance-b');
+  });
+
+  it('uses the group from the current route when the application is unchanged', async () => {
+    const instanceA = deferred<Instance>();
+    const instanceB = deferred<Instance>();
+    testState.getInstance
+      .mockReturnValueOnce(instanceA.promise)
+      .mockReturnValueOnce(instanceB.promise);
+
+    renderInstanceRoute();
+
+    await act(async () => instanceA.resolve(makeInstance('instance-a')));
+    expect(screen.getByTestId('group-details').textContent).toBe('group-1');
+
+    fireEvent.click(screen.getByText('Show instance B in group 2'));
+    await act(async () => instanceB.resolve(makeInstance('instance-b')));
+
+    expect(screen.getByTestId('group-details').textContent).toBe('group-2');
   });
 });

--- a/frontend/src/components/layouts/InstanceLayout/InstanceLayout.tsx
+++ b/frontend/src/components/layouts/InstanceLayout/InstanceLayout.tsx
@@ -35,7 +35,7 @@ export default function InstanceLayout() {
     [groupID]
   );
 
-  const [group, setGroup] = React.useState(getGroupFromApplication(application || null));
+  const group = getGroupFromApplication(application || null);
 
   const onChange = React.useCallback(() => {
     if (!appID || !groupID || !instanceID) {
@@ -57,9 +57,8 @@ export default function InstanceLayout() {
     const app = apps.find(({ id }) => id === appID) || null;
     if (app !== application) {
       setApplication(app);
-      setGroup(getGroupFromApplication(app));
     }
-  }, [appID, application, getGroupFromApplication, groupID, instanceID]);
+  }, [appID, application, groupID, instanceID]);
 
   React.useEffect(() => {
     setInstance(null);

--- a/frontend/src/components/layouts/InstanceLayout/InstanceLayout.tsx
+++ b/frontend/src/components/layouts/InstanceLayout/InstanceLayout.tsx
@@ -21,6 +21,7 @@ export default function InstanceLayout() {
     applicationsStore().getCachedApplication(appID || '')
   );
   const [instance, setInstance] = React.useState<Instance | null>(null);
+  const instanceRequestID = React.useRef(0);
   const { t } = useTranslation();
 
   const getGroupFromApplication = React.useCallback(
@@ -41,7 +42,11 @@ export default function InstanceLayout() {
       return;
     }
 
+    const requestID = ++instanceRequestID.current;
     API.getInstance(appID, groupID, instanceID).then(instance => {
+      if (requestID !== instanceRequestID.current) {
+        return;
+      }
       instance.statusInfo = getInstanceStatus(
         instance.application.status,
         instance.application.version
@@ -55,6 +60,13 @@ export default function InstanceLayout() {
       setGroup(getGroupFromApplication(app));
     }
   }, [appID, application, getGroupFromApplication, groupID, instanceID]);
+
+  React.useEffect(() => {
+    setInstance(null);
+    return () => {
+      instanceRequestID.current += 1;
+    };
+  }, [appID, groupID, instanceID]);
 
   React.useEffect(() => {
     if (!appID) {

--- a/frontend/src/components/layouts/InstanceLayout/InstanceLayout.tsx
+++ b/frontend/src/components/layouts/InstanceLayout/InstanceLayout.tsx
@@ -55,12 +55,10 @@ export default function InstanceLayout() {
     });
     const apps = applicationsStore().getCachedApplications() || [];
     const app = apps.find(({ id }) => id === appID) || null;
-    if (app !== application) {
-      setApplication(app);
-    }
-  }, [appID, application, groupID, instanceID]);
+    setApplication(currentApplication => (app === currentApplication ? currentApplication : app));
+  }, [appID, groupID, instanceID]);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     setInstance(null);
     return () => {
       instanceRequestID.current += 1;

--- a/frontend/src/components/layouts/InstanceLayout/InstanceLayout.tsx
+++ b/frontend/src/components/layouts/InstanceLayout/InstanceLayout.tsx
@@ -22,6 +22,7 @@ export default function InstanceLayout() {
   );
   const [instance, setInstance] = React.useState<Instance | null>(null);
   const instanceRequestID = React.useRef(0);
+  const activeRoute = React.useRef({ appID, groupID, instanceID });
   const { t } = useTranslation();
 
   const getGroupFromApplication = React.useCallback(
@@ -39,6 +40,13 @@ export default function InstanceLayout() {
 
   const onChange = React.useCallback(() => {
     if (!appID || !groupID || !instanceID) {
+      return;
+    }
+    if (
+      activeRoute.current.appID !== appID ||
+      activeRoute.current.groupID !== groupID ||
+      activeRoute.current.instanceID !== instanceID
+    ) {
       return;
     }
 
@@ -59,6 +67,7 @@ export default function InstanceLayout() {
   }, [appID, groupID, instanceID]);
 
   React.useLayoutEffect(() => {
+    activeRoute.current = { appID, groupID, instanceID };
     setInstance(null);
     return () => {
       instanceRequestID.current += 1;


### PR DESCRIPTION
## Description

`InstanceLayout` can remain mounted while its route parameters change. The previous instance then remains visible while the next request is pending, and a late response for the previous route can overwrite the current instance.

Clear the displayed instance when the route identity changes and associate each request with an identifier. Responses belonging to earlier routes are ignored.

Add regression coverage for clearing stale details during navigation and preventing an out-of-order response from replacing the current instance.

Closes #1515

## Testing

- `npm test -- --run src/__tests__/Common/InstanceLayout.spec.tsx`
- `npm test -- --run`
- `npm run tsc`
- Targeted ESLint and Prettier checks
- `npm run build`