### PR TITLE
syncer: add Email and Webhook notifications on public server sync

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -54,6 +54,14 @@ type Config struct {
 	OidcUseUserInfo   bool   `koanf:"oidc-use-userinfo"`
 	CAFile            string `koanf:"ca-file"`
 	CACertPool        *x509.CertPool
+
+	NotificationEmailFrom  string `koanf:"sync-notification-email-from"`
+	NotificationEmailTo    string `koanf:"sync-notification-email-to"`
+	NotificationSMTPHost   string `koanf:"sync-notification-smtp-host"`
+	NotificationSMTPPort   int    `koanf:"sync-notification-smtp-port"`
+	NotificationSMTPUser   string `koanf:"sync-notification-smtp-user"`
+	NotificationSMTPPass   string `koanf:"sync-notification-smtp-pass"`
+	NotificationWebhookURL string `koanf:"sync-notification-webhook-url"`
 }
 
 const (
@@ -139,6 +147,13 @@ func Parse() (*Config, error) {
 	f.String("ca-file", "", "path to a PEM-encoded CA certificate file to trust for TLS verification (additive to system CAs, supports multiple certs in one file)")
 	f.String("sync-update-url", "https://public.update.flatcar-linux.net/v1/update/", "Flatcar update URL to sync from")
 	f.String("sync-interval", "1h", "Sync check interval (the minimum depends on the number of channels to sync, e.g., 8m for 8 channels incl. different architectures)")
+	f.String("sync-notification-email-from", "", "Email address to send sync notifications from")
+	f.String("sync-notification-email-to", "", "Comma-separated list of email addresses to send sync notifications to")
+	f.String("sync-notification-smtp-host", "", "SMTP host for sending sync notification emails")
+	f.Int("sync-notification-smtp-port", 25, "SMTP port for sending sync notification emails")
+	f.String("sync-notification-smtp-user", "", "SMTP username")
+	f.String("sync-notification-smtp-pass", "", "SMTP password")
+	f.String("sync-notification-webhook-url", "", "Webhook URL (e.g. Slack/Teams/HTTP) to send sync notifications to")
 	f.String("client-logo", "", "Client app logo, should be a path to svg file")
 	f.String("client-title", "", "Client app title")
 	f.String("client-header-style", "light", "Client app header style, should be either dark or light")

--- a/backend/pkg/notifier/notifier.go
+++ b/backend/pkg/notifier/notifier.go
@@ -1,0 +1,145 @@
+package notifier
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/smtp"
+	"strings"
+	"time"
+
+	"github.com/flatcar/nebraska/backend/pkg/logger"
+)
+
+var l = logger.New("notifier")
+
+// SyncEvent represents the payload sent when a new package is synced.
+type SyncEvent struct {
+	Channel  string    `json:"channel"`
+	Arch     string    `json:"arch"`
+	Version  string    `json:"version"`
+	Filename string    `json:"filename"`
+	SyncedAt time.Time `json:"synced_at"`
+}
+
+// Notifier defines the interface for dispatching notifications on sync events.
+type Notifier interface {
+	NotifySync(event SyncEvent) error
+}
+
+// Config holds settings for notification dispatchers.
+type Config struct {
+	EmailFrom  string
+	EmailTo    []string
+	SMTPHost   string
+	SMTPPort   int
+	SMTPUser   string
+	SMTPPass   string
+	WebhookURL string
+}
+
+type multiNotifier struct {
+	notifiers []Notifier
+}
+
+// New creates a combined Notifier from the given configuration.
+func New(conf Config) Notifier {
+	var notifiers []Notifier
+	if conf.SMTPHost != "" && len(conf.EmailTo) > 0 {
+		notifiers = append(notifiers, newEmailNotifier(conf))
+	}
+	if conf.WebhookURL != "" {
+		notifiers = append(notifiers, newWebhookNotifier(conf.WebhookURL))
+	}
+	return &multiNotifier{notifiers: notifiers}
+}
+
+func (m *multiNotifier) NotifySync(event SyncEvent) error {
+	var errs []string
+	for _, n := range m.notifiers {
+		if err := n.NotifySync(event); err != nil {
+			l.Error().Err(err).Msg("failed to send notification")
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("notification errors: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+type emailNotifier struct {
+	conf Config
+	sendMail func(addr string, a smtp.Auth, from string, to []string, msg []byte) error
+}
+
+func newEmailNotifier(conf Config) *emailNotifier {
+	return &emailNotifier{
+		conf:     conf,
+		sendMail: smtp.SendMail,
+	}
+}
+
+func (e *emailNotifier) NotifySync(event SyncEvent) error {
+	subject := fmt.Sprintf("[Nebraska] New Flatcar package synced: %s (%s, %s)", event.Version, event.Channel, event.Arch)
+	body := fmt.Sprintf("A new Flatcar package has been successfully synced in Nebraska.\n\n"+
+		"Channel: %s\n"+
+		"Architecture: %s\n"+
+		"Version: %s\n"+
+		"Filename: %s\n"+
+		"Synced At: %s\n",
+		event.Channel, event.Arch, event.Version, event.Filename, event.SyncedAt.Format(time.RFC1123))
+
+	msg := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n%s",
+		e.conf.EmailFrom, strings.Join(e.conf.EmailTo, ","), subject, body)
+
+	addr := fmt.Sprintf("%s:%d", e.conf.SMTPHost, e.conf.SMTPPort)
+	var auth smtp.Auth
+	if e.conf.SMTPUser != "" {
+		auth = smtp.PlainAuth("", e.conf.SMTPUser, e.conf.SMTPPass, e.conf.SMTPHost)
+	}
+
+	return e.sendMail(addr, auth, e.conf.EmailFrom, e.conf.EmailTo, []byte(msg))
+}
+
+type webhookNotifier struct {
+	webhookURL string
+	client     *http.Client
+}
+
+func newWebhookNotifier(webhookURL string) *webhookNotifier {
+	return &webhookNotifier{
+		webhookURL: webhookURL,
+		client:     &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (w *webhookNotifier) NotifySync(event SyncEvent) error {
+	payload := map[string]interface{}{
+		"text":      fmt.Sprintf("New Flatcar package synced: *%s* (Channel: %s, Arch: %s)", event.Version, event.Channel, event.Arch),
+		"event":     "package_synced",
+		"channel":   event.Channel,
+		"arch":      event.Arch,
+		"version":   event.Version,
+		"filename":  event.Filename,
+		"synced_at": event.SyncedAt.Format(time.RFC3339),
+	}
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	resp, err := w.client.Post(w.webhookURL, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("webhook endpoint returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/backend/pkg/notifier/notifier_test.go
+++ b/backend/pkg/notifier/notifier_test.go
@@ -1,0 +1,74 @@
+package notifier
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/smtp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmailNotifier(t *testing.T) {
+	sent := false
+	n := newEmailNotifier(Config{
+		EmailFrom: "nebraska@example.com",
+		EmailTo:   []string{"admin@example.com"},
+		SMTPHost:  "smtp.example.com",
+		SMTPPort:  25,
+	})
+
+	n.sendMail = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		sent = true
+		assert.Equal(t, "smtp.example.com:25", addr)
+		assert.Equal(t, "nebraska@example.com", from)
+		assert.Equal(t, []string{"admin@example.com"}, to)
+		assert.Contains(t, string(msg), "Subject: [Nebraska] New Flatcar package synced: 3578.0.0 (stable, amd64)")
+		return nil
+	}
+
+	err := n.NotifySync(SyncEvent{
+		Channel:  "stable",
+		Arch:     "amd64",
+		Version:  "3578.0.0",
+		Filename: "flatcar-amd64-3578.0.0.gz",
+		SyncedAt: time.Now(),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, sent)
+}
+
+func TestWebhookNotifier(t *testing.T) {
+	received := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var payload map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&payload)
+		require.NoError(t, err)
+		assert.Equal(t, "3578.0.0", payload["version"])
+		assert.Equal(t, "stable", payload["channel"])
+		assert.Equal(t, "amd64", payload["arch"])
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	n := newWebhookNotifier(server.URL)
+	err := n.NotifySync(SyncEvent{
+		Channel:  "stable",
+		Arch:     "amd64",
+		Version:  "3578.0.0",
+		Filename: "flatcar-amd64-3578.0.0.gz",
+		SyncedAt: time.Now(),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, received)
+}

--- a/backend/pkg/syncer/syncer.go
+++ b/backend/pkg/syncer/syncer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/flatcar/nebraska/backend/pkg/api/admin"
 	"github.com/flatcar/nebraska/backend/pkg/config"
 	"github.com/flatcar/nebraska/backend/pkg/logger"
+	"github.com/flatcar/nebraska/backend/pkg/notifier"
 	"github.com/flatcar/nebraska/backend/pkg/tlsutil"
 )
 
@@ -71,6 +72,7 @@ type Syncer struct {
 	channelsIDs       map[channelDescriptor]string
 	httpClient        *http.Client
 	ticker            *time.Ticker
+	notifier          notifier.Notifier
 }
 
 // Config represents the configuration used to create a new Syncer instance.
@@ -83,6 +85,7 @@ type Config struct {
 	FlatcarUpdatesURL string
 	CheckFrequency    time.Duration
 	HTTPClient        *http.Client
+	Notifier          notifier.Notifier
 }
 
 // Setup creates a new syncer from config and db connection, and returns it.
@@ -98,6 +101,25 @@ func Setup(conf *config.Config, db *api.API, adminSvc *admin.Service) (*Syncer, 
 		conf.SyncerPkgsURL = conf.NebraskaURL + "/flatcar/"
 	}
 
+	var emailTo []string
+	if conf.NotificationEmailTo != "" {
+		for _, email := range strings.Split(conf.NotificationEmailTo, ",") {
+			if trimmed := strings.TrimSpace(email); trimmed != "" {
+				emailTo = append(emailTo, trimmed)
+			}
+		}
+	}
+
+	syncerNotifier := notifier.New(notifier.Config{
+		EmailFrom:  conf.NotificationEmailFrom,
+		EmailTo:    emailTo,
+		SMTPHost:   conf.NotificationSMTPHost,
+		SMTPPort:   conf.NotificationSMTPPort,
+		SMTPUser:   conf.NotificationSMTPUser,
+		SMTPPass:   conf.NotificationSMTPPass,
+		WebhookURL: conf.NotificationWebhookURL,
+	})
+
 	syncer, err := New(&Config{
 		API:               db,
 		Admin:             adminSvc,
@@ -107,6 +129,7 @@ func Setup(conf *config.Config, db *api.API, adminSvc *admin.Service) (*Syncer, 
 		FlatcarUpdatesURL: conf.FlatcarUpdatesURL,
 		CheckFrequency:    checkFrequency,
 		HTTPClient:        httpClient,
+		Notifier:          syncerNotifier,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error setting up syncer: %w", err)
@@ -144,6 +167,7 @@ func New(conf *Config) (*Syncer, error) {
 		channelsIDs:       make(map[channelDescriptor]string, 8),
 		versions:          make(map[channelDescriptor]string, 8),
 		httpClient:        conf.HTTPClient,
+		notifier:          conf.Notifier,
 	}
 
 	if s.httpClient == nil {
@@ -549,6 +573,18 @@ func (s *Syncer) updateChannelToPackage(
 		Str("arch", descriptor.arch.String()).
 		Str("newVersion", pkg.Version).
 		Msg("Updated channel to new version")
+
+	if s.notifier != nil {
+		if errNotif := s.notifier.NotifySync(notifier.SyncEvent{
+			Channel:  descriptor.name,
+			Arch:     descriptor.arch.String(),
+			Version:  pkg.Version,
+			Filename: pkg.Filename.String,
+			SyncedAt: time.Now(),
+		}); errNotif != nil {
+			l.Error().Err(errNotif).Msg("failed to dispatch sync notification")
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Add support for dispatching Email (SMTP) and Webhook (Slack/HTTP) notifications when Nebraska's syncer processes updates and creates/updates Flatcar packages.

When Nebraska's syncer checks official Flatcar channels for updates and creates or updates packages, it can now dispatch notifications detailing the new package version, channel, architecture, filename, and timestamp.

Includes configuration flags:
- sync-notification-email-from
- sync-notification-email-to
- sync-notification-smtp-host
- sync-notification-smtp-port
- sync-notification-smtp-user
- sync-notification-smtp-pass
- sync-notification-webhook-url

Fixes: flatcar/nebraska#354

## How to use

Reviewers can validate this PR by running the notification package unit tests in the backend directory:

```bash
cd backend && go test -v ./pkg/notifier/...