### PR TITLE
dbreads: close rows in GetGroupVersionCountTimeline

### DIFF
--- a/backend/pkg/api/internal/dbreads/groups.go
+++ b/backend/pkg/api/internal/dbreads/groups.go
@@ -537,14 +537,18 @@ func (q *Queries) GetGroupVersionCountTimeline(groupID string, duration string) 
 		if err != nil {
 			return err
 		}
+		defer versionAggRows.Close()
 
 		for versionAggRows.Next() {
 			vc := versionCount{}
-			err = versionAggRows.StructScan(&vc)
-			if err != nil {
+			if err := versionAggRows.StructScan(&vc); err != nil {
 				return err
 			}
 			versionCounts = append(versionCounts, vc)
+		}
+
+		if err := versionAggRows.Err(); err != nil {
+			return err
 		}
 
 		return nil


### PR DESCRIPTION
Fixes #1539

The third query goroutine in GetGroupVersionCountTimeline never closed its result set, so when StructScan fails the goroutine returns without releasing the pooled connection. The other two goroutines in the same function already defer a close.

Also added a rows.Err() check, so a query that fails part way through iteration is reported instead of returning partial version counts as a success.

No test added asserting connection release isn't practical in Go, and the change follows the pattern already used by the sibling goroutines.