### PR TITLE
syncer: guard against index-out-of-bounds panic on empty Omaha response

### DIFF
--- a/backend/pkg/syncer/syncer.go
+++ b/backend/pkg/syncer/syncer.go
@@ -163,13 +163,17 @@ func (s *Syncer) Start() {
 	l.Debug().Msg("syncer ready!")
 	s.ticker = time.NewTicker(s.checkFrequency)
 
-	_ = s.checkForUpdates()
+	if err := s.checkForUpdates(); err != nil {
+		l.Error().Err(err).Msg("syncer: initial check for updates failed")
+	}
 
 L:
 	for {
 		select {
 		case <-s.ticker.C:
-			_ = s.checkForUpdates()
+			if err := s.checkForUpdates(); err != nil {
+				l.Error().Err(err).Msg("syncer: periodic check for updates failed")
+			}
 		case <-s.stopCh:
 			break L
 		}

--- a/backend/pkg/syncer/syncer.go
+++ b/backend/pkg/syncer/syncer.go
@@ -297,6 +297,10 @@ func (s *Syncer) doOmahaRequest(descriptor channelDescriptor, currentVersion str
 		return nil, err
 	}
 
+	if len(oresp.Apps) == 0 {
+		return nil, fmt.Errorf("omaha response contains no apps")
+	}
+
 	return oresp.Apps[0].UpdateCheck, nil
 }
 
@@ -430,6 +434,9 @@ func (s *Syncer) createPackage(
 	}
 
 	// Determine URL and filename
+	if len(update.URLs) == 0 {
+		return nil, fmt.Errorf("omaha update response contains no URLs for version %s", manifest.Version)
+	}
 	url := update.URLs[0].CodeBase
 	filename := omahaPkg.Name
 
@@ -754,6 +761,9 @@ func (s *Syncer) downloadPackage(update *omaha.UpdateResponse, pkgName, sha1Base
 	}
 	defer os.Remove(tmpFile.Name())
 
+	if len(update.URLs) == 0 {
+		return fmt.Errorf("omaha update response contains no URLs")
+	}
 	updateURL, err := url.Parse(update.URLs[0].CodeBase)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

`doOmahaRequest()`, `createPackage()`, and `downloadPackage()` accessed slice index `[0]` without checking the length first. A malformed Omaha response with no apps or no URLs caused an index-out-of-bounds panic, crashing Nebraska entirely.

## Before vs After

Before — unguarded slice access panics:

return oresp.Apps[0].UpdateCheck, nil     // panics if Apps is empty
url := update.URLs[0].CodeBase            // panics if URLs is empty
url.Parse(update.URLs[0].CodeBase)        // panics if URLs is empty

→ runtime error: index out of range [0] with length 0
→ Nebraska crashes, all updates stop

After — bounds check returns clean error:

if len(oresp.Apps) == 0 {
    return nil, fmt.Errorf("omaha response contains no apps")
}
if len(update.URLs) == 0 {
    return nil, fmt.Errorf("omaha update response contains no URLs")
}

→ syncer logs the error and keeps running
→ next sync attempt happens on the next tick

## Changes

- `backend/pkg/syncer/syncer.go` — added 3 bounds checks before unguarded slice accesses

## How to use

cd backend && go build ./pkg/syncer/...

## Testing done

Full Nebraska stack built and run via Docker Compose. Build version: staging-36-g33699e2f

$ docker compose -f backend/docker-compose.test.yaml up -d --build
✅ Build successful - zero errors

Server running on port 8002:

nebraska_open_db_connections 1    ✅
nebraska_idle_db_connections 1    ✅
nebraska_in_use_db_connections 0  ✅

Nebraska starts cleanly with the bounds checks in place.

Fixes #1526
