### PR TITLE
api/admin: migrate password hashing from MD5 to bcrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Security
+
+- **User password secrets now hashed with bcrypt instead of unsalted md5:** `backend/pkg/api/admin/users.go` stored the local `users.secret` column as a raw `md5(username:realm:password)` digest, which is fast to brute-force and gives identical users with the same password identical stored values. New and changed passwords are now hashed with bcrypt (`golang.org/x/crypto/bcrypt`), which is deliberately slow and per-hash salted. Existing legacy md5 secrets keep verifying correctly and are transparently upgraded to bcrypt on the account's next successful login (`admin.Service.Authenticate`); no scheme-marker column was needed since a bcrypt hash and a hex md5 digest can never have the same shape. Requires migration `0024_widen_user_secret_for_bcrypt.sql`, which widens `users.secret` from `varchar(50)` to `text` to fit bcrypt's longer output.
 ### Added
 
 - **Custom CA Certificate for TLS:** Added `--ca-file` flag to trust additional CA certificates for TLS verification (e.g., internal CA, Let's Encrypt staging). Applies to the OIDC provider client and the syncer. Supports multiple PEM-encoded certs, additive to system CAs. Also exposed as `config.caFile` in the Helm chart.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/rubenv/sql-migrate v1.8.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.19.0
+	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 	gopkg.in/guregu/null.v4 v4.0.0
@@ -249,7 +250,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.57.0 // indirect

--- a/backend/pkg/api/admin/users.go
+++ b/backend/pkg/api/admin/users.go
@@ -1,11 +1,15 @@
 package admin
 
 import (
-	"crypto/md5"
+	"crypto/md5" //nolint:gosec // retained only to verify pre-existing legacy secrets, see VerifyUserPassword
+	"crypto/subtle"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/doug-martin/goqu/v9"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
@@ -13,6 +17,14 @@ import (
 const (
 	// Realm used for basic authentication.
 	Realm = "nebraska"
+
+	// bcryptSecretPrefix is the prefix of every hash produced by
+	// golang.org/x/crypto/bcrypt (e.g. "$2a$", "$2b$", "$2y$"). Secrets
+	// stored before the move to bcrypt are exactly a 32-character
+	// hex-encoded MD5 digest, which can never start with "$", so a
+	// stored value's own shape tells the two schemes apart and no
+	// separate scheme-marker column is needed.
+	bcryptSecretPrefix = "$2"
 )
 
 // AddUser registers a user.
@@ -32,7 +44,8 @@ func (s *Service) AddUser(user *types.User) (*types.User, error) {
 	return user, nil
 }
 
-// UpdateUserPassword updates the password of the provided user.
+// UpdateUserPassword updates the password of the provided user, storing
+// it hashed with bcrypt.
 func (s *Service) UpdateUserPassword(username, newPassword string) error {
 	secret, err := s.GenerateUserSecret(username, newPassword)
 	if err != nil {
@@ -60,13 +73,88 @@ func (s *Service) UpdateUserPassword(username, newPassword string) error {
 	return nil
 }
 
-// GenerateUserSecret generates a md5 hash from the username and password
-// provided (username:realm:password).
-func (s *Service) GenerateUserSecret(username, password string) (string, error) {
-	h := md5.New()
+// GenerateUserSecret hashes the password provided with bcrypt. The
+// username parameter is kept only for backward compatibility with
+// callers written for the previous md5(username:realm:password) scheme;
+// it is not mixed into the bcrypt input, which already gets its own
+// random salt and would otherwise silently count against bcrypt's
+// 72-byte input limit, capping real passwords well below that.
+func (s *Service) GenerateUserSecret(_, password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}
+
+// VerifyUserPassword checks a username/password pair against a stored
+// secret, accepting both formats a stored secret can be in:
+//   - a bcrypt hash of the password, the current format;
+//   - a legacy md5 hash of "username:realm:password", used before the
+//     move to bcrypt.
+//
+// isLegacy reports whether the stored secret was in the legacy format,
+// so that on a successful login the caller can re-hash the password
+// with GenerateUserSecret and persist it via UpdateUserPassword,
+// upgrading the account to bcrypt without requiring a password change.
+func VerifyUserPassword(username, password, storedSecret string) (ok, isLegacy bool, err error) {
+	if strings.HasPrefix(storedSecret, bcryptSecretPrefix) {
+		err = bcrypt.CompareHashAndPassword([]byte(storedSecret), []byte(password))
+		if err != nil {
+			if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+				return false, false, nil
+			}
+			return false, false, err
+		}
+		return true, false, nil
+	}
+
+	legacySecret, err := generateLegacyMD5Secret(username, password)
+	if err != nil {
+		return false, false, err
+	}
+	match := subtle.ConstantTimeCompare([]byte(storedSecret), []byte(legacySecret)) == 1
+	// isLegacy reflects the stored secret's format, not whether this
+	// particular password matched it.
+	return match, true, nil
+}
+
+// generateLegacyMD5Secret reproduces the pre-bcrypt secret format
+// (username:realm:password), kept only so VerifyUserPassword can still
+// check accounts that have not logged in since the move to bcrypt.
+func generateLegacyMD5Secret(username, password string) (string, error) {
+	h := md5.New() //nolint:gosec // legacy verification only, see VerifyUserPassword
 	if _, err := io.WriteString(h, username+":"+Realm+":"+password); err != nil {
 		return "", err
 	}
-
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// Authenticate verifies a username/password pair against the user's
+// stored secret and, on success, transparently upgrades a legacy md5
+// secret to bcrypt so the password is never checked against the
+// weaker scheme again.
+func (s *Service) Authenticate(username, password string) (*types.User, error) {
+	user, err := s.GetUser(username)
+	if err != nil {
+		return nil, err
+	}
+
+	ok, isLegacy, err := VerifyUserPassword(username, password, user.Secret)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, types.ErrInvalidCredentials
+	}
+
+	if isLegacy {
+		if err := s.UpdateUserPassword(username, password); err != nil {
+			// The login itself already succeeded; failing to upgrade
+			// the stored secret shouldn't fail it.
+			l.Warn().Err(err).Str("username", username).Msg("failed to upgrade legacy password secret")
+		}
+	}
+
+	return user, nil
 }

--- a/backend/pkg/api/db/migrations/0024_widen_user_secret_for_bcrypt.sql
+++ b/backend/pkg/api/db/migrations/0024_widen_user_secret_for_bcrypt.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+
+-- Widen users.secret so it can hold a bcrypt hash (60 characters, e.g.
+-- "$2a$10$..."), which replaces the raw MD5 digest (32 hex characters)
+-- previously stored here. Existing legacy MD5 secrets keep working
+-- unchanged: bcrypt's own output always starts with "$2", so the
+-- value's own shape tells the two formats apart and no separate
+-- scheme-marker column is needed. See backend/pkg/api/admin/users.go.
+alter table users alter column secret type text;
+
+-- +migrate Down
+
+-- Only safe if no bcrypt secret (>50 chars) has been written since the
+-- Up migration ran.
+alter table users alter column secret type varchar(50);

--- a/backend/pkg/api/internal/types/user.go
+++ b/backend/pkg/api/internal/types/user.go
@@ -9,11 +9,15 @@ import (
 // the user's password.
 var ErrUpdatingPassword = errors.New("nebraska: error updating password")
 
+// ErrInvalidCredentials indicates that a username/password pair didn't
+// match the stored secret.
+var ErrInvalidCredentials = errors.New("nebraska: invalid credentials")
+
 // User represents a Nebraska user.
 type User struct {
 	ID        string    `db:"id" json:"id"`             // UUID v4 unique, created automatically
 	Username  string    `db:"username" json:"username"` // unique username
-	Secret    string    `db:"secret" json:"secret"`     // md5 hash from (username:realm:password)
+	Secret    string    `db:"secret" json:"secret"`     // bcrypt hash of the password, or a legacy md5 hash of (username:realm:password)
 	CreatedTs time.Time `db:"created_ts" json:"-"`      // Created automatically
 	TeamID    string    `db:"team_id" json:"team_id"`   // User can be in single team
 }

--- a/backend/pkg/api/users_test.go
+++ b/backend/pkg/api/users_test.go
@@ -1,9 +1,17 @@
 package api
 
 import (
+	"crypto/md5" //nolint:gosec // test fixture reproducing the legacy secret format on purpose
+	"fmt"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/flatcar/nebraska/backend/pkg/api/admin"
+	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
 const (
@@ -39,8 +47,111 @@ func TestUpdateUserPassword(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "admin", user.Username)
 	assert.Equal(t, defaultTeamID, user.TeamID)
+	// The stored secret is no longer the legacy md5 value, and is a
+	// bcrypt hash (which, unlike md5, embeds a random salt, so it can't
+	// be asserted against a fixed string).
 	assert.NotEqual(t, "8b31292d4778582c0e5fa96aee5513f1", user.Secret)
-	assert.Equal(t, "c01e8daa7a6c135909f218ff2bea1cfe", user.Secret)
+	assert.True(t, strings.HasPrefix(user.Secret, "$2"), "expected a bcrypt hash, got %q", user.Secret)
+	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.Secret), []byte("new-password")))
+
+	ok, isLegacy, err := admin.VerifyUserPassword("admin", "new-password", user.Secret)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.False(t, isLegacy)
+
+	ok, _, err = admin.VerifyUserPassword("admin", "wrong-password", user.Secret)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// TestGenerateUserSecretUsesRandomSalt confirms two users with the same
+// password no longer get an identical stored secret, unlike with the
+// previous unsalted md5 scheme.
+func TestGenerateUserSecretUsesRandomSalt(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	as := adminSvc(a)
+
+	secret1, err := as.GenerateUserSecret("alice", "same-password")
+	assert.NoError(t, err)
+	secret2, err := as.GenerateUserSecret("bob", "same-password")
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, secret1, secret2)
+
+	ok, _, err := admin.VerifyUserPassword("alice", "same-password", secret1)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, _, err = admin.VerifyUserPassword("bob", "same-password", secret2)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}
+
+// TestVerifyUserPasswordLegacyMD5 checks that an account whose secret is
+// still in the pre-bcrypt md5(username:realm:password) format can be
+// verified, so existing accounts keep working until they log in again.
+func TestVerifyUserPasswordLegacyMD5(t *testing.T) {
+	legacySecret := legacyMD5Secret(t, "chandler", "correct-password")
+
+	ok, isLegacy, err := admin.VerifyUserPassword("chandler", "correct-password", legacySecret)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.True(t, isLegacy)
+
+	ok, isLegacy, err = admin.VerifyUserPassword("chandler", "wrong-password", legacySecret)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+	assert.True(t, isLegacy)
+}
+
+// TestAuthenticateUpgradesLegacySecret checks that a successful login
+// against a legacy md5 secret transparently rewrites it as a bcrypt
+// hash, so the weaker scheme is only ever checked once per account.
+func TestAuthenticateUpgradesLegacySecret(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	as := adminSvc(a)
+
+	username, password := "chandler", "correct-password"
+	user := &User{
+		Username: username,
+		Secret:   legacyMD5Secret(t, username, password),
+		TeamID:   defaultTeamID,
+	}
+	_, err := as.AddUser(user)
+	assert.NoError(t, err)
+
+	authed, err := as.Authenticate(username, password)
+	assert.NoError(t, err)
+	assert.Equal(t, username, authed.Username)
+
+	upgraded, err := a.GetUser(username)
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(upgraded.Secret, "$2"), "expected the secret to be upgraded to bcrypt, got %q", upgraded.Secret)
+	assert.NotEqual(t, user.Secret, upgraded.Secret)
+
+	// A second login goes through the bcrypt path and doesn't touch the
+	// secret again.
+	_, err = as.Authenticate(username, password)
+	assert.NoError(t, err)
+	unchanged, err := a.GetUser(username)
+	assert.NoError(t, err)
+	assert.Equal(t, upgraded.Secret, unchanged.Secret)
+
+	_, err = as.Authenticate(username, "wrong-password")
+	assert.ErrorIs(t, err, types.ErrInvalidCredentials)
+}
+
+// legacyMD5Secret reproduces the pre-bcrypt secret format so tests can
+// exercise the legacy verification and upgrade paths without depending
+// on the actual password behind any seeded fixture data.
+func legacyMD5Secret(t *testing.T, username, password string) string {
+	t.Helper()
+	h := md5.New() //nolint:gosec // test fixture reproducing the legacy format on purpose
+	_, err := io.WriteString(h, username+":"+admin.Realm+":"+password)
+	assert.NoError(t, err)
+	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 func TestAddUser(t *testing.T) {


### PR DESCRIPTION
## Why

GenerateUserSecret hashed passwords with MD5 — a fast, general-purpose
hash with no per-user randomness, unsuited for password storage. Modern
hardware can attempt billions of guesses per second against it, and two
users with the same password produce identical stored values.

If stored secrets are ever exposed by any means — a backup leak, an
overly broad database credential, misconfigured access — MD5 offers
essentially no protection: common passwords fall in seconds, and
matching hashes reveal which users share a password. The stored value
is also directly reusable, since it's the exact string the
authentication check compares against.

## What changed

- `GenerateUserSecret` now hashes with bcrypt at `DefaultCost`. Username
  dropped from the hash input (bcrypt salts itself; including it would
  eat into bcrypt's 72-byte input limit) but kept in the function
  signature so callers don't change.
- New `VerifyUserPassword(username, password, storedSecret) (ok,
  isLegacy, err)` — verifies against either format and reports which.
  `Service.Authenticate` re-hashes and persists on the first successful
  legacy login; a later login on an already-upgraded secret is a no-op.
  Format is detected by shape — bcrypt output starts `$2`, legacy MD5 is
  32 hex characters — no separate scheme-marker column needed.
- `0024_widen_user_secret_for_bcrypt.sql` widens `users.secret` from
  `varchar(50)` to `text` (bcrypt output is 60 characters).
- Added `types.ErrInvalidCredentials`; corrected the `User.Secret` doc
  comment.
- `golang.org/x/crypto` promoted from indirect to direct in `go.mod`.
- CHANGELOG entry under Security.

## Note for reviewers

`Authenticate` is new API surface — nothing calls it yet, since today's
auth modes are noop/github/oidc with no local-password login path. It's
the piece a future basic-auth path would use, and it's what makes the
upgrade-on-login behavior meaningful rather than dead code. Happy to
drop it and keep this PR scoped to hashing + migration only if you'd
rather land that separately.

Rebased on top of the `pkg/api` → `pkg/api/runtime` refactor and
re-verified against the new tree; no conflicts (no upstream `0024`
migration, `admin/users.go` and `users_test.go` unmoved).

## Test plan

- [x] New tests: bcrypt round trip; two users with the same password
      produce different secrets; legacy MD5 still verifies; legacy
      login upgrades the secret, a second login leaves it alone; wrong
      password returns `ErrInvalidCredentials`
- [x] `go build ./...`, `go vet ./...`,
      `golangci-lint run ./pkg/api/...` → 0 issues, `gofmt` clean
- [x] Full `./pkg/api/...` suite: 2 pre-existing failures
      (`TestUpdateInstanceStats`,
      `TestGetUpdatePackage_MaxUpdatesLimitsReached`), confirmed
      identical on a clean stash of `main` — unrelated to this change
- [x] Migration verified live: `users.secret` is `text` with the check
      constraint intact; `TestMigrateDown` passes