### PR TITLE
sessions: mark session cookie Secure and SameSite=Lax

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Debug               bool   `koanf:"debug"`
 	ServerPort          uint   `koanf:"port"`
 	RollbackDBTo        string `koanf:"rollback-db-to"`
+	SecureCookie        bool   `koanf:"secure-cookie"`
 
 	GhClientID        string `koanf:"gh-client-id"`
 	GhClientSecret    string `koanf:"gh-client-secret"`
@@ -145,6 +146,7 @@ func Parse() (*Config, error) {
 	f.String("api-endpoint-suffix", "", "Additional suffix for the API endpoint to serve Omaha clients on; use a secret to only serve your clients, e.g., mysecret results in /v1/update/mysecret")
 	f.Bool("debug", false, "sets log level to debug")
 	f.Uint("port", 8000, "port to run server")
+	f.Bool("secure-cookie", true, "mark the session cookie as Secure (HTTPS only); only disable this if Nebraska is deliberately served over plain HTTP, e.g. behind a trusted TLS-terminating proxy on a private network")
 
 	k := koanf.New(".")
 

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -212,7 +212,7 @@ func setupSessionStore(conf config.Config) *sessions.Store {
 	case "github":
 		cache := memcache.New(memcachegob.New())
 		codec := securecookie.New([]byte(conf.GhSessionAuthKey), []byte(conf.GhSessionCryptKey))
-		return sessions.NewStore(cache, codec)
+		return sessions.NewStore(cache, codec, conf.SecureCookie)
 	}
 	return nil
 }

--- a/backend/pkg/sessions/harness.go
+++ b/backend/pkg/sessions/harness.go
@@ -27,7 +27,7 @@ func (h *TestHarness) RunBasicSessionLifecycleTests() {
 	codec := NewMockCodec()
 	codec.AddIDValueMapping("id1", "val1")
 	cache := h.NewCache()
-	store := NewStore(cache, codec)
+	store := NewStore(cache, codec, true)
 	// new session
 	request1 := newRequest()
 	session1 := store.GetSessionUse(request1, "test")
@@ -63,7 +63,7 @@ func (h *TestHarness) RunDeadCookiesTests() {
 	codec := NewMockCodec()
 	codec.AddIDValueMapping("id1", "val1", "id2", "val2")
 	cache := h.NewCache()
-	store := NewStore(cache, codec)
+	store := NewStore(cache, codec, true)
 
 	// session from cookie
 	request1 := newRequestWithCookie("test", "bogusvalue")

--- a/backend/pkg/sessions/session.go
+++ b/backend/pkg/sessions/session.go
@@ -44,6 +44,7 @@ type Session struct {
 	cache  Cache
 	codec  Codec
 	marked bool
+	secure bool
 }
 
 // Has returns true if the session object contains a value under the
@@ -115,6 +116,8 @@ func (s *Session) Save(writer http.ResponseWriter) error {
 		Path:     "/",
 		MaxAge:   maxAge,
 		HttpOnly: true,
+		Secure:   s.secure,
+		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(writer, cookie)
 	return nil
@@ -155,7 +158,8 @@ func (s sessionExt) Session() *Session {
 }
 
 type sessionBuilder struct {
-	codec Codec
+	codec  Codec
+	secure bool
 }
 
 var _ SessionBuilder = sessionBuilder{}
@@ -169,6 +173,7 @@ func (b sessionBuilder) NewSession(name string, cache Cache) SessionExt {
 			cache:  cache,
 			codec:  b.codec,
 			marked: false,
+			secure: b.secure,
 		},
 	}
 }
@@ -182,6 +187,7 @@ func (b sessionBuilder) NewExistingSession(name, id string, values ValuesType, c
 			cache:  cache,
 			codec:  b.codec,
 			marked: false,
+			secure: b.secure,
 		},
 	}
 }

--- a/backend/pkg/sessions/session_test.go
+++ b/backend/pkg/sessions/session_test.go
@@ -1,6 +1,7 @@
 package sessions
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -81,6 +82,42 @@ func TestSavedExpiredSessionSave(t *testing.T) {
 		assert.Equal(t, "test", cookie.Name)
 		assert.Equal(t, "", cookie.Value)
 		assert.Equal(t, -1, cookie.MaxAge)
+	}
+}
+
+func TestSessionSaveCookieAttributes(t *testing.T) {
+	newSession := func(secure bool) *Session {
+		cache := NewMockCache()
+		codec := NewMockCodec()
+		codec.AddIDValueMapping("id1", "val1")
+		builder := sessionBuilder{codec: codec, secure: secure}
+		return builder.NewSession("test", cache).Session()
+	}
+
+	// A session cookie must always be HttpOnly and SameSite=Lax, and
+	// Secure whenever the store is configured to require it, so it
+	// can't be read by JavaScript, replayed cross-site, or captured
+	// off an unencrypted connection.
+	secureSession := newSession(true)
+	writer := httptest.NewRecorder()
+	assert.NoError(t, secureSession.Save(writer))
+	cookies := writer.Result().Cookies()
+	if assert.Len(t, cookies, 1) {
+		cookie := cookies[0]
+		assert.True(t, cookie.HttpOnly)
+		assert.True(t, cookie.Secure)
+		assert.Equal(t, http.SameSiteLaxMode, cookie.SameSite)
+	}
+
+	insecureSession := newSession(false)
+	writer = httptest.NewRecorder()
+	assert.NoError(t, insecureSession.Save(writer))
+	cookies = writer.Result().Cookies()
+	if assert.Len(t, cookies, 1) {
+		cookie := cookies[0]
+		assert.True(t, cookie.HttpOnly)
+		assert.False(t, cookie.Secure)
+		assert.Equal(t, http.SameSiteLaxMode, cookie.SameSite)
 	}
 }
 

--- a/backend/pkg/sessions/store.go
+++ b/backend/pkg/sessions/store.go
@@ -45,15 +45,20 @@ type Cache interface {
 
 // Store contains cache and codec for session management.
 type Store struct {
-	cache Cache
-	codec Codec
+	cache  Cache
+	codec  Codec
+	secure bool
 }
 
-// NewStore creates a new sessions store.
-func NewStore(cache Cache, codec Codec) *Store {
+// NewStore creates a new sessions store. secure controls whether the
+// Secure flag is set on the session cookie, restricting it to
+// encrypted connections; it should be true unless Nebraska is
+// deliberately served over plain HTTP.
+func NewStore(cache Cache, codec Codec, secure bool) *Store {
 	return &Store{
-		cache: cache,
-		codec: codec,
+		cache:  cache,
+		codec:  codec,
+		secure: secure,
 	}
 }
 
@@ -76,7 +81,8 @@ func (s *Store) GetSessionUse(request *http.Request, name string) *Session {
 		return session
 	}
 	builder := sessionBuilder{
-		codec: s.codec,
+		codec:  s.codec,
+		secure: s.secure,
 	}
 	if id, err := s.getSessionIDFromRequest(request, name); err == nil {
 		if session := s.cache.GetSessionUseByID(builder, id, name); session != nil {


### PR DESCRIPTION
## Why

Session.Save built the session cookie with HttpOnly set but never Secure
or SameSite.

- Without Secure, the cookie is sent over plain HTTP too. Anyone
  observing traffic on shared Wi-Fi, or able to get a browser to load
  any plain `http://` link to the Nebraska host, can capture the cookie
  in readable form and use it to impersonate that user — including an
  admin.
- Without SameSite, another site the user visits can cause their
  browser to send authenticated requests to Nebraska. Modern browsers
  apply a Lax default on their own, but relying on that leaves older
  and differently configured browsers exposed.

## What changed

- `Session.Save` (`backend/pkg/sessions/session.go`) now sets
  `Secure` and `SameSite: http.SameSiteLaxMode` on the cookie.
- `Secure` follows a new `--secure-cookie` flag
  (`config.SecureCookie`, defaults to `true`), since Nebraska can
  legitimately run behind a plain-HTTP reverse proxy in some setups.
  Threaded through `sessions.NewStore` → session builder → `Session`.
- `pkg/server/server.go`'s `setupSessionStore` passes
  `conf.SecureCookie` through — the only real caller, since only the
  `github` auth mode uses cookie sessions today.
- Test harness (`pkg/sessions/harness.go`) updated to pass
  `secure: true` so its own coverage is unchanged.
- Added `TestSessionSaveCookieAttributes`, which exercises
  `Session.Save` with the store configured both ways and asserts
  `HttpOnly`, `Secure`, and `SameSite` on the resulting cookie.

## Note for reviewers

`harness.go` also builds a raw `http.Cookie` in `newRequestWithCookie`,
used to simulate an *incoming* request cookie. I left that alone —
it's only ever passed to `http.Request.AddCookie`, which only reads
`Name`/`Value`, so `Secure`/`SameSite`/`HttpOnly` have no effect on it.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/sessions/... ./pkg/config/... ./pkg/server/...` → 0 issues
- [x] `go test ./pkg/sessions/...` — all pass, including new cookie-attribute test
