### PR TITLE
refactor(api): give the shared db connection its own owner

### DIFF
--- a/backend/cmd/nebraska/main.go
+++ b/backend/cmd/nebraska/main.go
@@ -77,10 +77,10 @@ func main() {
 	}
 
 	// setup admin service (injected into syncer and the HTTP handlers)
-	adminSvc := admin.NewService(db.Reads())
+	adminSvc := admin.NewService(db.Conn(), db.Reads())
 
 	// setup runtime service (injected into the HTTP handlers and the stats job)
-	runtimeSvc := runtime.NewService(db.Reads(), runtime.Config{})
+	runtimeSvc := runtime.NewService(db.Conn(), db.Reads(), runtime.Config{})
 
 	// setup syncer
 	if conf.EnableSyncer {

--- a/backend/pkg/api/admin/activity_test.go
+++ b/backend/pkg/api/admin/activity_test.go
@@ -21,7 +21,7 @@ func TestAdminActivityRouting(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, a)
 	defer a.Close()
-	svc := NewService(a.Reads())
+	svc := NewService(a.Conn(), a.Reads())
 
 	tVersion := "12.1.0"
 	tTeam, _ := svc.AddTeam(&types.Team{Name: "test_team_routing"})

--- a/backend/pkg/api/admin/service.go
+++ b/backend/pkg/api/admin/service.go
@@ -5,6 +5,7 @@ package admin
 import (
 	"github.com/jmoiron/sqlx"
 
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbconn"
 	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbreads"
 	"github.com/flatcar/nebraska/backend/pkg/logger"
 )
@@ -18,11 +19,12 @@ type Service struct {
 	db *sqlx.DB
 }
 
-// NewService creates a new admin Service that reuses the given read queries
-// (and their underlying DB connection).
-func NewService(q *dbreads.Queries) *Service {
+// NewService creates a new admin Service that writes over the given connection
+// and reuses the given read queries.
+// conn must be the same connection used to construct q.
+func NewService(conn *dbconn.Conn, q *dbreads.Queries) *Service {
 	return &Service{
 		Queries: q,
-		db:      dbreads.DB(q),
+		db:      dbconn.DB(conn),
 	}
 }

--- a/backend/pkg/api/api.go
+++ b/backend/pkg/api/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	migrate "github.com/rubenv/sql-migrate"
 
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbconn"
 	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbreads"
 	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 	"github.com/flatcar/nebraska/backend/pkg/logger"
@@ -57,11 +58,16 @@ const migrationsTable = "database_migrations"
 
 // API represents an api instance used to interact with Nebraska entities.
 type API struct {
-	db       *sqlx.DB
+	conn     *dbconn.Conn
 	dbDriver string
 	dbURL    string
 
 	*dbreads.Queries
+}
+
+// db returns the handle for the statements api runs itself.
+func (api *API) db() *sqlx.DB {
+	return dbconn.DB(api.conn)
 }
 
 // New creates a new API instance, creates the underlying db connection.
@@ -76,13 +82,6 @@ func New(options ...func(*API) error) (*API, error) {
 	}
 
 	var err error
-	api.db, err = sqlx.Open(api.dbDriver, api.dbURL)
-	if err != nil {
-		return nil, err
-	}
-	if err := api.db.Ping(); err != nil {
-		return nil, err
-	}
 
 	var (
 		maxOpenConns    int
@@ -104,9 +103,14 @@ func New(options ...func(*API) error) (*API, error) {
 		connMaxLifetime = dBConnMaxLifetime
 	}
 
-	api.db.SetMaxOpenConns(maxOpenConns)
-	api.db.SetMaxIdleConns(maxIdleConns)
-	api.db.SetConnMaxLifetime(time.Duration(connMaxLifetime) * time.Second)
+	api.conn, err = dbconn.Open(api.dbDriver, api.dbURL, dbconn.PoolConfig{
+		MaxOpenConns:    maxOpenConns,
+		MaxIdleConns:    maxIdleConns,
+		ConnMaxLifetime: time.Duration(connMaxLifetime) * time.Second,
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	// Load max floors per response configuration
 	maxFloorsPerResponse, err := strconv.Atoi(os.Getenv("NEBRASKA_MAX_FLOORS_PER_RESPONSE"))
@@ -114,7 +118,7 @@ func New(options ...func(*API) error) (*API, error) {
 		maxFloorsPerResponse = dbreads.DefaultMaxFloorsPerResponse
 	}
 
-	api.Queries = dbreads.New(api.db, maxFloorsPerResponse)
+	api.Queries = dbreads.New(api.conn, maxFloorsPerResponse)
 
 	for _, option := range options {
 		err := option(api)
@@ -137,7 +141,7 @@ func NewWithMigrations(options ...func(*API) error) (*API, error) {
 	migrate.SetTable(migrationsTable)
 	migrations := migrationAssets()
 
-	if _, err := migrate.Exec(api.db.DB, "postgres", migrations, migrate.Up); err != nil {
+	if _, err := migrate.Exec(api.db().DB, "postgres", migrations, migrate.Up); err != nil {
 		return nil, err
 	}
 	api.UpdateCachedGroups()
@@ -162,7 +166,7 @@ func (api *API) MigrateDown(version string) (int, error) {
 	}
 
 	var mig migration
-	err = api.db.QueryRowx(query).StructScan(&mig)
+	err = api.db().QueryRowx(query).StructScan(&mig)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return 0, fmt.Errorf("no migrations found for: %s, err: %v", version, err)
@@ -178,14 +182,14 @@ func (api *API) MigrateDown(version string) (int, error) {
 
 	countMap := make(map[string]interface{})
 
-	err = api.db.QueryRowx(query).MapScan(countMap)
+	err = api.db().QueryRowx(query).MapScan(countMap)
 	if err != nil {
 		return 0, err
 	}
 
 	levels := countMap["count"].(int64)
 	l.Info().Msgf("migrating down %d levels", levels)
-	count, err := migrate.ExecMax(api.db.DB, "postgres", migrations, migrate.Down, int(levels))
+	count, err := migrate.ExecMax(api.db().DB, "postgres", migrations, migrate.Down, int(levels))
 	if err != nil {
 		return 0, err
 	}
@@ -209,7 +213,7 @@ func OptionInitDB(api *API) error {
 		return err
 	}
 
-	if _, err := api.db.Exec(string(sqlFile)); err != nil {
+	if _, err := api.db().Exec(string(sqlFile)); err != nil {
 		return err
 	}
 	api.UpdateCachedGroups()
@@ -219,7 +223,13 @@ func OptionInitDB(api *API) error {
 
 // Close releases the connections to the database.
 func (api *API) Close() {
-	_ = api.db.Close()
+	_ = api.conn.Close()
+}
+
+// Conn returns the shared database connection (dbconn.Conn) owned by this API
+// instance.
+func (api *API) Conn() *dbconn.Conn {
+	return api.conn
 }
 
 // Reads returns the shared read queries (dbreads.Queries) owned by this API
@@ -241,7 +251,7 @@ func NewForTest(options ...func(*API) error) (*API, error) {
 		return nil, err
 	}
 
-	_, err = a.db.Exec(string(sqlFile))
+	_, err = a.db().Exec(string(sqlFile))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/api/api_test.go
+++ b/backend/pkg/api/api_test.go
@@ -57,7 +57,7 @@ func TestMigrateDown(t *testing.T) {
 	require.NoError(t, err)
 
 	var migrations []migration
-	rows, err := db.db.Queryx(query)
+	rows, err := db.db().Queryx(query)
 	require.NoError(t, err)
 
 	defer rows.Close()

--- a/backend/pkg/api/helpers_test.go
+++ b/backend/pkg/api/helpers_test.go
@@ -19,14 +19,14 @@ const flatcarAppID = types.FlatcarAppID
 // adminSvc returns an admin.Service that reuses a's shared read queries so
 // tests can exercise admin write operations (which moved to package admin).
 func adminSvc(a *API) *admin.Service {
-	return admin.NewService(a.Reads())
+	return admin.NewService(a.Conn(), a.Reads())
 }
 
 // runtimeSvc returns a runtime.Service that reuses a's shared read queries so
 // tests can exercise the runtime operations (which moved to package
 // runtime).
 func runtimeSvc(a *API) *runtime.Service {
-	return runtime.NewService(a.Reads(), runtime.Config{DisableUpdatesOnFailedRollout: true})
+	return runtime.NewService(a.Conn(), a.Reads(), runtime.Config{DisableUpdatesOnFailedRollout: true})
 }
 
 // Test helper functions to reduce boilerplate in floor tests

--- a/backend/pkg/api/internal/dbconn/conn.go
+++ b/backend/pkg/api/internal/dbconn/conn.go
@@ -1,0 +1,49 @@
+// Package dbconn owns the database connection shared by the api stack.
+package dbconn
+
+import (
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// PoolConfig holds the connection pool limits applied when the connection is opened.
+type PoolConfig struct {
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+}
+
+// Conn owns the database connection shared by the api stack.
+type Conn struct {
+	db *sqlx.DB
+}
+
+// Open opens the database connection, verifies it is reachable and applies the
+// pool limits.
+func Open(driver string, url string, pool PoolConfig) (*Conn, error) {
+	db, err := sqlx.Open(driver, url)
+	if err != nil {
+		return nil, err
+	}
+	if err := db.Ping(); err != nil {
+		return nil, err
+	}
+
+	db.SetMaxOpenConns(pool.MaxOpenConns)
+	db.SetMaxIdleConns(pool.MaxIdleConns)
+	db.SetConnMaxLifetime(pool.ConnMaxLifetime)
+
+	return &Conn{db: db}, nil
+}
+
+// Close releases the connection.
+func (c *Conn) Close() error {
+	return c.db.Close()
+}
+
+// DB returns the underlying database handle. It is a package function rather
+// than a method so the handle stays unreachable outside pkg/api.
+func DB(c *Conn) *sqlx.DB {
+	return c.db
+}

--- a/backend/pkg/api/internal/dbreads/queries.go
+++ b/backend/pkg/api/internal/dbreads/queries.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbconn"
 	"github.com/flatcar/nebraska/backend/pkg/logger"
 )
 
@@ -23,14 +24,9 @@ type Queries struct {
 	maxFloorsPerResponse int
 }
 
-func New(db *sqlx.DB, maxFloorsPerResponse int) *Queries {
+func New(conn *dbconn.Conn, maxFloorsPerResponse int) *Queries {
 	if maxFloorsPerResponse <= 0 {
 		maxFloorsPerResponse = DefaultMaxFloorsPerResponse
 	}
-	return &Queries{db: db, maxFloorsPerResponse: maxFloorsPerResponse}
-}
-
-// DB returns the underlying database handle shared by the read queries.
-func DB(q *Queries) *sqlx.DB {
-	return q.db
+	return &Queries{db: dbconn.DB(conn), maxFloorsPerResponse: maxFloorsPerResponse}
 }

--- a/backend/pkg/api/runtime/helpers_test.go
+++ b/backend/pkg/api/runtime/helpers_test.go
@@ -24,11 +24,11 @@ func newForTest(t *testing.T) *api.API {
 // runtime tests can build the domain fixtures (teams, apps, channels, groups)
 // that only the admin write surface can create.
 func adminSvc(a *api.API) *admin.Service {
-	return admin.NewService(a.Reads())
+	return admin.NewService(a.Conn(), a.Reads())
 }
 
 // runtimeSvc returns a runtime.Service that reuses a's shared read queries so
 // tests can exercise the runtime operations under test.
 func runtimeSvc(a *api.API) *Service {
-	return NewService(a.Reads(), Config{DisableUpdatesOnFailedRollout: true})
+	return NewService(a.Conn(), a.Reads(), Config{DisableUpdatesOnFailedRollout: true})
 }

--- a/backend/pkg/api/runtime/service.go
+++ b/backend/pkg/api/runtime/service.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"github.com/jmoiron/sqlx"
 
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbconn"
 	"github.com/flatcar/nebraska/backend/pkg/api/internal/dbreads"
 	"github.com/flatcar/nebraska/backend/pkg/logger"
 )
@@ -29,12 +30,13 @@ type Config struct {
 	DisableUpdatesOnFailedRollout bool
 }
 
-// NewService creates a new runtime Service that reuses the given read queries
-// (and their underlying DB connection).
-func NewService(q *dbreads.Queries, cfg Config) *Service {
+// NewService creates a new runtime Service that writes over the given
+// connection and reuses the given read queries.
+// conn must be the same connection used to construct q.
+func NewService(conn *dbconn.Conn, q *dbreads.Queries, cfg Config) *Service {
 	return &Service{
 		Queries:                       q,
-		db:                            dbreads.DB(q),
+		db:                            dbconn.DB(conn),
 		disableUpdatesOnFailedRollout: cfg.DisableUpdatesOnFailedRollout,
 	}
 }

--- a/backend/pkg/api/updates_test.go
+++ b/backend/pkg/api/updates_test.go
@@ -479,7 +479,7 @@ func TestAlreadyGrantedWithoutLastUpdateVersion(t *testing.T) {
 	assert.Equal(t, "2000.0.0", instance.Application.LastUpdateVersion.String)
 
 	// Simulate old instance: clear LastUpdateVersion but keep UpdateGranted status
-	_, err = a.db.Exec(`UPDATE instance_application SET last_update_version = NULL
+	_, err = a.db().Exec(`UPDATE instance_application SET last_update_version = NULL
 		WHERE instance_id = $1 AND application_id = $2`, instanceID, setup.AppID)
 	assert.NoError(t, err)
 

--- a/backend/pkg/omaha/helpers_test.go
+++ b/backend/pkg/omaha/helpers_test.go
@@ -14,13 +14,13 @@ import (
 // adminSvc returns an admin.Service that reuses a's shared read queries so
 // tests can exercise admin write operations.
 func adminSvc(a *api.API) *admin.Service {
-	return admin.NewService(a.Reads())
+	return admin.NewService(a.Conn(), a.Reads())
 }
 
 // runtimeSvc returns a runtime.Service that reuses a's shared read queries so
 // tests can construct the Omaha handler over the runtime service.
 func runtimeSvc(a *api.API) *runtime.Service {
-	return runtime.NewService(a.Reads(), runtime.Config{DisableUpdatesOnFailedRollout: true})
+	return runtime.NewService(a.Conn(), a.Reads(), runtime.Config{DisableUpdatesOnFailedRollout: true})
 }
 
 // setupOmahaFloorTest creates a complete Omaha floor test environment

--- a/backend/pkg/syncer/helpers_test.go
+++ b/backend/pkg/syncer/helpers_test.go
@@ -13,7 +13,7 @@ import (
 // adminSvc returns an admin.Service that reuses a's shared read queries so
 // tests can exercise admin write operations.
 func adminSvc(a *api.API) *admin.Service {
-	return admin.NewService(a.Reads())
+	return admin.NewService(a.Conn(), a.Reads())
 }
 
 // setupSyncerTest sets up a standard syncer test environment

--- a/backend/test/api/helper_test.go
+++ b/backend/test/api/helper_test.go
@@ -21,13 +21,13 @@ import (
 // adminSvc returns an admin.Service that reuses db's shared read queries so
 // tests can construct a server with admin write support.
 func adminSvc(db *api.API) *admin.Service {
-	return admin.NewService(db.Reads())
+	return admin.NewService(db.Conn(), db.Reads())
 }
 
 // runtimeSvc returns a runtime.Service that reuses db's shared read queries so
 // tests can construct a server with the runtime service.
 func runtimeSvc(db *api.API) *runtime.Service {
-	return runtime.NewService(db.Reads(), runtime.Config{})
+	return runtime.NewService(db.Conn(), db.Reads(), runtime.Config{})
 }
 
 // newDBForTest is a helper function that

--- a/backend/test/auth/oidc/helper_test.go
+++ b/backend/test/auth/oidc/helper_test.go
@@ -25,13 +25,13 @@ func newDBForTest(t *testing.T) *api.API {
 // adminSvc builds an admin.Service over the given API's shared read queries,
 // matching how the composition root injects it into the server.
 func adminSvc(db *api.API) *admin.Service {
-	return admin.NewService(db.Reads())
+	return admin.NewService(db.Conn(), db.Reads())
 }
 
 // runtimeSvc builds a runtime.Service over the given API's shared read queries,
 // matching how the composition root injects it into the server.
 func runtimeSvc(db *api.API) *runtime.Service {
-	return runtime.NewService(db.Reads(), runtime.Config{})
+	return runtime.NewService(db.Conn(), db.Reads(), runtime.Config{})
 }
 
 // newOIDCMockServer creates a new mockoidc server and returns it.


### PR DESCRIPTION
# refactor(api): give the shared db connection its own owner

`admin` and `runtime` took their write handle from the read layer, through `dbreads.DB()`, so the reads package was the one handing out the database connection. That encodes the wrong dependency: the write services do not need reads in order to get a connection, they need the connection.

A new `pkg/api/internal/dbconn` owns the handle instead. It opens the connection, applies the pool limits and closes it. `pkg/api` still decides the configuration and drives the migrations, and passes the connection and the shared reads to the write services:

Roadmap follow-up to RFC #1375.

```mermaid
graph LR
    subgraph before["before — the reads package hands out the connection"]
        bapi["api"] --> breads["internal/dbreads"]
        breads -->|"dbreads.DB(q)"| badmin["admin.Service"]
        breads -->|"dbreads.DB(q)"| bruntime["runtime.Service"]
    end

    subgraph after["after — dbconn owns the connection"]
        aapi["api"] -->|"opens, closes"| aconn["internal/dbconn"]
        aconn -->|"dbconn.DB(c)"| areads["internal/dbreads"]
        aconn -->|"dbconn.DB(c)"| aadmin["admin.Service"]
        aconn -->|"dbconn.DB(c)"| aruntime["runtime.Service"]
    end
```

This commit is purely refactoring and shouldn't change any behavior.

Refs: #1375

## How to use

This PR is intended to be purely refactoring. To validate, we should ensure that there's no behavior change at all.

## Testing done

```console
$ cd backend
$ make code-checks
go build ./...
./tools/check_pkg_test.sh
NEBRASKA_SKIP_TESTS=1 go test ./... >/dev/null
./tools/golangci-lint run --fix
0 issues.
go mod tidy
```

```console
$ make check-backend-with-container

ok  github.com/flatcar/nebraska/backend/pkg/api                    25.943s
ok  github.com/flatcar/nebraska/backend/pkg/api/admin              0.276s
ok  github.com/flatcar/nebraska/backend/pkg/api/runtime            2.799s
ok  github.com/flatcar/nebraska/backend/pkg/auth                   0.006s
ok  github.com/flatcar/nebraska/backend/pkg/middleware             0.009s
ok  github.com/flatcar/nebraska/backend/pkg/omaha                  4.395s
ok  github.com/flatcar/nebraska/backend/pkg/random                 0.004s
ok  github.com/flatcar/nebraska/backend/pkg/sessions               0.007s
ok  github.com/flatcar/nebraska/backend/pkg/sessions/memcache      0.006s
ok  github.com/flatcar/nebraska/backend/pkg/sessions/memcache/gob  0.007s
ok  github.com/flatcar/nebraska/backend/pkg/syncer                 6.052s
ok  github.com/flatcar/nebraska/backend/test/api                   22.846s
ok  github.com/flatcar/nebraska/backend/test/auth/oidc             3.904s
```

Plus an e2e smoke run against the live container server covering admin CRUD, package floors, the Omaha update flow, instance reads, activity and metrics.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.