### PR TITLE
WIP: latest instance stats query + endpoint (LFX mentorship POC)

### DIFF
--- a/backend/pkg/api/internal/dbreads/instances.go
+++ b/backend/pkg/api/internal/dbreads/instances.go
@@ -463,3 +463,30 @@ func (q *Queries) GetInstanceStatsByTimestamp(t time.Time) ([]types.InstanceStat
 
 	return instances, nil
 }
+
+// GetLatestInstanceStatsTimestamp returns the MAX(timestamp) from instance_stats.
+func (q *Queries) GetLatestInstanceStatsTimestamp() (time.Time, error) {
+	var t time.Time
+	query, _, err := goqu.From("instance_stats").
+		Select(goqu.MAX("timestamp")).ToSQL()
+	if err != nil {
+		return t, err
+	}
+
+	err = q.db.QueryRowx(query).Scan(&t)
+	if err != nil {
+		return t, err
+	}
+
+	return t, nil
+}
+
+// GetInstanceStatsLatest returns an InstanceStats array of instances matching the
+// latest timestamp, ordered by version.
+func (q *Queries) GetInstanceStatsLatest() ([]types.InstanceStats, error) {
+	t, err := q.GetLatestInstanceStatsTimestamp()
+	if err != nil {
+		return nil, err
+	}
+	return q.GetInstanceStatsByTimestamp(t.UTC())
+}

--- a/backend/pkg/api/internal/dbreads/instances_test.go
+++ b/backend/pkg/api/internal/dbreads/instances_test.go
@@ -1,0 +1,47 @@
+package dbreads_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flatcar/nebraska/backend/pkg/api"
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbreads"
+)
+
+func TestGetInstanceStatsLatest(t *testing.T) {
+	a, err := api.NewForTest(api.OptionInitDB, api.OptionDisableUpdatesOnFailedRollout)
+	require.NoError(t, err)
+	defer a.Close()
+
+	db := dbreads.DB(a.Queries)
+
+	// 1. Seed two different timestamps
+	ts1 := time.Now().UTC().Add(-1 * time.Hour)
+	ts2 := time.Now().UTC()
+
+	_, err = db.Exec(`INSERT INTO instance_stats (timestamp, channel_name, arch, version, instances) VALUES ($1, $2, $3, $4, $5)`, ts1, "channel", "AMD64", "1.0.0", 1)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`INSERT INTO instance_stats (timestamp, channel_name, arch, version, instances) VALUES ($1, $2, $3, $4, $5)`, ts2, "channel", "AMD64", "1.0.1", 2)
+	require.NoError(t, err)
+
+	// Get latest stats
+	instanceStats, err := a.GetInstanceStatsLatest()
+	assert.NoError(t, err)
+	require.NotEmpty(t, instanceStats, "GetInstanceStatsLatest returned 0 items. This is likely due to the known timezone offset dropping bug in GetInstanceStatsByTimestamp's timestamp cast.")
+
+	assert.Equal(t, 1, len(instanceStats))
+	for _, stat := range instanceStats {
+		maxTs, err := a.GetLatestInstanceStatsTimestamp()
+		assert.NoError(t, err)
+		
+		// Postgres might truncate microseconds, check with diff <= 1 sec
+		assert.WithinDuration(t, maxTs, stat.Timestamp, time.Second)
+		assert.WithinDuration(t, ts2, maxTs, time.Second)
+		assert.Equal(t, "1.0.1", stat.Version)
+		assert.Equal(t, 2, stat.Instances)
+	}
+}


### PR DESCRIPTION
Exploring the "monitoring coverage" candidate area from flatcar/Flatcar#2239 as part of looking into the LFX mentorship. Builds on the read-query work already merged (GetInstanceStats / GetInstanceStatsByTimestamp) rather than duplicating it also relevant to the still-open #665.

## Progress
- [x] GetInstanceStatsLatest query (dbreads), composing existing
      GetLatestInstanceStatsTimestamp + GetInstanceStatsByTimestamp
- [ ] /api/instances_stats/latest REST endpoint (spec.yaml + codegen + handler)
- [ ] Prometheus metric (pkg/metrics), stretch goal

## Note: found a latent bug while testing
GetInstanceStatsByTimestamp casts its literal to `timestamp` (no timezone) rather than `timestamptz`. Postgres then reinterprets the resulting bare clock digits using the session's timezone, which silently returns 0 rows whenever the caller's local time isn't
UTC  no error, just an empty result. Confirmed via direct psql comparison outside Go. Worked around it in the new GetInstanceStatsLatest by normalizing to t.UTC() before calling GetInstanceStatsByTimestamp, without touching that existing function (kept out of scope here). Happy to open this as a separate issue/fix if useful.

This is a draft  still WIP, opening early so progress is visible as I go.
