### PR TITLE
fix(omaha): continue processing remaining apps on unknown app ID or group

### DIFF
--- a/backend/pkg/omaha/omaha.go
+++ b/backend/pkg/omaha/omaha.go
@@ -119,7 +119,7 @@ func (h *Handler) buildOmahaResponse(omahaReq *omahaSpec.Request, ip string) (*o
 			respApp.Status = h.getStatusMessage(err)
 			respApp.AddUpdateCheck(omahaSpec.UpdateInternalError)
 
-			return omahaResp, nil
+			continue
 		}
 
 		respApp = omahaResp.AddApp(reqApp.ID, omahaSpec.AppOK)
@@ -137,7 +137,7 @@ func (h *Handler) buildOmahaResponse(omahaReq *omahaSpec.Request, ip string) (*o
 			l.Info().Str("machineId", reqApp.MachineID).Str("track", group).Msgf("buildOmahaResponse - no group found for track and arch error %s", err.Error())
 			respApp.Status = h.getStatusMessage(err)
 			respApp.AddUpdateCheck(omahaSpec.UpdateInternalError)
-			return omahaResp, nil
+			continue
 		}
 
 		for _, event := range reqApp.Events {

--- a/backend/pkg/omaha/omaha_test.go
+++ b/backend/pkg/omaha/omaha_test.go
@@ -278,6 +278,82 @@ func TestProductIDBasedRequest(t *testing.T) {
 	checkOmahaResponse(t, omahaResp, *tApp.ProductID.Ptr(), omahaSpec.AppOK)
 }
 
+func TestMultiAppRequestWithInvalidApp(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	h := NewHandler(a)
+	as := adminSvc(a)
+
+	tTeam, _ := as.AddTeam(&api.Team{Name: "test_team"})
+	tApp, _ := as.AddApp(&api.Application{Name: "test_app", Description: "Test app", TeamID: tTeam.ID})
+	tPkg, _ := as.AddPackage(&api.Package{Type: api.PkgTypeFlatcar, URL: "http://sample.url/pkg", Version: "640.0.0", ApplicationID: tApp.ID, Arch: api.ArchAMD64})
+	tChannel, _ := as.AddChannel(&api.Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID, PackageID: null.StringFrom(tPkg.ID), Arch: api.ArchAMD64})
+	tGroup, _ := as.AddGroup(&api.Group{Name: "test_group", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: false, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 4, PolicyUpdateTimeout: "60 minutes"})
+
+	validUnregisteredIP := "127.0.0.1"
+	validUnregisteredMachineID := "some-machine-id"
+	validUnverifiedAppVersion := "100.0.1"
+	addPing := false
+	updateCheck := true
+
+	// Create a multi-app request: first app invalid, second app valid
+	omahaReq := omahaSpec.NewRequest()
+	omahaReq.OS.Version = reqVersion
+	omahaReq.OS.Platform = reqPlatform
+	omahaReq.OS.ServicePack = reqSp
+	omahaReq.OS.Arch = reqArch
+
+	// First app: invalid ID
+	appReq1 := omahaReq.AddApp("invalid-app-uuid", validUnverifiedAppVersion)
+	appReq1.MachineID = validUnregisteredMachineID
+	appReq1.Track = tGroup.ID
+	if updateCheck {
+		appReq1.AddUpdateCheck()
+	}
+	if addPing {
+		appReq1.AddPing()
+	}
+
+	// Second app: valid ID
+	appReq2 := omahaReq.AddApp(tApp.ID, validUnverifiedAppVersion)
+	appReq2.MachineID = validUnregisteredMachineID
+	appReq2.Track = tGroup.ID
+	if updateCheck {
+		appReq2.AddUpdateCheck()
+	}
+	if addPing {
+		appReq2.AddPing()
+	}
+
+	omahaReqXML, err := xml.Marshal(omahaReq)
+	require.NoError(t, err)
+
+	omahaRespXML := new(bytes.Buffer)
+	err = h.Handle(bytes.NewReader(omahaReqXML), omahaRespXML, validUnregisteredIP)
+	require.NoError(t, err)
+
+	var omahaResp *omahaSpec.Response
+	err = xml.NewDecoder(omahaRespXML).Decode(&omahaResp)
+	require.NoError(t, err)
+
+	// Both apps should be in the response
+	require.Equal(t, 2, len(omahaResp.Apps))
+
+	// First app should have error status (AppUnknownID)
+	appResp1 := omahaResp.Apps[0]
+	assert.Equal(t, "invalid-app-uuid", appResp1.ID)
+	assert.Equal(t, omahaSpec.AppUnknownID, appResp1.Status)
+	assert.NotNil(t, appResp1.UpdateCheck)
+	assert.Equal(t, omahaSpec.UpdateInternalError, appResp1.UpdateCheck.Status)
+
+	// Second app should have OK status
+	appResp2 := omahaResp.Apps[1]
+	assert.Equal(t, tApp.ID, appResp2.ID)
+	assert.Equal(t, omahaSpec.AppOK, appResp2.Status)
+	assert.NotNil(t, appResp2.UpdateCheck)
+	assert.Equal(t, omahaSpec.NoUpdate, appResp2.UpdateCheck.Status) // No update because version is unverified
+}
+
 func TestMultiManifestResponse(t *testing.T) {
 	a := newForTest(t)
 	defer a.Close()


### PR DESCRIPTION
## Summary

When an Omaha request contains multiple `<app>` elements and the first app has an unknown ID or invalid track/group, `buildOmahaResponse` was returning early with only the failed app's response. This silently dropped all subsequent apps from the response.

## Testing

Added regression test `TestMultiAppRequestWithInvalidApp` that sends a multi-app request with:
1. First app: invalid UUID → expects `AppUnknownID` + `UpdateInternalError`
2. Second app: valid app ID → expects `AppOK` + `NoUpdate`

Both apps now appear in the response with correct status codes.
