### PR TITLE
frontend: use stable keys for channel and version lists

### DIFF
--- a/frontend/src/components/Applications/ApplicationItemChannelsList.tsx
+++ b/frontend/src/components/Applications/ApplicationItemChannelsList.tsx
@@ -1,24 +1,16 @@
 import Grid from '@mui/material/Grid';
-import React from 'react';
 
 import { Channel } from '../../api/apiDataTypes';
 import ChannelItem from '../Channels/ChannelItem';
 
 function ApplicationItemChannelsList(props: { channels?: Channel[] }) {
   const channels = props.channels || [];
-  let entries: React.ReactNode[] = [];
-
-  if (channels) {
-    entries = channels.map((channel, i) => (
-      <ChannelItem channel={channel} key={`channelItem_${i}`} />
-    ));
-  }
 
   return (
     <Grid container justifyContent="space-between">
-      {entries.map((entry: React.ReactNode, i: number) => (
-        <Grid key={i} size={4}>
-          {entry}
+      {channels.map(channel => (
+        <Grid key={channel.id} size={4}>
+          <ChannelItem channel={channel} />
         </Grid>
       ))}
     </Grid>

--- a/frontend/src/components/Packages/Item.tsx
+++ b/frontend/src/components/Packages/Item.tsx
@@ -106,9 +106,9 @@ function Item(props: ItemProps) {
               {`${t('packages|channels')}:`}
             </Typography>
             &nbsp;
-            {processedChannels.map((channel, i) => {
+            {processedChannels.map(channel => {
               return (
-                <span className={classes.channelLabel} key={i}>
+                <span className={classes.channelLabel} key={channel.id}>
                   <ChannelAvatar color={channel.color} size="10px" />
                   &nbsp;
                   {channel.name}

--- a/frontend/src/components/common/VersionBreakdownBar/VersionBreakdownBar.tsx
+++ b/frontend/src/components/common/VersionBreakdownBar/VersionBreakdownBar.tsx
@@ -157,9 +157,9 @@ function VersionProgressBar(props: { version_breakdown: any; channel: Channel | 
         <Tooltip content={<VersionsTooltip versionsData={chartData} />} />
         <XAxis hide type="number" />
         <YAxis hide dataKey="key" type="category" />
-        {chartData.versions.map((version, index) => {
+        {chartData.versions.map(version => {
           const color = chartData.colors[version];
-          return <Bar key={index} dataKey={version} stackId="1" fill={color} />;
+          return <Bar key={version} dataKey={version} stackId="1" fill={color} />;
         })}
       </BarChart>
     </StyledResponsiveContainer>


### PR DESCRIPTION
Issue #328 asked whether each use of an array index as a React key is intended and safe. I went through all ten occurrences. Three had a stable identifier already in scope and now key on it:

- `VersionBreakdownBar` keyed `<Bar>` by index while `dataKey` was already the version string.
- `Packages/Item` now keys channel labels on `channel.id`.
- `ApplicationItemChannelsList` mapped channels twice and keyed both by index. The second map only received a `ReactNode`, so it had no access to the channel; collapsing to a single map is what makes keying on `channel.id` possible. That also drops an `if (channels)` branch which was always true, since `channels` is defaulted to `[]` above it.

I left the rest alone:

- `Tabs`: the index *is* the identity. It is also passed as `index` and to `a11yProps`.
- `ListHeader`, `MoreMenu`, `Instances/Charts`: static lists that never reorder.
- `TimelineChart`: also index-keyed, but it is in scope for #407, which someone else is already working on. I stayed out of it.

`SimpleTable` is the one place where this could actually mis-associate rows, since it keys rows by index over paginated data. Its `instances` prop is typed `any[]` and neither caller supplies an id, so a correct fix needs either a key derived from the row's column values (which assumes no two rows are ever identical) or a new `getRowKey` prop. Both felt like a separate discussion, so I kept it out. Happy to take it on if you have a preference. I've used `Refs #328` rather than `Fixes` for that reason.

### Testing

`npx tsc -b`, `npx eslint --max-warnings 0`, and `npx vitest run` (79 tests, 20 files) all pass.

I did not add tests. None of the existing tests would have failed before this change either, since these lists do not currently reorder and there is no observable behaviour change today. A test that proved key stability would have to assert DOM node identity across a reorder, which seemed more brittle than valuable. If you'd rather have one, say so and I'll add it.
