### PR TITLE
fix(metrics): migrate to echoprometheus, preserving all metrics

### DIFF
--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/labstack/echo-contrib/prometheus"
+	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	echomiddleware "github.com/oapi-codegen/echo-middleware"
+	"github.com/prometheus/client_golang/prometheus"
 
 	db "github.com/flatcar/nebraska/backend/pkg/api"
 	"github.com/flatcar/nebraska/backend/pkg/api/admin"
@@ -58,8 +59,23 @@ func New(conf *config.Config, db *db.API, adminSvc *admin.Service) (*echo.Echo, 
 		return nil, fmt.Errorf("swagger config error: %w", err)
 	}
 
-	p := prometheus.NewPrometheus(serviceName, nil)
-	p.Use(e)
+	// Register the Echo request metrics on a private registry so that repeated
+	// calls to New() (e.g. in tests) don't panic with duplicate registration on
+	// the default registerer. The /metrics handler gathers from both this
+	// registry and the default gatherer, so Go/process collectors and the
+	// Nebraska business metrics (registered on the default registerer in the
+	// metrics package) are still exposed.
+	metricsRegistry := prometheus.NewRegistry()
+	e.Use(echoprometheus.NewMiddlewareWithConfig(echoprometheus.MiddlewareConfig{
+		Subsystem:  serviceName,
+		Registerer: metricsRegistry,
+		Skipper: func(c echo.Context) bool {
+			return c.Path() == "/metrics"
+		},
+	}))
+	e.GET("/metrics", echoprometheus.NewHandlerWithConfig(echoprometheus.HandlerConfig{
+		Gatherer: prometheus.Gatherers{metricsRegistry, prometheus.DefaultGatherer},
+	}))
 
 	// setup authenticator
 	defaultTeam, err := db.GetTeam()


### PR DESCRIPTION
Replaces the deprecated `echo-contrib/prometheus` package with the maintained `echoprometheus` package (already available in echo-contrib v0.17.4, so no dependency bump — only `server.go` changes).

## Why this instead of #1292 / #1152
Both prior attempts had a defect; this does neither:
- Echo request metrics are registered on a **private registry**, so repeated `server.New()` calls can't panic with duplicate registration on the default registerer.
- The `/metrics` handler gathers from **both** the private registry **and** the default gatherer (`prometheus.Gatherers{registry, prometheus.DefaultGatherer}`), so `go_*`, `process_*` and the Nebraska business metrics (registered on the default registerer in `pkg/metrics`) remain exposed. A private-registry-only handler would have silently dropped them.

## Verification
Live `/metrics` scrape of a running server confirms all families present: `go_` (35), `process_` (9), `nebraska_` business metrics (db connections, instances_per_channel, failed_updates), and echo request metrics (`nebraska_request_*`). `build`, `vet`, and the full test compile pass.

Supersedes #1292 and #1152.
