### PR TITLE
fix(metrics): scope failed_updates to last day and add group label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **`nebraska_failed_updates` metric:** Counts only failed updates from the last day (matching other reporting windows) and adds a `group` label so operators can alert per rollout group. The gauge is reset before each refresh to avoid stale series. ([#1567](https://github.com/flatcar/nebraska/issues/1567))
 - **Per-group runtime state moved to node-local `group_local` sidecar:** `rollout_in_progress` plus a nullable override column for each `policy_*` column on `groups` now live on a new `group_local` table, in preparation for the distributed Nebraska topology described in [RFC #1375](https://github.com/flatcar/nebraska/issues/1375). The safe-mode auto-pause brake writes the local override instead of mutating the admin default; reads return `COALESCE(override, default)`. The JSON contract is unchanged. ([#1396](https://github.com/flatcar/nebraska/pull/1396))
 - **Activity events split across runtime-local and admin tables:** Admin-originated activity events (channel package updates) are now stored in a separate `admin_activity` table, in preparation for the distributed Nebraska topology described in [RFC #1375](https://github.com/flatcar/nebraska/issues/1375). The JSON contract is unchanged. ([#1398](https://github.com/flatcar/nebraska/pull/1398))
 - **Package Management UI Improvements:**

--- a/backend/pkg/api/internal/dbreads/metrics.go
+++ b/backend/pkg/api/internal/dbreads/metrics.go
@@ -16,13 +16,24 @@ GROUP BY app_name, version, channel_name
 ORDER BY app_name, version, channel_name
 `, ignoreFakeInstanceCondition("ia.instance_id"))
 
+	// Count failed update-complete events from the last day, broken down by
+	// application and group. The event table has no group_id, so group comes
+	// from the instance's current instance_application row.
 	failedUpdatesSQL = fmt.Sprintf(`
-SELECT a.name AS app_name, count(*) as fail_count
-FROM application a, event e, event_type et
-WHERE a.id = e.application_id AND e.event_type_id = et.id AND et.result = 0 AND et.type = 3 AND %s
-GROUP BY app_name
-ORDER BY app_name
-`, ignoreFakeInstanceCondition("e.instance_id"))
+SELECT a.name AS app_name,
+       COALESCE(NULLIF(g.name, ''), 'unknown') AS group_name,
+       count(*) AS fail_count
+FROM event e
+JOIN event_type et ON e.event_type_id = et.id
+JOIN application a ON a.id = e.application_id
+LEFT JOIN instance_application ia ON ia.instance_id = e.instance_id AND ia.application_id = e.application_id
+LEFT JOIN groups g ON g.id = ia.group_id
+WHERE et.result = 0 AND et.type = 3
+  AND e.created_ts > now() - interval '%s'
+  AND %s
+GROUP BY app_name, group_name
+ORDER BY app_name, group_name
+`, validityInterval, ignoreFakeInstanceCondition("e.instance_id"))
 )
 
 func (q *Queries) GetAppInstancesPerChannelMetrics() ([]types.AppInstancesPerChannelMetric, error) {

--- a/backend/pkg/api/internal/types/metrics.go
+++ b/backend/pkg/api/internal/types/metrics.go
@@ -9,5 +9,6 @@ type AppInstancesPerChannelMetric struct {
 
 type FailedUpdatesMetric struct {
 	ApplicationName string `db:"app_name" json:"app_name"`
+	GroupName       string `db:"group_name" json:"group_name"`
 	FailureCount    int    `db:"fail_count" json:"fail_count"`
 }

--- a/backend/pkg/api/metrics_test.go
+++ b/backend/pkg/api/metrics_test.go
@@ -77,6 +77,7 @@ func TestGetFailedUpdatesMetrics(t *testing.T) {
 	expectedMetrics := []FailedUpdatesMetric{
 		{
 			ApplicationName: "Sample application",
+			GroupName:       "Failing Qa-Dev",
 			FailureCount:    1,
 		},
 	}

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -33,10 +33,11 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: "nebraska",
 			Name:      "failed_updates",
-			Help:      "Number of failed updates of an application",
+			Help:      "Number of failed updates per application and group in the last day",
 		},
 		[]string{
 			"application",
+			"group",
 		},
 	)
 
@@ -144,8 +145,10 @@ func calculateMetrics(api *api.API) error {
 		return fmt.Errorf("failed to get failed update metrics: %w", err)
 	}
 
+	// Reset before repopulating so removed apps/groups do not leave stale series.
+	failedUpdatesGaugeMetric.Reset()
 	for _, metric := range fuMetrics {
-		failedUpdatesGaugeMetric.WithLabelValues(metric.ApplicationName).Set(float64(metric.FailureCount))
+		failedUpdatesGaugeMetric.WithLabelValues(metric.ApplicationName, metric.GroupName).Set(float64(metric.FailureCount))
 	}
 
 	// db stats


### PR DESCRIPTION
## Summary
Fixes #1567.

`nebraska_failed_updates` previously counted every failed update event ever recorded and only exposed an `application` label. That made it hard to use for current rollout health.

This PR:
- Limits counts to failed update-complete events from the **last day** (same window as other reporting queries)
- Adds a **`group`** label (via `instance_application` → `groups`; missing group → `unknown`)
- **Resets** the gauge vector before each refresh to avoid stale series

## Test plan
- [ ] `cd backend && go test ./pkg/api/ -run TestGetFailedUpdatesMetrics`
- [ ] Scrape `/metrics` and confirm series look like `nebraska_failed_updates{application="...",group="..."}`
- [ ] Confirm old failures outside the 1-day window are not counted

## Notes
Adding the `group` label changes the metric’s label set. Existing Grafana queries that only use `application` can keep working with `sum by (application) (nebraska_failed_updates)`.