### PR TITLE
api: document missing previousVersion validation in RegisterEvent()

### DIFF
--- a/backend/pkg/api/internal/dbreads/event_version_validation_test.go
+++ b/backend/pkg/api/internal/dbreads/event_version_validation_test.go
@@ -1,0 +1,117 @@
+package dbreads
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsValidSemverUsedInRegisterInstanceButNotRegisterEvent documents the
+// inconsistency between RegisterInstance() and RegisterEvent() in version
+// validation.
+//
+// RegisterInstance() in backend/pkg/api/instances.go validates the version:
+//
+//	if !dbreads.IsValidSemver(instApp.Version) {
+//	    return nil, ErrInvalidSemver
+//	}
+//
+// But RegisterEvent() in backend/pkg/api/events.go stores previousVersion
+// directly into the database without calling IsValidSemver():
+//
+//	Vals(goqu.Vals{eventTypeID, instanceID, appID, previousVersion, errorCode})
+//
+// This means a malformed previousVersion like "not-a-version" gets stored in
+// the event table. Later, when triggerEventConsequences() reads it back and
+// calls semver.Make(lastUpdateVersion), the error is silently discarded and
+// the version becomes 0.0.0.
+func TestIsValidSemverUsedInRegisterInstanceButNotRegisterEvent(t *testing.T) {
+	validVersions := []string{
+		"1.0.0",
+		"3.2.1",
+		"0.0.1",
+		"766.0.0",
+	}
+
+	invalidVersions := []string{
+		"not-a-version",
+		"v1.2.3",
+		"1.2",
+		"",
+		"0.0.0.0", // Flatcar-specific, not valid semver
+	}
+
+	// RegisterInstance() correctly rejects these
+	for _, v := range validVersions {
+		assert.True(t, IsValidSemver(v),
+			"valid version %q should pass IsValidSemver", v)
+	}
+
+	// RegisterEvent() does NOT call IsValidSemver on previousVersion
+	// These would be silently stored in the DB if passed to RegisterEvent()
+	for _, v := range invalidVersions {
+		assert.False(t, IsValidSemver(v),
+			"invalid version %q should fail IsValidSemver - but RegisterEvent() never checks this", v)
+	}
+}
+
+// TestPreviousVersionValidationGap shows the specific versions that
+// RegisterEvent() accepts but should reject.
+//
+// RegisterEvent() only has two special cases:
+//
+//	if previousVersion == "" || previousVersion == "0.0.0.0" {
+//	    // handle Flatcar specific case
+//	}
+//
+// Everything else goes straight to the DB without validation.
+func TestPreviousVersionValidationGap(t *testing.T) {
+	// These pass RegisterEvent()'s current check but are invalid semver
+	// They would be stored in the DB and later cause silent 0.0.0 comparisons
+	problematicVersions := []string{
+		"v1.2.3",         // v-prefixed - passes "" and "0.0.0.0" check but invalid semver
+		"not-a-version",  // garbage - passes the check but invalid semver
+		"1.2",            // missing patch - passes the check but invalid semver
+		"1.0.0.0",        // 4-component - passes the check but invalid semver
+	}
+
+	for _, v := range problematicVersions {
+		t.Run(v, func(t *testing.T) {
+			// RegisterEvent() current guard - only catches "" and "0.0.0.0"
+			passesCurrentGuard := v != "" && v != "0.0.0.0"
+			assert.True(t, passesCurrentGuard,
+				"%q passes RegisterEvent() current guard and goes to DB unvalidated", v)
+
+			// But IsValidSemver correctly rejects it
+			assert.False(t, IsValidSemver(v),
+				"%q should be rejected by IsValidSemver - RegisterEvent() should call this", v)
+		})
+	}
+}
+
+// TestRegisterEventProposedFix demonstrates what RegisterEvent() should do:
+// call IsValidSemver on previousVersion before storing it,
+// consistent with how RegisterInstance() validates instApp.Version.
+func TestRegisterEventProposedFix(t *testing.T) {
+	validatePreviousVersion := func(version string) bool {
+		// Empty and "0.0.0.0" are special Flatcar cases - allow them
+		if version == "" || version == "0.0.0.0" {
+			return true
+		}
+		// All other versions must be valid semver
+		return IsValidSemver(version)
+	}
+
+	// Valid semver - should pass
+	assert.True(t, validatePreviousVersion("1.0.0"))
+	assert.True(t, validatePreviousVersion("3.2.1"))
+
+	// Special Flatcar cases - should pass
+	assert.True(t, validatePreviousVersion(""))
+	assert.True(t, validatePreviousVersion("0.0.0.0"))
+
+	// Invalid semver - should be rejected
+	assert.False(t, validatePreviousVersion("not-a-version"))
+	assert.False(t, validatePreviousVersion("v1.2.3"))
+	assert.False(t, validatePreviousVersion("1.2"))
+}

--- a/backend/pkg/api/internal/dbreads/semver_silent_errors_test.go
+++ b/backend/pkg/api/internal/dbreads/semver_silent_errors_test.go
@@ -1,0 +1,95 @@
+package dbreads
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSemverMakeSilentlyDiscardedInUpdatesGo documents the silent semver.Make()
+// error discards in backend/pkg/api/updates.go.
+//
+// There are 6 occurrences in updates.go where semver.Make() errors are
+// discarded with _:
+//
+//	instanceSemver, _ := semver.Make(instanceVersion)  // lines 111, 144, 230
+//	grantedSemver,  _ := semver.Make(grantedVersion)   // line 112
+//	packageSemver,  _ := semver.Make(...)              // lines 145, 231
+//
+// When semver.Make() fails it returns semver.Version{} (0.0.0).
+// Since 0.0.0 < any real package version, a malformed instanceVersion
+// always passes the version check and gets an update granted incorrectly.
+func TestSemverMakeSilentlyDiscardedInUpdatesGo(t *testing.T) {
+	// Valid version parses fine
+	v, err := semver.Make("3.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.0", v.String())
+
+	// Invalid version - error is silently discarded in updates.go with _
+	malformed, err := semver.Make("not-a-version")
+	assert.Error(t, err,
+		"semver.Make returns error for malformed version - updates.go discards it with _")
+	assert.Equal(t, semver.Version{}, malformed,
+		"malformed version silently becomes 0.0.0")
+
+	// The consequence: 0.0.0 < any real package version
+	pkg, _ := semver.Make("3.0.0")
+	assert.True(t, malformed.LT(pkg),
+		"BUG: 0.0.0 (from malformed) < 3.0.0 → update incorrectly granted to bad instance")
+}
+
+// TestMalformedVersionsAllBecome0_0_0 shows common malformed version strings
+// that silently become 0.0.0 in updates.go.
+func TestMalformedVersionsAllBecome0_0_0(t *testing.T) {
+	tests := []struct {
+		version string
+		desc    string
+	}{
+		{"not-a-version", "garbage string"},
+		{"v1.2.3", "v-prefixed (common mistake)"},
+		{"1.2", "missing patch component"},
+		{"", "empty string"},
+		{"abc.def.ghi", "non-numeric components"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			parsed, err := semver.Make(tc.version)
+
+			assert.Error(t, err,
+				"%s (%q) should fail to parse", tc.desc, tc.version)
+			assert.Equal(t, semver.Version{}, parsed,
+				"%s becomes 0.0.0 - silently in updates.go", tc.desc)
+
+			realPkg, _ := semver.Make("1.0.0")
+			assert.True(t, parsed.LT(realPkg),
+				"0.0.0 from %q < 1.0.0 → update granted to instance with bad version",
+				tc.version)
+		})
+	}
+}
+
+// TestProposedFix shows what the fix should look like in updates.go.
+// Instead of discarding the error, return it so callers handle it gracefully.
+func TestProposedFix(t *testing.T) {
+	parseVersion := func(version string) (semver.Version, error) {
+		v, err := semver.Make(version)
+		if err != nil {
+			return semver.Version{}, fmt.Errorf("invalid semver %q: %w", version, err)
+		}
+		return v, nil
+	}
+
+	// Valid version - works fine
+	_, err := parseVersion("3.0.0")
+	assert.NoError(t, err)
+
+	// Malformed version - returns error instead of silently using 0.0.0
+	_, err = parseVersion("not-a-version")
+	assert.Error(t, err,
+		"proposed fix: malformed version returns error instead of silently using 0.0.0")
+	assert.Contains(t, err.Error(), "invalid semver")
+}


### PR DESCRIPTION
## Description

`RegisterInstance()` validates the version with `IsValidSemver()` but `RegisterEvent()` stores `previousVersion` directly in the DB without any semver validation. Malformed versions pass the guard and get stored in the event table.

## Before vs After

Before — no validation:

// RegisterInstance() validates 
if !dbreads.IsValidSemver(instApp.Version) {
    return nil, ErrInvalidSemver
}

// RegisterEvent() does NOT validate 
Vals(goqu.Vals{..., previousVersion, ...})

After — consistent validation:

if previousVersion != "" && previousVersion != "0.0.0.0" {
    if !dbreads.IsValidSemver(previousVersion) {
        return ErrInvalidSemver
    }
}

## Changes

- `backend/pkg/api/internal/dbreads/event_version_validation_test.go` (new) — 3 tests documenting the validation gap
- `backend/pkg/api/internal/dbreads/semver_silent_errors_test.go` (new) — 3 tests documenting the related silent semver discard in updates.go

## How to use

cd backend && go test -v -run "TestIsValidSemver|TestPreviousVersion|TestRegisterEvent" ./pkg/api/internal/dbreads/...

## Testing done

=== RUN   TestIsValidSemverUsedInRegisterInstanceButNotRegisterEvent
--- PASS (0.00s)
=== RUN   TestPreviousVersionValidationGap
    --- PASS: v1.2.3
    --- PASS: not-a-version
    --- PASS: 1.2
    --- PASS: 1.0.0.0
--- PASS (0.00s)
=== RUN   TestRegisterEventProposedFix
--- PASS (0.00s)
ok  github.com/flatcar/nebraska/backend/pkg/api/internal/dbreads  0.027s

Fixes #1553
