### PR TITLE
api/admin: wrap application cloning in a transaction, return real errors

### DIFF
--- a/backend/pkg/api/admin/applications.go
+++ b/backend/pkg/api/admin/applications.go
@@ -1,19 +1,23 @@
 package admin
 
 import (
+	"database/sql"
 	"fmt"
 	"regexp"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/jmoiron/sqlx"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
-// AddApp registers the provided application.
-func (s *Service) AddApp(app *types.Application) (*types.Application, error) {
+// addApp validates and inserts the application using the transaction
+// provided. The caller owns the transaction and is responsible for committing
+// it and for invalidating the application cache afterwards.
+func (s *Service) addApp(app *types.Application, tx *sqlx.Tx) error {
 	if err := validateProductID(app.ProductID); err != nil {
-		return nil, fmt.Errorf("cannot add application %v: %w", app.ID, err)
+		return fmt.Errorf("cannot add application %v: %w", app.ID, err)
 	}
 	query, _, err := goqu.Insert("application").
 		Cols("name", "product_id", "description", "team_id").
@@ -21,10 +25,28 @@ func (s *Service) AddApp(app *types.Application) (*types.Application, error) {
 		Returning(goqu.T("application").All()).
 		ToSQL()
 	if err != nil {
+		return err
+	}
+	return tx.QueryRowx(query).StructScan(app)
+}
+
+// AddApp registers the provided application.
+func (s *Service) AddApp(app *types.Application) (*types.Application, error) {
+	tx, err := s.db.Beginx()
+	if err != nil {
 		return nil, err
 	}
-	err = s.db.QueryRowx(query).StructScan(app)
-	if err != nil {
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			l.Error().Err(err).Msg("AddApp - could not roll back")
+		}
+	}()
+
+	if err := s.addApp(app, tx); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 
@@ -35,19 +57,33 @@ func (s *Service) AddApp(app *types.Application) (*types.Application, error) {
 // AddAppCloning registers the provided application, cloning the groups and
 // channels from an existing application. Channels' packages will be set to null
 // as packages won't be cloned.
+//
+// The application and every cloned channel and group are written in a single
+// transaction, so a failure to copy any one of them rolls the whole clone back
+// and returns the error. A successful return therefore always means a complete
+// copy, never an application that silently lost some of its channels or has
+// groups pointing at channels that were never created.
 func (s *Service) AddAppCloning(app *types.Application, sourceAppID string) (*types.Application, error) {
-	app, err := s.AddApp(app)
+	tx, err := s.db.Beginx()
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			l.Error().Err(err).Msg("AddAppCloning - could not roll back")
+		}
+	}()
 
-	// NOTE: cloning operation is not transactional and something could go wrong
+	if err := s.addApp(app, tx); err != nil {
+		return nil, err
+	}
 
 	if sourceAppID != "" {
+		// The source application is pre-existing, committed data and isn't
+		// touched by this transaction, so it's read on the shared connection.
 		sourceApp, err := s.GetApp(sourceAppID)
 		if err != nil {
-			l.Error().Err(err).Msg("AddAppCloning - could not get source app")
-			return app, nil
+			return nil, fmt.Errorf("cannot clone application: could not get source app %v: %w", sourceAppID, err)
 		}
 
 		channelsIDsMappings := make(map[string]null.String)
@@ -56,30 +92,32 @@ func (s *Service) AddAppCloning(app *types.Application, sourceAppID string) (*ty
 			originalChannelID := channel.ID
 			channel.ApplicationID = app.ID
 			channel.PackageID = null.String{}
-			channelCopy, err := s.AddChannel(channel)
-			if err != nil {
-				l.Error().Err(err).Msg("AddAppCloning - could not add channel")
-				return app, nil // FIXME - think about what we should return to the caller
+			if err := s.addChannel(channel, tx); err != nil {
+				return nil, fmt.Errorf("cannot clone application: could not copy channel %v: %w", originalChannelID, err)
 			}
-			channelsIDsMappings[originalChannelID] = null.StringFrom(channelCopy.ID)
+			channelsIDsMappings[originalChannelID] = null.StringFrom(channel.ID)
 		}
 
 		for _, group := range sourceApp.Groups {
+			originalGroupID := group.ID
 			group.ApplicationID = app.ID
 			if group.ChannelID.String != "" {
 				group.ChannelID = channelsIDsMappings[group.ChannelID.String]
 			}
 			group.PolicyUpdatesEnabled = true
 			group.ID = ""
-			if _, err := s.AddGroup(group); err != nil {
-				l.Error().Err(err).Msg("AddAppCloning - could not add group")
-				return app, nil // FIXME - think about what we should return to the caller
+			if err := s.addGroup(group, tx); err != nil {
+				return nil, fmt.Errorf("cannot clone application: could not copy group %v: %w", originalGroupID, err)
 			}
 		}
 	}
-	// Even though AddApp will invalidate the cache, we need to do it again here
-	// to prevent eventual race issues.
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
 	s.ClearCachedAppIDs()
+	s.UpdateCachedGroups()
 	return app, nil
 }
 

--- a/backend/pkg/api/admin/channels.go
+++ b/backend/pkg/api/admin/channels.go
@@ -1,19 +1,28 @@
 package admin
 
 import (
+	"database/sql"
+
 	"github.com/doug-martin/goqu/v9"
+	"github.com/jmoiron/sqlx"
 
 	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
-// AddChannel registers the provided channel.
-func (s *Service) AddChannel(channel *types.Channel) (*types.Channel, error) {
+// addChannel validates and inserts the channel using the transaction
+// provided. The caller owns the transaction and is responsible for
+// committing it.
+func (s *Service) addChannel(channel *types.Channel, tx *sqlx.Tx) error {
 	if !channel.Arch.IsValid() {
-		return nil, types.ErrInvalidArch
+		return types.ErrInvalidArch
 	}
 	if channel.PackageID.String != "" {
+		// The package is looked up outside the transaction, which is fine:
+		// packages are never created by the same transaction that creates a
+		// channel pointing at them. Cloning an application clears PackageID,
+		// so this doesn't run on that path at all.
 		if _, err := s.validatePackage(channel.PackageID.String, channel.ID, channel.ApplicationID, channel.Arch); err != nil {
-			return nil, err
+			return err
 		}
 	}
 	query, _, err := goqu.Insert("channel").
@@ -27,10 +36,28 @@ func (s *Service) AddChannel(channel *types.Channel) (*types.Channel, error) {
 		Returning(goqu.T("channel").All()).
 		ToSQL()
 	if err != nil {
+		return err
+	}
+	return tx.QueryRowx(query).StructScan(channel)
+}
+
+// AddChannel registers the provided channel.
+func (s *Service) AddChannel(channel *types.Channel) (*types.Channel, error) {
+	tx, err := s.db.Beginx()
+	if err != nil {
 		return nil, err
 	}
-	err = s.db.QueryRowx(query).StructScan(channel)
-	if err != nil {
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			l.Error().Err(err).Msg("AddChannel - could not roll back")
+		}
+	}()
+
+	if err := s.addChannel(channel, tx); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 	return channel, nil

--- a/backend/pkg/api/admin/groups.go
+++ b/backend/pkg/api/admin/groups.go
@@ -1,23 +1,30 @@
 package admin
 
 import (
+	"database/sql"
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
 
 	"github.com/flatcar/nebraska/backend/pkg/api/internal/types"
 )
 
-// AddGroup registers the provided group.
-func (s *Service) AddGroup(group *types.Group) (*types.Group, error) {
+// addGroup validates and inserts the group using the transaction provided.
+// The caller owns the transaction and is responsible for committing it and
+// for invalidating the group cache afterwards.
+func (s *Service) addGroup(group *types.Group, tx *sqlx.Tx) error {
 	if group.PolicyOfficeHours && !isTimezoneValid(group.PolicyTimezone.String) {
-		return nil, types.ErrExpectingValidTimezone
+		return types.ErrExpectingValidTimezone
 	}
 
 	if group.ChannelID.String != "" {
-		if err := s.validateChannel(group.ChannelID.String, group.ApplicationID); err != nil {
-			return nil, err
+		// Validated through the transaction: when cloning an application the
+		// channel this group points at was inserted by the same transaction
+		// and isn't visible to reads made outside of it yet.
+		if err := validateChannel(tx, group.ChannelID.String, group.ApplicationID); err != nil {
+			return err
 		}
 	}
 	// Instead of trying to solve this in the database, generate the ID beforehand to copy it to the track.
@@ -48,12 +55,31 @@ func (s *Service) AddGroup(group *types.Group) (*types.Group, error) {
 		Returning(goqu.T("groups").All()).
 		ToSQL()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	err = s.db.QueryRowx(query).StructScan(group)
+	return tx.QueryRowx(query).StructScan(group)
+}
+
+// AddGroup registers the provided group.
+func (s *Service) AddGroup(group *types.Group) (*types.Group, error) {
+	tx, err := s.db.Beginx()
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			l.Error().Err(err).Msg("AddGroup - could not roll back")
+		}
+	}()
+
+	if err := s.addGroup(group, tx); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
 	s.UpdateCachedGroups()
 	// Re-read through groupsQuery so the returned struct reflects the joined
 	// group_local row.
@@ -73,7 +99,7 @@ func (s *Service) UpdateGroup(group *types.Group) error {
 	}
 
 	if group.ChannelID.String != "" {
-		if err := s.validateChannel(group.ChannelID.String, groupBeforeUpdate.ApplicationID); err != nil {
+		if err := validateChannel(s.db, group.ChannelID.String, groupBeforeUpdate.ApplicationID); err != nil {
 			return err
 		}
 	}
@@ -139,12 +165,22 @@ func (s *Service) DeleteGroup(groupID string) error {
 }
 
 // validateChannel checks if a channel belongs to the application provided.
-func (s *Service) validateChannel(channelID, appID string) error {
-	channel, err := s.GetChannel(channelID)
+// It takes the queryer to run against so that it can be called either on the
+// shared connection or on an open transaction, the latter being required when
+// the channel was inserted by that same, not yet committed, transaction.
+func validateChannel(q sqlx.Queryer, channelID, appID string) error {
+	query, _, err := goqu.From("channel").
+		Select("application_id").
+		Where(goqu.C("id").Eq(channelID)).
+		ToSQL()
 	if err != nil {
 		return err
 	}
-	if channel.ApplicationID != appID {
+	var channelAppID string
+	if err := q.QueryRowx(query).Scan(&channelAppID); err != nil {
+		return err
+	}
+	if channelAppID != appID {
 		return types.ErrInvalidChannel
 	}
 	return nil

--- a/backend/pkg/api/applications_test.go
+++ b/backend/pkg/api/applications_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/flatcar/nebraska/backend/pkg/api/runtime"
@@ -109,6 +110,62 @@ func TestAddAppCloning(t *testing.T) {
 		},
 	)
 	assert.Error(t, err, "duplicate name because it is case insensitive")
+}
+
+// TestAddAppCloningRollsBackOnFailure checks that a clone which fails partway
+// through reports the error and leaves nothing behind, rather than returning a
+// success and an application missing some of its channels and groups.
+func TestAddAppCloningRollsBackOnFailure(t *testing.T) {
+	a := newForTest(t)
+	defer a.Close()
+	as := adminSvc(a)
+
+	tTeam, err := as.AddTeam(&Team{Name: "test_team"})
+	require.NoError(t, err)
+	tApp, err := as.AddApp(&Application{Name: "source_app", TeamID: tTeam.ID})
+	require.NoError(t, err)
+	tChannel, err := as.AddChannel(&Channel{Name: "test_channel", Color: "blue", ApplicationID: tApp.ID})
+	require.NoError(t, err)
+	_, err = as.AddGroup(&Group{Name: "group1", ApplicationID: tApp.ID, ChannelID: null.StringFrom(tChannel.ID), PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	require.NoError(t, err)
+	lastGroup, err := as.AddGroup(&Group{Name: "group2", ApplicationID: tApp.ID, PolicyUpdatesEnabled: true, PolicySafeMode: true, PolicyPeriodInterval: "15 minutes", PolicyMaxUpdatesPerPeriod: 2, PolicyUpdateTimeout: "60 minutes"})
+	require.NoError(t, err)
+
+	// Make the last source group impossible to copy, so the clone fails only
+	// after the application, its channel and the first group have been
+	// written. This is done in SQL because AddGroup rightly refuses to create
+	// a group in this state in the first place.
+	_, err = a.db().Exec("update groups set policy_office_hours = true, policy_timezone = 'Not/AZone' where id = $1", lastGroup.ID)
+	require.NoError(t, err)
+
+	_, err = as.AddAppCloning(&Application{Name: "cloned_app", TeamID: tTeam.ID}, tApp.ID)
+	assert.Error(t, err, "a clone that cannot copy every group must fail")
+
+	// Nothing from the failed clone may survive: no application row, and no
+	// channels or groups left pointing at it.
+	var clonedApps int
+	err = a.db().QueryRow("select count(*) from application where name = 'cloned_app'").Scan(&clonedApps)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, clonedApps, "the half-built application must be rolled back")
+
+	sourceApp, err := a.GetApp(tApp.ID)
+	assert.NoError(t, err)
+	assert.Len(t, sourceApp.Channels, 1, "the source application must be untouched")
+	assert.Len(t, sourceApp.Groups, 2, "the source application must be untouched")
+
+	// The copies carry the same names as the originals, so finding more than
+	// the one source row means part of the clone survived the failure. The
+	// names are checked rather than the cloned application id, which never
+	// made it to the database.
+	var channelCopies int
+	err = a.db().QueryRow("select count(*) from channel where name = 'test_channel'").Scan(&channelCopies)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, channelCopies, "channels written by the failed clone must be rolled back")
+
+	var groupCopies int
+	err = a.db().QueryRow("select count(*) from groups where name in ('group1', 'group2')").Scan(&groupCopies)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, groupCopies, "groups written by the failed clone must be rolled back")
 }
 
 func TestUpdateApp(t *testing.T) {


### PR DESCRIPTION
## Why

AddAppCloning copies an existing application's channels and groups when
creating a new one via clone. If any single channel or group failed to
copy, the failure was logged and the partially-built application was
returned with a nil error — the caller, and the operator in the UI, saw
success.

The practical effect: an application missing some channels or groups,
or with groups pointing at channels that were never created. An
operator has no way to know this happened and will reasonably point
machines at the new application. Those machines land in a group with
no channel and silently stop receiving updates, including security
updates, with nothing in the UI indicating a problem. The clone wasn't
wrapped in a transaction either, so a failed clone left whatever had
already been written in place rather than rolling back.

Two `FIXME - think about what we should return to the caller` comments
in the existing code mark this as known and unresolved.

## What changed

- `AddAppCloning` (`backend/pkg/api/admin/applications.go`) now runs
  the source-application lookup and the full channel/group copy inside
  a single database transaction, following the same transaction
  pattern already used in `backend/pkg/api/admin/packages.go`.
- Any failure at any step now returns the actual error to the caller
  instead of `nil` — a failed clone leaves no partial application
  behind and the caller gets a clear failure rather than a silent
  partial success.

[fill in: any signature changes, new error types, anything else that
changed beyond the two points above]

## Test plan

[fill in what you actually ran — e.g. a test that forces a mid-clone
failure and asserts (a) an error is returned and (b) no application
row is left behind; existing clone tests still passing; go build/vet/
lint output]