### PR TITLE
test(api): assert group and channel fields in TestAddAppCloning

### DIFF
--- a/backend/pkg/api/applications_test.go
+++ b/backend/pkg/api/applications_test.go
@@ -59,8 +59,10 @@ func TestAddAppCloning(t *testing.T) {
 	assert.Equal(t, len(sourceApp.Channels), len(clonedAppX.Channels))
 
 	// Verify cloned channel fields
-	assert.Equal(t, tChannel.Name, clonedAppX.Channels[0].Name)
-	assert.Equal(t, tChannel.Color, clonedAppX.Channels[0].Color)
+	if assert.NotEmpty(t, clonedAppX.Channels) {
+		assert.Equal(t, tChannel.Name, clonedAppX.Channels[0].Name)
+		assert.Equal(t, tChannel.Color, clonedAppX.Channels[0].Color)
+	}
 
 	// Verify cloned group fields and linked channel ID
 	var groupWithChannel *Group
@@ -70,14 +72,15 @@ func TestAddAppCloning(t *testing.T) {
 			break
 		}
 	}
-	assert.NotNil(t, groupWithChannel)
-	assert.True(t, groupWithChannel.ChannelID.Valid)
-	assert.Equal(t, clonedAppX.Channels[0].ID, groupWithChannel.ChannelID.String)
-	assert.True(t, groupWithChannel.PolicyUpdatesEnabled)
-	assert.True(t, groupWithChannel.PolicySafeMode)
-	assert.Equal(t, "15 minutes", groupWithChannel.PolicyPeriodInterval)
-	assert.Equal(t, 2, groupWithChannel.PolicyMaxUpdatesPerPeriod)
-	assert.Equal(t, "60 minutes", groupWithChannel.PolicyUpdateTimeout)
+	if assert.NotNil(t, groupWithChannel) && assert.NotEmpty(t, clonedAppX.Channels) {
+		assert.True(t, groupWithChannel.ChannelID.Valid)
+		assert.Equal(t, clonedAppX.Channels[0].ID, groupWithChannel.ChannelID.String)
+		assert.True(t, groupWithChannel.PolicyUpdatesEnabled)
+		assert.True(t, groupWithChannel.PolicySafeMode)
+		assert.Equal(t, "15 minutes", groupWithChannel.PolicyPeriodInterval)
+		assert.Equal(t, 2, groupWithChannel.PolicyMaxUpdatesPerPeriod)
+		assert.Equal(t, "60 minutes", groupWithChannel.PolicyUpdateTimeout)
+	}
 
 	_, err = as.AddAppCloning(&Application{Name: "app2", TeamID: tTeam.ID}, "")
 	assert.NoError(t, err, "Using an empty source app id when cloning has the same effect as not cloning.")

--- a/backend/pkg/api/applications_test.go
+++ b/backend/pkg/api/applications_test.go
@@ -58,7 +58,26 @@ func TestAddAppCloning(t *testing.T) {
 	assert.Equal(t, len(sourceApp.Groups), len(clonedAppX.Groups))
 	assert.Equal(t, len(sourceApp.Channels), len(clonedAppX.Channels))
 
-	// TODO: test specific fields in groups and channels (do not forget channel id in group!)
+	// Verify cloned channel fields
+	assert.Equal(t, tChannel.Name, clonedAppX.Channels[0].Name)
+	assert.Equal(t, tChannel.Color, clonedAppX.Channels[0].Color)
+
+	// Verify cloned group fields and linked channel ID
+	var groupWithChannel *Group
+	for _, g := range clonedAppX.Groups {
+		if g.Name == "group1" {
+			groupWithChannel = g
+			break
+		}
+	}
+	assert.NotNil(t, groupWithChannel)
+	assert.True(t, groupWithChannel.ChannelID.Valid)
+	assert.Equal(t, clonedAppX.Channels[0].ID, groupWithChannel.ChannelID.String)
+	assert.True(t, groupWithChannel.PolicyUpdatesEnabled)
+	assert.True(t, groupWithChannel.PolicySafeMode)
+	assert.Equal(t, "15 minutes", groupWithChannel.PolicyPeriodInterval)
+	assert.Equal(t, 2, groupWithChannel.PolicyMaxUpdatesPerPeriod)
+	assert.Equal(t, "60 minutes", groupWithChannel.PolicyUpdateTimeout)
 
 	_, err = as.AddAppCloning(&Application{Name: "app2", TeamID: tTeam.ID}, "")
 	assert.NoError(t, err, "Using an empty source app id when cloning has the same effect as not cloning.")


### PR DESCRIPTION
### Summary
Fixes #1530

This PR resolves a longstanding `TODO` in `backend/pkg/api/applications_test.go` within `TestAddAppCloning`.

### Context & Problem
Previously, `TestAddAppCloning` only asserted the count/length of groups and channels cloned from a source application. It did not verify whether individual field attributes (such as channel properties, group policy parameters, and linked channel IDs) were accurately copied over to the newly cloned application structure.

### Changes Made
- Added explicit assertions to ensure cloned channels maintain the source channel's `Name` and `Color`.
- Added explicit assertions for cloned group policy fields (`PolicyUpdatesEnabled`, `PolicySafeMode`, `PolicyPeriodInterval`, `PolicyMaxUpdatesPerPeriod`, and `PolicyUpdateTimeout`).
- Added assertion to verify that the group's `ChannelID` is valid and points specifically to the newly cloned channel's ID.

### Checklist
- [x] Code passes linting (`golangci-lint`)
- [x] Code changes pass unit test suite
- [x] Commit contains DCO `Signed-off-by` header
