### PR TITLE
random: add error-returning DataE and StringE variants

### DIFF
--- a/backend/pkg/random/random.go
+++ b/backend/pkg/random/random.go
@@ -9,26 +9,49 @@ import (
 // deterministic.
 var randRead = rand.Read
 
-// Data returns a slice with n random bytes.
-func Data(n int) []byte {
+// DataE returns a slice with n random bytes, or an error if the random source fails.
+func DataE(n int) ([]byte, error) {
 	if n < 1 {
-		return nil
+		return nil, nil
 	}
 	data := make([]byte, n)
 	if _, err := randRead(data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// Data returns a slice with n random bytes.
+func Data(n int) []byte {
+	data, err := DataE(n)
+	if err != nil {
 		// docs say that the error doesn't happen
 		panic(err)
 	}
 	return data
 }
 
+// StringE returns a string with n random characters, or an error if the random source fails.
+// The characters are based on base32 encoding, containing characters from A-Z and digits from 2 to 7.
+func StringE(n int) (string, error) {
+	if n < 1 {
+		return "", nil
+	}
+	dataN := ((n-1)/8 + 1) * 5
+	data, err := DataE(dataN)
+	if err != nil {
+		return "", err
+	}
+	return base32.StdEncoding.EncodeToString(data)[0:n], nil
+}
+
 // String returns a string with n random characters. The characters
 // are base on base32 encoding, so string will contain characters from
 // A-Z and digits from 2 to 7.
 func String(n int) string {
-	if n < 1 {
-		return ""
+	str, err := StringE(n)
+	if err != nil {
+		panic(err)
 	}
-	dataN := ((n-1)/8 + 1) * 5
-	return base32.StdEncoding.EncodeToString(Data(dataN))[0:n]
+	return str
 }

--- a/backend/pkg/random/random_test.go
+++ b/backend/pkg/random/random_test.go
@@ -1,6 +1,7 @@
 package random
 
 import (
+	"errors"
 	"os"
 	"testing"
 )
@@ -54,6 +55,14 @@ func TestRandomData(t *testing.T) {
 		if !byteSliceEqual(tt.output, got) {
 			t.Errorf("For n = %d, expected %#v, got %#v", tt.n, tt.output, got)
 		}
+
+		gotE, err := DataE(tt.n)
+		if err != nil {
+			t.Errorf("DataE returned unexpected error for n = %d: %v", tt.n, err)
+		}
+		if !byteSliceEqual(tt.output, gotE) {
+			t.Errorf("DataE for n = %d, expected %#v, got %#v", tt.n, tt.output, gotE)
+		}
 	}
 }
 
@@ -103,6 +112,34 @@ func TestRandomString(t *testing.T) {
 		if tt.output != got {
 			t.Errorf("For n = %d, expected %s, got %s", tt.n, tt.output, got)
 		}
+
+		gotE, err := StringE(tt.n)
+		if err != nil {
+			t.Errorf("StringE returned unexpected error for n = %d: %v", tt.n, err)
+		}
+		if tt.output != gotE {
+			t.Errorf("StringE for n = %d, expected %s, got %s", tt.n, tt.output, gotE)
+		}
+	}
+}
+
+func TestRandomDataEError(t *testing.T) {
+	origRandRead := randRead
+	defer func() { randRead = origRandRead }()
+
+	errMock := errors.New("mock randRead failure")
+	randRead = func(b []byte) (int, error) {
+		return 0, errMock
+	}
+
+	_, err := DataE(10)
+	if !errors.Is(err, errMock) {
+		t.Errorf("expected error %v, got %v", errMock, err)
+	}
+
+	_, err = StringE(10)
+	if !errors.Is(err, errMock) {
+		t.Errorf("expected error %v, got %v", errMock, err)
 	}
 }
 


### PR DESCRIPTION
The `Data()` and `String()` functions in `backend/pkg/random/random.go` panic if the underlying `randRead` (`crypto/rand.Read`) call returns an error. In restricted container environments or environments with entropy starvation, this causes an unrecoverable process crash instead of a recoverable error response.

This PR introduces `DataE()` and `StringE()` functions that return `(result, error)`, allowing callers throughout Nebraska to handle randomness failures gracefully. The original `Data()` and `String()` functions are retained as backwards-compatible wrappers.

Fixes: #1536

## How to use

Reviewers can validate this PR by running the backend unit test suite in the `backend/` directory:

```bash
cd backend && go test -v ./pkg/random/...