### PR TITLE
fix(updater): correct event type on installation finished

### DIFF
--- a/updater/updater.go
+++ b/updater/updater.go
@@ -66,7 +66,7 @@ func progressToEventRequest(p progress) *omaha.EventRequest {
 		}
 	case ProgressInstallationFinished:
 		return &omaha.EventRequest{
-			Type:   omaha.EventTypeInstallStarted,
+			Type:   omaha.EventTypeInstallComplete,
 			Result: omaha.EventResultSuccess,
 		}
 	case ProgressError:

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -277,3 +277,10 @@ func TestTryUpdate(t *testing.T) {
 		assert.ErrorIs(t, err, NoUpdateError{AppID: appID, Channel: group.Track, UpdateStatus: "noupdate"})
 	})
 }
+
+func TestProgressToEventRequest(t *testing.T) {
+	req := progressToEventRequest(ProgressInstallationFinished)
+	require.NotNil(t, req)
+	assert.Equal(t, omahaSpec.EventTypeInstallComplete, req.Type)
+	assert.Equal(t, omahaSpec.EventResultSuccess, req.Result)
+}


### PR DESCRIPTION
In `updater.go`, `progressToEventRequest` was previously mapping `ProgressInstallationFinished` to `EventTypeInstallStarted`, likely due to a copy-paste error from the preceding `ProgressInstallationStarted` case. This resulted in the client erroneously reporting the installation as starting twice instead of signaling its completion.

I've updated the event mapping to use the correct `omaha.EventTypeUpdateComplete` constant and added a corresponding unit test to ensure we don't regress on this behavior.
