### PR TITLE
docs: update Apache 2.0 license URL to HTTPS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For instructions on how to set up user access, please check the [authorization d
 
 ## License
 
-Nebraska is released under the terms of the [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0), and was forked from the [CoreRoller](https://github.com/coreroller/coreroller) project.
+Nebraska is released under the terms of the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0), and was forked from the [CoreRoller](https://github.com/coreroller/coreroller) project.
 
 ---
 


### PR DESCRIPTION
### Summary
Fixes #1532 

Updates the Apache 2.0 license link in `README.md` from `http://` to `https://`.

### Changes Made
- Changed `http://www.apache.org/licenses/LICENSE-2.0` to `https://www.apache.org/licenses/LICENSE-2.0` in `README.md`.

### Checklist
- [x] Documentation updated
- [x] Commit contains DCO `Signed-off-by` header
